### PR TITLE
JAVA-1828: Render Filters.and as {$and : [] }

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/Filters.java
+++ b/driver-core/src/main/com/mongodb/client/model/Filters.java
@@ -810,6 +810,10 @@ public final class Filters {
                 }
             }
 
+            if (andRenderable.isEmpty()) {
+                andRenderable.append("$and", new BsonArray());
+            }
+
             return andRenderable;
         }
 

--- a/driver-core/src/test/unit/com/mongodb/client/model/FiltersSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/FiltersSpecification.groovy
@@ -126,10 +126,22 @@ class FiltersSpecification extends Specification {
         toBson(exists('x', false)) == parse('{x : {$exists : false} }')
     }
 
+    def 'or should render empty or using $or'() {
+        expect:
+        toBson(or([])) == parse('{$or : []}')
+        toBson(or()) == parse('{$or : []}')
+    }
+
     def 'should render $or'() {
         expect:
         toBson(or([eq('x', 1), eq('y', 2)])) == parse('{$or : [{x : 1}, {y : 2}]}')
         toBson(or(eq('x', 1), eq('y', 2))) == parse('{$or : [{x : 1}, {y : 2}]}')
+    }
+
+    def 'and should render empty and using $and'() {
+        expect:
+        toBson(and([])) == parse('{$and : []}')
+        toBson(and()) == parse('{$and : []}')
     }
 
     def 'and should render and without using $and'() {


### PR DESCRIPTION
 Render Filters.and as {$and : [] } if the list of filters is empty. That way, the driver leaves it to the server to decide the meaning of an empty array for both $and and $or operators, which currently is to return an error.

 https://jira.mongodb.org/browse/JAVA-1828