### PR TITLE
Added MongoCommandException

### DIFF
--- a/src/main/com/mongodb/CommandFailureException.java
+++ b/src/main/com/mongodb/CommandFailureException.java
@@ -18,10 +18,11 @@ package com.mongodb;
 
 /**
  * An exception indicating that a command sent to a MongoDB server returned a failure.
+ * @deprecated Use {@link com.mongodb.MongoCommandException instead}.
  */
-public class CommandFailureException extends MongoException {
+@Deprecated
+public class CommandFailureException extends MongoCommandException {
     private static final long serialVersionUID = -1180715413196161037L;
-    private final CommandResult commandResult;
 
     /**
      * Construct a new instance with the CommandResult from a failed command
@@ -31,28 +32,7 @@ public class CommandFailureException extends MongoException {
      */
     @Deprecated
     public CommandFailureException(CommandResult commandResult){
-        super(ServerError.getCode(commandResult), commandResult.toString());
-        this.commandResult = commandResult;
-    }
-
-    /**
-     * Gets the address of the server that the command executed on.
-     *
-     * @return the address of the server that the command executed on
-     * @since 2.13
-     */
-    public ServerAddress getServerAddress() {
-        return commandResult.getServerUsed();
-    }
-
-    /**
-     * Gets the error message from the command failure, typically from the "errmsg" property of the document returned from the failed
-     * command.
-     *
-     * @return the error message
-     */
-    public String getErrorMessage() {
-        return commandResult.getErrorMessage();
+        super(commandResult);
     }
 
     /**
@@ -63,6 +43,6 @@ public class CommandFailureException extends MongoException {
      */
     @Deprecated
     public CommandResult getCommandResult() {
-        return commandResult;
+        return super.getCommandResult();
     }
 }

--- a/src/main/com/mongodb/DuplicateKeyException.java
+++ b/src/main/com/mongodb/DuplicateKeyException.java
@@ -33,8 +33,4 @@ public class DuplicateKeyException extends WriteConcernException {
     DuplicateKeyException(final CommandResult commandResult) {
         super(commandResult);
     }
-
-    DuplicateKeyException(final int code, final CommandResult commandResult) {
-        super(code, commandResult);
-    }
 }

--- a/src/main/com/mongodb/MongoClientException.java
+++ b/src/main/com/mongodb/MongoClientException.java
@@ -18,6 +18,8 @@ package com.mongodb;
 
 /**
  * A base class for exceptions indicating a failure condition within the driver.
+ *
+ * @since 2.12
  */
 public class MongoClientException extends MongoInternalException {
 

--- a/src/main/com/mongodb/MongoCommandException.java
+++ b/src/main/com/mongodb/MongoCommandException.java
@@ -1,0 +1,46 @@
+package com.mongodb;
+
+/**
+ * An exception indicating that a command sent to a MongoDB server returned a failure.
+ *
+ * @since 2.13
+ */
+public class MongoCommandException extends MongoException {
+    private static final long serialVersionUID = 8160676451944215078L;
+    private final CommandResult commandResult;
+
+    public MongoCommandException(final CommandResult commandResult) {
+        super(ServerError.getCode(commandResult), commandResult.toString());
+        this.commandResult = commandResult;
+    }
+
+    /**
+     * Gets the address of the server that this command failed on.
+     * @return the server address
+     */
+    public ServerAddress getServerAddress() {
+        return commandResult.getServerUsed();
+    }
+
+    /**
+     * Gets the error code associated with the command failure.
+     *
+     * @return the error code
+     */
+    public int getErrorCode() {
+        return getCode();
+    }
+
+    /**
+     * Gets the error message associated with the command failure.
+     *
+     * @return the error message
+     */
+    public String getErrorMessage() {
+        return commandResult.getErrorMessage();
+    }
+
+    CommandResult getCommandResult() {
+        return commandResult;
+    }
+}

--- a/src/main/com/mongodb/MongoException.java
+++ b/src/main/com/mongodb/MongoException.java
@@ -124,10 +124,6 @@ public class MongoException extends RuntimeException {
         public DuplicateKey(final CommandResult commandResult) {
             super(commandResult);
         }
-
-        DuplicateKey(final int code, final CommandResult commandResult) {
-            super(code, commandResult);
-        }
     }
 
     /**

--- a/src/main/com/mongodb/UnacknowledgedWriteException.java
+++ b/src/main/com/mongodb/UnacknowledgedWriteException.java
@@ -23,8 +23,10 @@ package com.mongodb;
  * @see WriteResult
  * @see BulkWriteResult
  * @since 2.12
+ * @deprecated Catch {@link java.lang.UnsupportedOperationException instead}
  */
-public class UnacknowledgedWriteException extends MongoClientException {
+@Deprecated
+public class UnacknowledgedWriteException extends UnsupportedOperationException {
 
     private static final long serialVersionUID = 6974332938681213965L;
 

--- a/src/test/com/mongodb/CommandResultTest.java
+++ b/src/test/com/mongodb/CommandResultTest.java
@@ -124,6 +124,7 @@ public class CommandResultTest extends TestCase {
         } catch (CommandFailureException e) {
             assertEquals(commandResult, e.getCommandResult());
             assertEquals(-5, e.getCode());
+            assertEquals(-5, e.getErrorCode());
         }
     }
 
@@ -141,6 +142,7 @@ public class CommandResultTest extends TestCase {
             assertEquals(new ServerAddress("host1"), e.getServerAddress());
             assertEquals(errorMessage, e.getErrorMessage());
             assertEquals(5000, e.getCode());
+            assertEquals(5000, e.getErrorCode());
             assertEquals(commandResult, e.getCommandResult());
         }
     }

--- a/src/test/com/mongodb/DBCollectionTest.java
+++ b/src/test/com/mongodb/DBCollectionTest.java
@@ -653,6 +653,7 @@ public class DBCollectionTest extends TestCase {
         } catch (WriteConcernException e) {
             assertNotNull(e.getServerAddress());
             assertNotNull(e.getErrorMessage());
+            assertEquals(64, e.getCode());
             assertNotNull(e.getCommandResult().get("err"));
             assertEquals(0, e.getCommandResult().get("n"));
         } finally {


### PR DESCRIPTION
Changes for 2.13.0 release.

CommandFailureException extends MongoCommandException and is deprecated
UnacknowledgedWriteException extends UnsupportedOperationException instead of MongoClientException and is deprecated

  JAVA-1570
