### PR TITLE
JAVA-1887

### DIFF
--- a/bson/src/main/org/bson/BsonArray.java
+++ b/bson/src/main/org/bson/BsonArray.java
@@ -16,7 +16,6 @@
 
 package org.bson;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -29,9 +28,8 @@ import java.util.ListIterator;
  *
  * @since 3.0
  */
-public class BsonArray extends BsonValue implements List<BsonValue>, Serializable {
+public class BsonArray extends BsonValue implements List<BsonValue> {
 
-    private static final long serialVersionUID = -6848772175446898432L;
     private final List<BsonValue> values;
 
     /**

--- a/bson/src/main/org/bson/BsonArray.java
+++ b/bson/src/main/org/bson/BsonArray.java
@@ -211,16 +211,21 @@ public class BsonArray extends BsonValue implements List<BsonValue>, Cloneable {
     public BsonArray clone() {
         BsonArray to = new BsonArray();
         for (BsonValue cur : this) {
-            if (cur.isDocument()) {
-                to.add(cur.asDocument().clone());
-            } else if (cur.isArray()) {
-                to.add(cur.asArray().clone());
-            } else if (cur.isBinary()) {
-                to.add(BsonBinary.clone(cur.asBinary()));
-            } else if (cur.isJavaScriptWithScope()) {
-                to.add(BsonJavaScriptWithScope.clone(cur.asJavaScriptWithScope()));
-            } else {
-                to.add(cur);
+            switch (cur.getBsonType()) {
+                case DOCUMENT:
+                    to.add(cur.asDocument().clone());
+                    break;
+                case ARRAY:
+                    to.add(cur.asArray().clone());
+                    break;
+                case BINARY:
+                    to.add(BsonBinary.clone(cur.asBinary()));
+                    break;
+                case JAVASCRIPT_WITH_SCOPE:
+                    to.add(BsonJavaScriptWithScope.clone(cur.asJavaScriptWithScope()));
+                    break;
+                default:
+                    to.add(cur);
             }
         }
         return to;

--- a/bson/src/main/org/bson/BsonArray.java
+++ b/bson/src/main/org/bson/BsonArray.java
@@ -28,7 +28,7 @@ import java.util.ListIterator;
  *
  * @since 3.0
  */
-public class BsonArray extends BsonValue implements List<BsonValue> {
+public class BsonArray extends BsonValue implements List<BsonValue>, Cloneable {
 
     private final List<BsonValue> values;
 
@@ -205,5 +205,24 @@ public class BsonArray extends BsonValue implements List<BsonValue> {
         return "BsonArray{"
                + "values=" + values
                + '}';
+    }
+
+    @Override
+    public BsonArray clone() {
+        BsonArray to = new BsonArray();
+        for (BsonValue cur : this) {
+            if (cur.isDocument()) {
+                to.add(cur.asDocument().clone());
+            } else if (cur.isArray()) {
+                to.add(cur.asArray().clone());
+            } else if (cur.isBinary()) {
+                to.add(BsonBinary.clone(cur.asBinary()));
+            } else if (cur.isJavaScriptWithScope()) {
+                to.add(BsonJavaScriptWithScope.clone(cur.asJavaScriptWithScope()));
+            } else {
+                to.add(cur);
+            }
+        }
+        return to;
     }
 }

--- a/bson/src/main/org/bson/BsonBinary.java
+++ b/bson/src/main/org/bson/BsonBinary.java
@@ -133,4 +133,8 @@ public class BsonBinary extends BsonValue {
                + ", data=" + Arrays.toString(data)
                + '}';
     }
+
+    static BsonBinary clone(final BsonBinary from) {
+        return new BsonBinary(from.type, from.data.clone());
+    }
 }

--- a/bson/src/main/org/bson/BsonBinary.java
+++ b/bson/src/main/org/bson/BsonBinary.java
@@ -16,7 +16,6 @@
 
 package org.bson;
 
-import java.io.Serializable;
 import java.util.Arrays;
 
 /**
@@ -25,8 +24,7 @@ import java.util.Arrays;
  *
  * @since 3.0
  */
-public class BsonBinary extends BsonValue implements Serializable {
-    private static final long serialVersionUID = 5065134772326258148L;
+public class BsonBinary extends BsonValue {
 
     private final byte type;
     private final byte[] data;

--- a/bson/src/main/org/bson/BsonBoolean.java
+++ b/bson/src/main/org/bson/BsonBoolean.java
@@ -16,15 +16,12 @@
 
 package org.bson;
 
-import java.io.Serializable;
-
 /**
  * A representation of the BSON Boolean type.
  *
  * @since 3.0
  */
-public final class BsonBoolean extends BsonValue implements Comparable<BsonBoolean>, Serializable {
-    private static final long serialVersionUID = 2215506922933899945L;
+public final class BsonBoolean extends BsonValue implements Comparable<BsonBoolean> {
 
     private final boolean value;
 

--- a/bson/src/main/org/bson/BsonDateTime.java
+++ b/bson/src/main/org/bson/BsonDateTime.java
@@ -16,15 +16,12 @@
 
 package org.bson;
 
-import java.io.Serializable;
-
 /**
  * A representation of the BSON DateTime type.
  *
  * @since 3.0
  */
-public class BsonDateTime extends BsonValue implements Comparable<BsonDateTime>, Serializable {
-    private static final long serialVersionUID = 2215506922933899945L;
+public class BsonDateTime extends BsonValue implements Comparable<BsonDateTime> {
 
     private final long value;
 

--- a/bson/src/main/org/bson/BsonDbPointer.java
+++ b/bson/src/main/org/bson/BsonDbPointer.java
@@ -18,15 +18,12 @@ package org.bson;
 
 import org.bson.types.ObjectId;
 
-import java.io.Serializable;
-
 /**
  * Holder for a BSON type DBPointer(0x0c). It's deprecated in BSON Specification and present here because of compatibility reasons.
  *
  * @since 3.0
  */
-public class BsonDbPointer extends BsonValue implements Serializable {
-    private static final long serialVersionUID = -5105961452917374359L;
+public class BsonDbPointer extends BsonValue {
 
     private final String namespace;
     private final ObjectId id;

--- a/bson/src/main/org/bson/BsonDocument.java
+++ b/bson/src/main/org/bson/BsonDocument.java
@@ -773,16 +773,21 @@ public class BsonDocument extends BsonValue implements Map<String, BsonValue>, C
     public BsonDocument clone() {
         BsonDocument to = new BsonDocument();
         for (Entry<String, BsonValue> cur : entrySet()) {
-            if (cur.getValue().isDocument()) {
-                to.put(cur.getKey(), cur.getValue().asDocument().clone());
-            } else if (cur.getValue().isArray()) {
-                to.put(cur.getKey(), cur.getValue().asArray().clone());
-            } else if (cur.getValue().isBinary()) {
-                to.put(cur.getKey(), BsonBinary.clone(cur.getValue().asBinary()));
-            } else if (cur.getValue().isJavaScriptWithScope()) {
-                to.put(cur.getKey(), BsonJavaScriptWithScope.clone(cur.getValue().asJavaScriptWithScope()));
-            } else {
-                to.put(cur.getKey(), cur.getValue());
+            switch (cur.getValue().getBsonType()) {
+                case DOCUMENT:
+                    to.put(cur.getKey(), cur.getValue().asDocument().clone());
+                    break;
+                case ARRAY:
+                    to.put(cur.getKey(), cur.getValue().asArray().clone());
+                    break;
+                case BINARY:
+                    to.put(cur.getKey(), BsonBinary.clone(cur.getValue().asBinary()));
+                    break;
+                case JAVASCRIPT_WITH_SCOPE:
+                    to.put(cur.getKey(), BsonJavaScriptWithScope.clone(cur.getValue().asJavaScriptWithScope()));
+                    break;
+                default:
+                    to.put(cur.getKey(), cur.getValue());
             }
         }
         return to;

--- a/bson/src/main/org/bson/BsonDocument.java
+++ b/bson/src/main/org/bson/BsonDocument.java
@@ -799,10 +799,12 @@ public class BsonDocument extends BsonValue implements Map<String, BsonValue>, C
         }
     }
 
+    // see https://docs.oracle.com/javase/6/docs/platform/serialization/spec/output.html
     private Object writeReplace() {
         return new SerializationProxy(this);
     }
 
+    // see https://docs.oracle.com/javase/6/docs/platform/serialization/spec/input.html
     private void readObject(final ObjectInputStream stream) throws InvalidObjectException {
         throw new InvalidObjectException("Proxy required");
     }

--- a/bson/src/main/org/bson/BsonDocument.java
+++ b/bson/src/main/org/bson/BsonDocument.java
@@ -25,7 +25,6 @@ import org.bson.json.JsonReader;
 import org.bson.json.JsonWriter;
 import org.bson.json.JsonWriterSettings;
 
-import java.io.Serializable;
 import java.io.StringWriter;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -40,8 +39,7 @@ import static java.lang.String.format;
  *
  * @since 3.0
  */
-public class BsonDocument extends BsonValue implements Map<String, BsonValue>, Serializable, Bson {
-    private static final long serialVersionUID = -8366220692735186027L;
+public class BsonDocument extends BsonValue implements Map<String, BsonValue>, Bson {
 
     private final Map<String, BsonValue> map = new LinkedHashMap<String, BsonValue>();
 

--- a/bson/src/main/org/bson/BsonDocument.java
+++ b/bson/src/main/org/bson/BsonDocument.java
@@ -39,7 +39,7 @@ import static java.lang.String.format;
  *
  * @since 3.0
  */
-public class BsonDocument extends BsonValue implements Map<String, BsonValue>, Bson {
+public class BsonDocument extends BsonValue implements Map<String, BsonValue>, Cloneable, Bson {
 
     private final Map<String, BsonValue> map = new LinkedHashMap<String, BsonValue>();
 
@@ -760,6 +760,25 @@ public class BsonDocument extends BsonValue implements Map<String, BsonValue>, B
     @Override
     public String toString() {
         return toJson();
+    }
+
+    @Override
+    public BsonDocument clone() {
+        BsonDocument to = new BsonDocument();
+        for (Entry<String, BsonValue> cur : entrySet()) {
+            if (cur.getValue().isDocument()) {
+                to.put(cur.getKey(), cur.getValue().asDocument().clone());
+            } else if (cur.getValue().isArray()) {
+                to.put(cur.getKey(), cur.getValue().asArray().clone());
+            } else if (cur.getValue().isBinary()) {
+                to.put(cur.getKey(), BsonBinary.clone(cur.getValue().asBinary()));
+            } else if (cur.getValue().isJavaScriptWithScope()) {
+                to.put(cur.getKey(), BsonJavaScriptWithScope.clone(cur.getValue().asJavaScriptWithScope()));
+            } else {
+                to.put(cur.getKey(), cur.getValue());
+            }
+        }
+        return to;
     }
 
     private void throwIfKeyAbsent(final Object key) {

--- a/bson/src/main/org/bson/BsonDocumentWrapper.java
+++ b/bson/src/main/org/bson/BsonDocumentWrapper.java
@@ -20,6 +20,8 @@ import org.bson.codecs.Encoder;
 import org.bson.codecs.EncoderContext;
 import org.bson.codecs.configuration.CodecRegistry;
 
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -35,9 +37,10 @@ import java.util.Set;
  * @since 3.0
  */
 public final class BsonDocumentWrapper<T> extends BsonDocument {
+    private static final long serialVersionUID = 1L;
 
-    private final T wrappedDocument;
-    private final Encoder<T> encoder;
+    private final transient T wrappedDocument;
+    private final transient Encoder<T> encoder;
     private BsonDocument unwrapped;
 
     /**
@@ -193,5 +196,13 @@ public final class BsonDocumentWrapper<T> extends BsonDocument {
             this.unwrapped = unwrapped;
         }
         return unwrapped;
+    }
+
+    private Object writeReplace() {
+        return getUnwrapped();
+    }
+
+    private void readObject(final ObjectInputStream stream) throws InvalidObjectException {
+        throw new InvalidObjectException("Proxy required");
     }
 }

--- a/bson/src/main/org/bson/BsonDocumentWrapper.java
+++ b/bson/src/main/org/bson/BsonDocumentWrapper.java
@@ -34,7 +34,7 @@ import java.util.Set;
  * @see org.bson.BsonDocumentWriter
  * @since 3.0
  */
-public class BsonDocumentWrapper<T> extends BsonDocument {
+public final class BsonDocumentWrapper<T> extends BsonDocument {
 
     private final T wrappedDocument;
     private final Encoder<T> encoder;

--- a/bson/src/main/org/bson/BsonDocumentWrapper.java
+++ b/bson/src/main/org/bson/BsonDocumentWrapper.java
@@ -198,10 +198,12 @@ public final class BsonDocumentWrapper<T> extends BsonDocument {
         return unwrapped;
     }
 
+    // see https://docs.oracle.com/javase/6/docs/platform/serialization/spec/output.html
     private Object writeReplace() {
         return getUnwrapped();
     }
 
+    // see https://docs.oracle.com/javase/6/docs/platform/serialization/spec/input.html
     private void readObject(final ObjectInputStream stream) throws InvalidObjectException {
         throw new InvalidObjectException("Proxy required");
     }

--- a/bson/src/main/org/bson/BsonDocumentWrapper.java
+++ b/bson/src/main/org/bson/BsonDocumentWrapper.java
@@ -36,10 +36,8 @@ import java.util.Set;
  */
 public class BsonDocumentWrapper<T> extends BsonDocument {
 
-    private static final long serialVersionUID = 4164303588753136248L;
-
-    private final transient T wrappedDocument;
-    private final transient Encoder<T> encoder;
+    private final T wrappedDocument;
+    private final Encoder<T> encoder;
     private BsonDocument unwrapped;
 
     /**

--- a/bson/src/main/org/bson/BsonDocumentWrapper.java
+++ b/bson/src/main/org/bson/BsonDocumentWrapper.java
@@ -177,6 +177,11 @@ public final class BsonDocumentWrapper<T> extends BsonDocument {
         return getUnwrapped().toString();
     }
 
+    @Override
+    public BsonDocument clone() {
+        return getUnwrapped().clone();
+    }
+
     private BsonDocument getUnwrapped() {
         if (encoder == null) {
             throw new BsonInvalidOperationException("Can not unwrap a BsonDocumentWrapper with no Encoder");

--- a/bson/src/main/org/bson/BsonDouble.java
+++ b/bson/src/main/org/bson/BsonDouble.java
@@ -16,15 +16,12 @@
 
 package org.bson;
 
-import java.io.Serializable;
-
 /**
  * A representation of the BSON Double type.
  *
  * @since 3.0
  */
-public class BsonDouble extends BsonNumber implements Comparable<BsonDouble>, Serializable {
-    private static final long serialVersionUID = 2215506922933899945L;
+public class BsonDouble extends BsonNumber implements Comparable<BsonDouble> {
 
     private final double value;
 

--- a/bson/src/main/org/bson/BsonInt32.java
+++ b/bson/src/main/org/bson/BsonInt32.java
@@ -16,15 +16,12 @@
 
 package org.bson;
 
-import java.io.Serializable;
-
 /**
  * A representation of the BSON Int32 type.
  *
  * @since 3.0
  */
-public final class BsonInt32 extends BsonNumber implements Comparable<BsonInt32>, Serializable {
-    private static final long serialVersionUID = 2215506922933899945L;
+public final class BsonInt32 extends BsonNumber implements Comparable<BsonInt32> {
 
     private final int value;
 

--- a/bson/src/main/org/bson/BsonInt64.java
+++ b/bson/src/main/org/bson/BsonInt64.java
@@ -16,13 +16,10 @@
 
 package org.bson;
 
-import java.io.Serializable;
-
 /**
  * A representation of the BSON Int64 type.
  */
-public final class BsonInt64 extends BsonNumber implements Comparable<BsonInt64>, Serializable {
-    private static final long serialVersionUID = 2215506922933899945L;
+public final class BsonInt64 extends BsonNumber implements Comparable<BsonInt64> {
 
     private final long value;
 

--- a/bson/src/main/org/bson/BsonJavaScript.java
+++ b/bson/src/main/org/bson/BsonJavaScript.java
@@ -16,18 +16,14 @@
 
 package org.bson;
 
-import java.io.Serializable;
-
 /**
  * For using the JavaScript Code type.
  *
  * @since 3.0
  */
-public class BsonJavaScript extends BsonValue implements Serializable {
+public class BsonJavaScript extends BsonValue {
 
     private final String code;
-
-    private static final long serialVersionUID = 475535263314046697L;
 
     /**
      * Construct a new instance with the given JavaScript code.

--- a/bson/src/main/org/bson/BsonJavaScriptWithScope.java
+++ b/bson/src/main/org/bson/BsonJavaScriptWithScope.java
@@ -101,5 +101,9 @@ public class BsonJavaScriptWithScope extends BsonValue {
                + "scope=" + scope
                + '}';
     }
+
+    static BsonJavaScriptWithScope clone(final BsonJavaScriptWithScope from) {
+        return new BsonJavaScriptWithScope(from.code, from.scope.clone());
+    }
 }
 

--- a/bson/src/main/org/bson/BsonJavaScriptWithScope.java
+++ b/bson/src/main/org/bson/BsonJavaScriptWithScope.java
@@ -16,16 +16,12 @@
 
 package org.bson;
 
-import java.io.Serializable;
-
 /**
  * A representation of the JavaScript Code with Scope BSON type.
  *
  * @since 3.0
  */
-public class BsonJavaScriptWithScope extends BsonValue implements Serializable {
-
-    private static final long serialVersionUID = -6284832275113680002L;
+public class BsonJavaScriptWithScope extends BsonValue {
 
     private final String code;
     private final BsonDocument scope;

--- a/bson/src/main/org/bson/BsonMaxKey.java
+++ b/bson/src/main/org/bson/BsonMaxKey.java
@@ -16,14 +16,10 @@
 
 package org.bson;
 
-import java.io.Serializable;
-
 /**
  * Represent the maximum key value regardless of the key's type
  */
-public final class BsonMaxKey extends BsonValue implements Serializable {
-
-    private static final long serialVersionUID = 5123414776151687185L;
+public final class BsonMaxKey extends BsonValue {
 
     @Override
     public BsonType getBsonType() {

--- a/bson/src/main/org/bson/BsonMinKey.java
+++ b/bson/src/main/org/bson/BsonMinKey.java
@@ -16,14 +16,10 @@
 
 package org.bson;
 
-import java.io.Serializable;
-
 /**
  * Represent the minimum key value regardless of the key's type
  */
-public final class BsonMinKey extends BsonValue implements Serializable {
-
-    private static final long serialVersionUID = 4075901136671855684L;
+public final class BsonMinKey extends BsonValue {
 
     @Override
     public BsonType getBsonType() {

--- a/bson/src/main/org/bson/BsonNull.java
+++ b/bson/src/main/org/bson/BsonNull.java
@@ -16,15 +16,12 @@
 
 package org.bson;
 
-import java.io.Serializable;
-
 /**
  * A representation of the BSON Null type.
  *
  * @since 3.0
  */
-public final class BsonNull extends BsonValue implements Serializable {
-    private static final long serialVersionUID = -1197299174370690779L;
+public final class BsonNull extends BsonValue {
 
     public static final BsonNull VALUE = new BsonNull();
 

--- a/bson/src/main/org/bson/BsonObjectId.java
+++ b/bson/src/main/org/bson/BsonObjectId.java
@@ -18,16 +18,13 @@ package org.bson;
 
 import org.bson.types.ObjectId;
 
-import java.io.Serializable;
-
 /**
  * A representation of the BSON ObjectId type.
  *
  * @since 3.0
  */
-public class BsonObjectId extends BsonValue implements Comparable<BsonObjectId>, Serializable {
+public class BsonObjectId extends BsonValue implements Comparable<BsonObjectId> {
 
-    private static final long serialVersionUID = -8584037677369278059L;
     private final ObjectId value;
 
     /**

--- a/bson/src/main/org/bson/BsonRegularExpression.java
+++ b/bson/src/main/org/bson/BsonRegularExpression.java
@@ -16,8 +16,6 @@
 
 package org.bson;
 
-import java.io.Serializable;
-
 import static org.bson.assertions.Assertions.notNull;
 
 /**
@@ -25,8 +23,7 @@ import static org.bson.assertions.Assertions.notNull;
  *
  * @since 3.0
  */
-public final class BsonRegularExpression extends BsonValue implements Serializable {
-    private static final long serialVersionUID = 198506456131942797L;
+public final class BsonRegularExpression extends BsonValue {
 
     private final String pattern;
     private final String options;

--- a/bson/src/main/org/bson/BsonString.java
+++ b/bson/src/main/org/bson/BsonString.java
@@ -16,15 +16,12 @@
 
 package org.bson;
 
-import java.io.Serializable;
-
 /**
  * A representation of the BSON String type.
  *
  * @since 3.0
  */
-public class BsonString extends BsonValue implements Comparable<BsonString>, Serializable {
-    private static final long serialVersionUID = 2215506922933899945L;
+public class BsonString extends BsonValue implements Comparable<BsonString> {
 
     private final String value;
 

--- a/bson/src/main/org/bson/BsonSymbol.java
+++ b/bson/src/main/org/bson/BsonSymbol.java
@@ -18,18 +18,14 @@
 
 package org.bson;
 
-import java.io.Serializable;
-
 /**
  * Class to hold a BSON symbol object, which is an interned string in Ruby
  *
  * @since 3.0
  */
-public class BsonSymbol extends BsonValue implements Serializable {
+public class BsonSymbol extends BsonValue {
 
     private final String symbol;
-
-    private static final long serialVersionUID = 1326269319883146072L;
 
     /**
      * Creates a new instance.

--- a/bson/src/main/org/bson/BsonTimestamp.java
+++ b/bson/src/main/org/bson/BsonTimestamp.java
@@ -16,7 +16,6 @@
 
 package org.bson;
 
-import java.io.Serializable;
 import java.util.Date;
 
 /**
@@ -24,8 +23,7 @@ import java.util.Date;
  *
  * @since 3.0
  */
-public final class BsonTimestamp extends BsonValue implements Comparable<BsonTimestamp>, Serializable {
-    private static final long serialVersionUID = 2318841189917887752L;
+public final class BsonTimestamp extends BsonValue implements Comparable<BsonTimestamp> {
 
     private final int inc;
     private final Date time;

--- a/bson/src/main/org/bson/BsonTimestamp.java
+++ b/bson/src/main/org/bson/BsonTimestamp.java
@@ -16,8 +16,6 @@
 
 package org.bson;
 
-import java.util.Date;
-
 /**
  * A value representing the BSON timestamp type.
  *
@@ -25,25 +23,25 @@ import java.util.Date;
  */
 public final class BsonTimestamp extends BsonValue implements Comparable<BsonTimestamp> {
 
+    private final int seconds;
     private final int inc;
-    private final Date time;
 
     /**
      * Construct a new instance with a null time and a 0 increment.
      */
     public BsonTimestamp() {
+        seconds = 0;
         inc = 0;
-        time = null;
     }
 
     /**
      * Construct a new instance for the given time and increment.
      *
-     * @param time the number of seconds since the epoch
+     * @param seconds the number of seconds since the epoch
      * @param inc  the increment.
      */
-    public BsonTimestamp(final int time, final int inc) {
-        this.time = new Date(time * 1000L);
+    public BsonTimestamp(final int seconds, final int inc) {
+        this.seconds = seconds;
         this.inc = inc;
     }
 
@@ -58,10 +56,7 @@ public final class BsonTimestamp extends BsonValue implements Comparable<BsonTim
      * @return an int representing time in seconds since epoch
      */
     public int getTime() {
-        if (time == null) {
-            return 0;
-        }
-        return (int) (time.getTime() / 1000);
+       return seconds;
     }
 
     /**
@@ -76,8 +71,8 @@ public final class BsonTimestamp extends BsonValue implements Comparable<BsonTim
     @Override
     public String toString() {
         return "Timestamp{"
-               + "inc=" + inc
-               + ", time=" + time
+               + "seconds=" + seconds
+               + ", inc=" + inc
                + '}';
     }
 
@@ -101,10 +96,11 @@ public final class BsonTimestamp extends BsonValue implements Comparable<BsonTim
 
         BsonTimestamp timestamp = (BsonTimestamp) o;
 
-        if (inc != timestamp.inc) {
+        if (seconds != timestamp.seconds) {
             return false;
         }
-        if (!time.equals(timestamp.time)) {
+
+        if (inc != timestamp.inc) {
             return false;
         }
 
@@ -113,8 +109,8 @@ public final class BsonTimestamp extends BsonValue implements Comparable<BsonTim
 
     @Override
     public int hashCode() {
-        int result = inc;
-        result = 31 * result + time.hashCode();
+        int result = seconds;
+        result = 31 * result + inc;
         return result;
     }
 }

--- a/bson/src/main/org/bson/BsonUndefined.java
+++ b/bson/src/main/org/bson/BsonUndefined.java
@@ -16,8 +16,6 @@
 
 package org.bson;
 
-import java.io.Serializable;
-
 /**
  * Represents the value associated with the BSON Undefined type.  All values of this type are identical.  Note that this type has been
  * deprecated in the BSON specification.
@@ -26,8 +24,7 @@ import java.io.Serializable;
  * @see org.bson.BsonType#UNDEFINED
  * @since 3.0
  */
-public final class BsonUndefined extends BsonValue implements Serializable {
-    private static final long serialVersionUID = -6947231726163165009L;
+public final class BsonUndefined extends BsonValue {
 
     @Override
     public BsonType getBsonType() {

--- a/bson/src/main/org/bson/ByteBuf.java
+++ b/bson/src/main/org/bson/ByteBuf.java
@@ -185,11 +185,11 @@ public interface ByteBuf  {
     byte get();
 
     /**
-     * Absolute <em>get</em> method.  Reads the byte at the given index. </p>
+     * Absolute <em>get</em> method.  Reads the byte at the given index.
      *
      * @param index The index from which the byte will be read
      * @return The byte at the given index
-     * @throws IndexOutOfBoundsException If <tt>index</tt> is negative or not smaller than the buffer's limit
+     * @throws IndexOutOfBoundsException If {@code index} is negative or not smaller than the buffer's limit
      */
     byte get(int index);
 
@@ -211,10 +211,10 @@ public interface ByteBuf  {
 
     /**
      * <p>Absolute bulk {@code get} method.</p>
-     * <p/>
+     *
      * <p>This method transfers bytes from this buffer into the given destination array.  An invocation of this method of the form {@code
      * src.get(a)} behaves in exactly the same way as the invocation:</p>
-     * <p/>
+     *
      * <pre>
      * src.get(index, a, 0, a.length)
      * </pre>
@@ -282,35 +282,34 @@ public interface ByteBuf  {
 
     /**
      * Absolute bulk <i>get</i> method.
-     * <p/>
+     *
      * <p> This method transfers bytes from this buffer into the given destination array.  If there are fewer bytes remaining in the buffer
-     * than are required to satisfy the request, that is, if <tt>length</tt>&nbsp;<tt>&gt;</tt>&nbsp;<tt>remaining()</tt>, then no bytes are
-     * transferred and a {@link java.nio.BufferUnderflowException} is thrown.
-     * <p/>
-     * <p> Otherwise, this method copies <tt>length</tt> bytes from this buffer into the given array, starting at the given index buffer
-     * and at the given offset in the array.
-     * <p/>
-     * <p> In other words, an invocation of this method of the form <tt>src.get(dst,&nbsp;off,&nbsp;len)</tt> has exactly the same effect as
-     * the loop
-     * <p/>
+     * than are required to satisfy the request, that is, if {@code length &gt; remaining}, then no bytes are
+     * transferred and a {@link java.nio.BufferUnderflowException} is thrown.</p>
+     *
+     * <p> Otherwise, this method copies {@code length} bytes from this buffer into the given array, starting at the given index buffer
+     * and at the given offset in the array.</p>
+     *
+     * <p> In other words, an invocation of this method of the form {@code src.get(dst, off, len)} has exactly the same
+     * effect as the loop </p>
      * <pre>
      * {@code
      *     for (int i = off; i < off + len; i++)
      *         dst[i] = src.get(i);
      * }
      * </pre>
-     * <p/>
+     *
      * except that it first checks that there are sufficient bytes in this buffer and it is potentially much more efficient.
      *
      * @param index  The index from which the bytes will be read
      * @param bytes  The array into which bytes are to be written
      * @param offset The offset within the array of the first byte to be written; must be non-negative and no larger than
-     *               <tt>dst.length</tt>
-     * @param length The maximum number of bytes to be written to the given array; must be non-negative and no larger than <tt>dst.length -
-     *               offset</tt>
+     *               {@code dst.length}
+     * @param length The maximum number of bytes to be written to the given array; must be non-negative and no larger than
+     *               {@code dst.length - offset}
      * @return This buffer
-     * @throws java.nio.BufferUnderflowException If there are fewer than <tt>length</tt> bytes remaining in this buffer
-     * @throws IndexOutOfBoundsException         If the preconditions on the <tt>offset</tt> and <tt>length</tt> parameters do not hold
+     * @throws java.nio.BufferUnderflowException If there are fewer than {@code length} bytes remaining in this buffer
+     * @throws IndexOutOfBoundsException         If the preconditions on the {@code offset} and {@code length} parameters do not hold
      */
     ByteBuf get(int index, byte[] bytes, int offset, int length);
 
@@ -332,7 +331,7 @@ public interface ByteBuf  {
      *
      * @return The long value at the given index
      *
-     * @throws IndexOutOfBoundsException If <tt>index</tt> is negative or not smaller than the buffer's limit, minus seven
+     * @throws IndexOutOfBoundsException If {@code index} is negative or not smaller than the buffer's limit, minus seven
      */
     long getLong(int index);
 
@@ -348,12 +347,14 @@ public interface ByteBuf  {
     double getDouble();
 
     /**
-     * Absolute <i>get</i> method for reading a double value. <p> Reads eight bytes at the given index, composing them into a double value
+     * Absolute <em>get</em> method for reading a double value.
+     *
+     * <p> Reads eight bytes at the given index, composing them into a double value
      * according to the current byte order.  </p>
      *
      * @param index The index from which the bytes will be read
      * @return The double value at the given index
-     * @throws IndexOutOfBoundsException If <tt>index</tt> is negative or not smaller than the buffer's limit, minus seven
+     * @throws IndexOutOfBoundsException If {@code index} is negative or not smaller than the buffer's limit, minus seven
      */
     double getDouble(int index);
 
@@ -374,7 +375,7 @@ public interface ByteBuf  {
      *
      * @param index The index from which the bytes will be read
      * @return The int value at the given index
-     * @throws IndexOutOfBoundsException If <tt>index</tt> is negative or not smaller than the buffer's limit, minus three
+     * @throws IndexOutOfBoundsException If {@code index} is negative or not smaller than the buffer's limit, minus three
      */
     int getInt(int index);
 

--- a/bson/src/main/org/bson/ByteBuf.java
+++ b/bson/src/main/org/bson/ByteBuf.java
@@ -185,6 +185,15 @@ public interface ByteBuf  {
     byte get();
 
     /**
+     * Absolute <em>get</em> method.  Reads the byte at the given index. </p>
+     *
+     * @param index The index from which the byte will be read
+     * @return The byte at the given index
+     * @throws IndexOutOfBoundsException If <tt>index</tt> is negative or not smaller than the buffer's limit
+     */
+    byte get(int index);
+
+    /**
      * <p>Relative bulk {@code get} method.</p>
      *
      * <p>This method transfers bytes from this buffer into the given destination array.  An invocation of this method of the form {@code
@@ -199,6 +208,23 @@ public interface ByteBuf  {
      * @throws java.nio.BufferUnderflowException If there are fewer than {@code length} bytes remaining in this buffer
      */
     ByteBuf get(byte[] bytes);
+
+    /**
+     * <p>Absolute bulk {@code get} method.</p>
+     * <p/>
+     * <p>This method transfers bytes from this buffer into the given destination array.  An invocation of this method of the form {@code
+     * src.get(a)} behaves in exactly the same way as the invocation:</p>
+     * <p/>
+     * <pre>
+     * src.get(index, a, 0, a.length)
+     * </pre>
+     *
+     * @param index The index from which the bytes will be read
+     * @param bytes the destination byte array
+     * @return This buffer
+     * @throws java.nio.BufferUnderflowException If there are fewer than {@code length} bytes remaining in this buffer
+     */
+    ByteBuf get(int index, byte[] bytes);
 
     /**
      * Relative bulk <i>get</i> method.
@@ -255,6 +281,40 @@ public interface ByteBuf  {
     ByteBuf get(byte[] bytes, int offset, int length);
 
     /**
+     * Absolute bulk <i>get</i> method.
+     * <p/>
+     * <p> This method transfers bytes from this buffer into the given destination array.  If there are fewer bytes remaining in the buffer
+     * than are required to satisfy the request, that is, if <tt>length</tt>&nbsp;<tt>&gt;</tt>&nbsp;<tt>remaining()</tt>, then no bytes are
+     * transferred and a {@link java.nio.BufferUnderflowException} is thrown.
+     * <p/>
+     * <p> Otherwise, this method copies <tt>length</tt> bytes from this buffer into the given array, starting at the given index buffer
+     * and at the given offset in the array.
+     * <p/>
+     * <p> In other words, an invocation of this method of the form <tt>src.get(dst,&nbsp;off,&nbsp;len)</tt> has exactly the same effect as
+     * the loop
+     * <p/>
+     * <pre>
+     * {@code
+     *     for (int i = off; i < off + len; i++)
+     *         dst[i] = src.get(i);
+     * }
+     * </pre>
+     * <p/>
+     * except that it first checks that there are sufficient bytes in this buffer and it is potentially much more efficient.
+     *
+     * @param index  The index from which the bytes will be read
+     * @param bytes  The array into which bytes are to be written
+     * @param offset The offset within the array of the first byte to be written; must be non-negative and no larger than
+     *               <tt>dst.length</tt>
+     * @param length The maximum number of bytes to be written to the given array; must be non-negative and no larger than <tt>dst.length -
+     *               offset</tt>
+     * @return This buffer
+     * @throws java.nio.BufferUnderflowException If there are fewer than <tt>length</tt> bytes remaining in this buffer
+     * @throws IndexOutOfBoundsException         If the preconditions on the <tt>offset</tt> and <tt>length</tt> parameters do not hold
+     */
+    ByteBuf get(int index, byte[] bytes, int offset, int length);
+
+    /**
      * <p> Relative <em>get</em> method for reading a long value. </p> <p>Reads the next eight bytes at this buffer's current position,
      * composing them into a long value according to the current byte order, and then increments the position by eight.  </p>
      *
@@ -262,6 +322,19 @@ public interface ByteBuf  {
      * @throws java.nio.BufferUnderflowException If there are fewer than eight bytes remaining in this buffer
      */
     long getLong();
+
+    /**
+     * Absolute <i>get</i> method for reading a long value.
+     *
+     * <p> Reads eight bytes at the given index, composing them into a long value according to the current byte order.  </p>
+     *
+     * @param  index The index from which the bytes will be read
+     *
+     * @return The long value at the given index
+     *
+     * @throws IndexOutOfBoundsException If <tt>index</tt> is negative or not smaller than the buffer's limit, minus seven
+     */
+    long getLong(int index);
 
     /**
      * <p>Relative <em>get</em> method for reading a double value.</p>
@@ -275,6 +348,16 @@ public interface ByteBuf  {
     double getDouble();
 
     /**
+     * Absolute <i>get</i> method for reading a double value. <p> Reads eight bytes at the given index, composing them into a double value
+     * according to the current byte order.  </p>
+     *
+     * @param index The index from which the bytes will be read
+     * @return The double value at the given index
+     * @throws IndexOutOfBoundsException If <tt>index</tt> is negative or not smaller than the buffer's limit, minus seven
+     */
+    double getDouble(int index);
+
+    /**
      * <p>Relative <em>get</em> method for reading an int value.</p>
      *
      * <p>Reads the next four bytes at this buffer's current position, composing them into an int value according to the current byte order,
@@ -284,6 +367,16 @@ public interface ByteBuf  {
      * @throws java.nio.BufferUnderflowException If there are fewer than four bytes remaining in this buffer
      */
     int getInt();
+
+    /**
+     * Absolute <em>get</em> method for reading an int value. <p> Reads four bytes at the given index, composing them into a int value
+     * according to the current byte order.  </p>
+     *
+     * @param index The index from which the bytes will be read
+     * @return The int value at the given index
+     * @throws IndexOutOfBoundsException If <tt>index</tt> is negative or not smaller than the buffer's limit, minus three
+     */
+    int getInt(int index);
 
     /**
      * Returns this buffer's position.

--- a/bson/src/main/org/bson/ByteBufNIO.java
+++ b/bson/src/main/org/bson/ByteBufNIO.java
@@ -136,9 +136,19 @@ public class ByteBufNIO implements ByteBuf {
     }
 
     @Override
+    public byte get(final int index) {
+        return buf.get(index);
+    }
+
+    @Override
     public ByteBuf get(final byte[] bytes) {
         buf.get(bytes);
         return this;
+    }
+
+    @Override
+    public ByteBuf get(final int index, final byte[] bytes) {
+        return get(index, bytes, 0, bytes.length);
     }
 
     @Override
@@ -148,8 +158,21 @@ public class ByteBufNIO implements ByteBuf {
     }
 
     @Override
+    public ByteBuf get(final int index, final byte[] bytes, final int offset, final int length) {
+        for (int i = 0; i < length; i++) {
+            bytes[offset + i] = buf.get(index + i);
+        }
+        return this;
+    }
+
+    @Override
     public long getLong() {
         return buf.getLong();
+    }
+
+    @Override
+    public long getLong(final int index) {
+        return buf.getLong(index);
     }
 
     @Override
@@ -158,8 +181,18 @@ public class ByteBufNIO implements ByteBuf {
     }
 
     @Override
+    public double getDouble(final int index) {
+        return buf.getDouble(index);
+    }
+
+    @Override
     public int getInt() {
         return buf.getInt();
+    }
+
+    @Override
+    public int getInt(final int index) {
+        return buf.getInt(index);
     }
 
     @Override

--- a/bson/src/main/org/bson/RawBsonDocument.java
+++ b/bson/src/main/org/bson/RawBsonDocument.java
@@ -41,7 +41,7 @@ import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
  */
 public class RawBsonDocument extends BsonDocument {
     private static final long serialVersionUID = 5551249268878132972L;
-    private static CodecRegistry registry = fromProviders(new BsonValueCodecProvider());
+    private static final CodecRegistry REGISTRY = fromProviders(new BsonValueCodecProvider());
 
     private final byte[] bytes;
 
@@ -256,7 +256,7 @@ public class RawBsonDocument extends BsonDocument {
     }
 
     private BsonValue deserializeBsonValue(final BsonBinaryReader bsonReader) {
-        return registry.get(getClassForBsonType(bsonReader.getCurrentBsonType())).decode(bsonReader, DecoderContext.builder().build());
+        return REGISTRY.get(getClassForBsonType(bsonReader.getCurrentBsonType())).decode(bsonReader, DecoderContext.builder().build());
     }
 
     private BsonBinaryReader createReader() {

--- a/bson/src/main/org/bson/RawBsonDocument.java
+++ b/bson/src/main/org/bson/RawBsonDocument.java
@@ -40,7 +40,6 @@ import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
  * @since 3.0
  */
 public class RawBsonDocument extends BsonDocument {
-    private static final long serialVersionUID = 5551249268878132972L;
     private static final CodecRegistry REGISTRY = fromProviders(new BsonValueCodecProvider());
 
     private final byte[] bytes;

--- a/bson/src/main/org/bson/RawBsonDocument.java
+++ b/bson/src/main/org/bson/RawBsonDocument.java
@@ -281,10 +281,12 @@ public final class RawBsonDocument extends BsonDocument {
         }
     }
 
+    // see https://docs.oracle.com/javase/6/docs/platform/serialization/spec/output.html
     private Object writeReplace() {
         return new SerializationProxy(this.bytes);
     }
 
+    // see https://docs.oracle.com/javase/6/docs/platform/serialization/spec/input.html
     private void readObject(final ObjectInputStream stream) throws InvalidObjectException {
         throw new InvalidObjectException("Proxy required");
     }

--- a/bson/src/main/org/bson/RawBsonDocument.java
+++ b/bson/src/main/org/bson/RawBsonDocument.java
@@ -247,12 +247,12 @@ public class RawBsonDocument extends BsonDocument {
 
     @Override
     public boolean equals(final Object o) {
-        return super.equals(o);
+        return toBsonDocument().equals(o);
     }
 
     @Override
     public int hashCode() {
-        return super.hashCode();
+        return toBsonDocument().hashCode();
     }
 
     private BsonValue deserializeBsonValue(final BsonBinaryReader bsonReader) {

--- a/bson/src/main/org/bson/RawBsonDocument.java
+++ b/bson/src/main/org/bson/RawBsonDocument.java
@@ -254,6 +254,11 @@ public final class RawBsonDocument extends BsonDocument {
         return toBsonDocument().hashCode();
     }
 
+    @Override
+    public BsonDocument clone() {
+        return new RawBsonDocument(bytes.clone());
+    }
+
     private BsonValue deserializeBsonValue(final BsonBinaryReader bsonReader) {
         return REGISTRY.get(getClassForBsonType(bsonReader.getCurrentBsonType())).decode(bsonReader, DecoderContext.builder().build());
     }

--- a/bson/src/main/org/bson/RawBsonDocument.java
+++ b/bson/src/main/org/bson/RawBsonDocument.java
@@ -39,7 +39,7 @@ import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
  *
  * @since 3.0
  */
-public class RawBsonDocument extends BsonDocument {
+public final class RawBsonDocument extends BsonDocument {
     private static final CodecRegistry REGISTRY = fromProviders(new BsonValueCodecProvider());
 
     private final byte[] bytes;

--- a/bson/src/test/unit/org/bson/BsonDocumentSpecification.groovy
+++ b/bson/src/test/unit/org/bson/BsonDocumentSpecification.groovy
@@ -188,6 +188,41 @@ class BsonDocumentSpecification extends Specification {
         root.getBinary('m', binary).is(binary)
     }
 
+    def 'clone should make a deep copy of all mutable BsonValue types'() {
+        given:
+        def document = new BsonDocument('d', new BsonDocument().append('i2', new BsonInt32(1)))
+                .append('i', new BsonInt32(2))
+                .append('a', new BsonArray([new BsonInt32(3),
+                                            new BsonArray([new BsonInt32(11)]),
+                                            new BsonDocument('i3', new BsonInt32(6)),
+                                            new BsonBinary([1, 2, 3] as byte[]),
+                                            new BsonJavaScriptWithScope('code', new BsonDocument('a', new BsonInt32(4)))]))
+                .append('b', new BsonBinary([1, 2, 3] as byte[]))
+                .append('js', new BsonJavaScriptWithScope('code', new BsonDocument('a', new BsonInt32(4))))
+
+        when:
+        def clone = document.clone()
+
+        then:
+        document == clone
+        !clone.is(document)
+        clone.get('i').is(document.get('i'))
+        !clone.get('d').is(document.get('d'))
+        !clone.get('a').is(document.get('a'))
+        !clone.get('b').is(document.get('b'))
+        !clone.get('b').asBinary().getData().is(document.get('b').asBinary().getData())
+        !clone.get('js').asJavaScriptWithScope().getScope().is(document.get('js').asJavaScriptWithScope().getScope())
+
+        clone.get('a').asArray()[0].is(document.get('a').asArray()[0])
+        !clone.get('a').asArray()[1].is(document.get('a').asArray()[1])
+        !clone.get('a').asArray()[2].is(document.get('a').asArray()[2])
+        !clone.get('a').asArray()[3].is(document.get('a').asArray()[3])
+        !clone.get('a').asArray()[3].asBinary().getData().is(document.get('a').asArray()[3].asBinary().getData())
+        !clone.get('a').asArray()[4].is(document.get('a').asArray()[4])
+        !clone.get('a').asArray()[4].asJavaScriptWithScope().getScope().is(document.get('a').asArray()[4].asJavaScriptWithScope()
+                                                                                   .getScope())
+    }
+
     @SuppressWarnings('UnnecessaryObjectReferences')
     def 'get methods should throw if key is absent'() {
         given:

--- a/bson/src/test/unit/org/bson/BsonDocumentSpecification.groovy
+++ b/bson/src/test/unit/org/bson/BsonDocumentSpecification.groovy
@@ -306,4 +306,29 @@ class BsonDocumentSpecification extends Specification {
         then:
         thrown(BsonInvalidOperationException)
     }
+
+    def 'should serialize and deserialize'() {
+        given:
+        def document = new BsonDocument('d', new BsonDocument().append('i2', new BsonInt32(1)))
+                .append('i', new BsonInt32(2))
+                .append('a', new BsonArray([new BsonInt32(3),
+                                            new BsonArray([new BsonInt32(11)]),
+                                            new BsonDocument('i3', new BsonInt32(6)),
+                                            new BsonBinary([1, 2, 3] as byte[]),
+                                            new BsonJavaScriptWithScope('code', new BsonDocument('a', new BsonInt32(4)))]))
+                .append('b', new BsonBinary([1, 2, 3] as byte[]))
+                .append('js', new BsonJavaScriptWithScope('code', new BsonDocument('a', new BsonInt32(4))))
+
+        def baos = new ByteArrayOutputStream()
+        def oos = new ObjectOutputStream(baos)
+
+        when:
+        oos.writeObject(document)
+        def bais = new ByteArrayInputStream(baos.toByteArray())
+        def ois = new ObjectInputStream(bais)
+        def deserializedDocument = ois.readObject()
+
+        then:
+        document == deserializedDocument
+    }
 }

--- a/bson/src/test/unit/org/bson/BsonDocumentWrapperSpecification.groovy
+++ b/bson/src/test/unit/org/bson/BsonDocumentWrapperSpecification.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson
+
+import org.bson.codecs.DocumentCodec
+import spock.lang.Specification
+
+import static java.util.Arrays.asList
+
+class BsonDocumentWrapperSpecification extends Specification {
+    def document = new Document()
+            .append('a', 1)
+            .append('b', 2)
+            .append('c', asList('x', true))
+            .append('d', asList(new Document('y', false), 1));
+
+    def wrapper = new BsonDocumentWrapper(document, new DocumentCodec())
+
+    def 'should serialize and deserialize'() {
+        given:
+        def baos = new ByteArrayOutputStream()
+        def oos = new ObjectOutputStream(baos)
+
+        when:
+        oos.writeObject(wrapper)
+        def bais = new ByteArrayInputStream(baos.toByteArray())
+        def ois = new ObjectInputStream(bais)
+        def deserializedDocument = ois.readObject()
+
+        then:
+        wrapper == deserializedDocument
+    }
+}

--- a/bson/src/test/unit/org/bson/RawBsonDocumentSpecification.groovy
+++ b/bson/src/test/unit/org/bson/RawBsonDocumentSpecification.groovy
@@ -167,6 +167,21 @@ class RawBsonDocumentSpecification extends Specification {
         !cloned.getByteBuffer().array().is(rawDocument.getByteBuffer().array())
     }
 
+    def 'should serialize and deserialize'() {
+        given:
+        def baos = new ByteArrayOutputStream()
+        def oos = new ObjectOutputStream(baos)
+
+        when:
+        oos.writeObject(rawDocument)
+        def bais = new ByteArrayInputStream(baos.toByteArray())
+        def ois = new ObjectInputStream(bais)
+        def deserializedDocument = ois.readObject()
+
+        then:
+        rawDocument == deserializedDocument
+    }
+
     class TestEntry implements Map.Entry<String, BsonValue> {
 
         private final String key;

--- a/bson/src/test/unit/org/bson/RawBsonDocumentSpecification.groovy
+++ b/bson/src/test/unit/org/bson/RawBsonDocumentSpecification.groovy
@@ -158,6 +158,15 @@ class RawBsonDocumentSpecification extends Specification {
         !areEqual(rawDocument, emptyRawDocument)
     }
 
+    def 'clone should make a deep copy'() {
+        when:
+        RawBsonDocument cloned = rawDocument.clone()
+
+        then:
+        cloned == rawDocument
+        !cloned.getByteBuffer().array().is(rawDocument.getByteBuffer().array())
+    }
+
     class TestEntry implements Map.Entry<String, BsonValue> {
 
         private final String key;

--- a/bson/src/test/unit/org/bson/RawBsonDocumentSpecification.groovy
+++ b/bson/src/test/unit/org/bson/RawBsonDocumentSpecification.groovy
@@ -20,6 +20,7 @@ import org.bson.codecs.BsonDocumentCodec
 import spock.lang.Specification
 
 import static java.util.Arrays.asList
+import static util.GroovyHelpers.areEqual
 
 class RawBsonDocumentSpecification extends Specification {
 
@@ -142,6 +143,19 @@ class RawBsonDocumentSpecification extends Specification {
 
     def 'should decode'() {
         rawDocument.decode(new BsonDocumentCodec()) == document
+    }
+
+    def 'hashCode should equal hash code of identical BsonDocument'() {
+        expect:
+        rawDocument.hashCode() == document.hashCode()
+    }
+
+    def 'equals should equal identical BsonDocument'() {
+        expect:
+        areEqual(rawDocument, document)
+        areEqual(document, rawDocument)
+        areEqual(rawDocument, rawDocument)
+        !areEqual(rawDocument, emptyRawDocument)
     }
 
     class TestEntry implements Map.Entry<String, BsonValue> {

--- a/bson/src/test/unit/util/GroovyHelpers.java
+++ b/bson/src/test/unit/util/GroovyHelpers.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package util;
+
+public final class GroovyHelpers {
+    // Workaround for the fact that Groovy will use its own custom equals method instead of calling the one on the instance.
+    public static boolean areEqual(final Object first, final Object second) {
+        return first.equals(second);
+    }
+
+    private GroovyHelpers() {
+    }
+}

--- a/config/findbugs-exclude.xml
+++ b/config/findbugs-exclude.xml
@@ -55,11 +55,19 @@
 
     <!-- Special handling of clone method for cloneable BsonValue subclasses.  By design, they don't call super.clone() -->
     <Match>
-        <Or>
-            <Class name="org.bson.BsonArray"/>
-            <Class name="org.bson.BsonDocument"/>
-            <Class name="org.bson.BsonDocumentWrapper"/>
-        </Or>
+        <Class name="org.bson.BsonArray"/>
+        <Method name="clone"/>
+        <Bug pattern="CN_IDIOM_NO_SUPER_CALL"/>
+    </Match>
+
+    <Match>
+        <Class name="org.bson.BsonDocument"/>
+        <Method name="clone"/>
+        <Bug pattern="CN_IDIOM_NO_SUPER_CALL"/>
+    </Match>
+
+    <Match>
+        <Class name="org.bson.BsonDocumentWrapper"/>
         <Method name="clone"/>
         <Bug pattern="CN_IDIOM_NO_SUPER_CALL"/>
     </Match>

--- a/config/findbugs-exclude.xml
+++ b/config/findbugs-exclude.xml
@@ -53,6 +53,17 @@
         <Bug pattern="SE_COMPARATOR_SHOULD_BE_SERIALIZABLE"/>
     </Match>
 
+    <!-- Special handling of clone method for cloneable BsonValue subclasses.  By design, they don't call super.clone() -->
+    <Match>
+        <Or>
+            <Class name="org.bson.BsonArray"/>
+            <Class name="org.bson.BsonDocument"/>
+            <Class name="org.bson.BsonDocumentWrapper"/>
+        </Or>
+        <Method name="clone"/>
+        <Bug pattern="CN_IDIOM_NO_SUPER_CALL"/>
+    </Match>
+
     <!-- Test exclusions -->
     <!-- All bugs in test classes, except for JUnit-specific bugs -->
     <Match>

--- a/driver-core/src/main/com/mongodb/WriteConcern.java
+++ b/driver-core/src/main/com/mongodb/WriteConcern.java
@@ -363,9 +363,6 @@ public class WriteConcern implements Serializable {
      * @return The write concern as a Document, even if {@code w &lt;= 0}
      */
     public BsonDocument asDocument() {
-        if (!isAcknowledged()) {
-            throw new IllegalStateException("The write is unacknowledged, so no document can be created");
-        }
         BsonDocument document = new BsonDocument();
 
         addW(document);

--- a/driver-core/src/main/com/mongodb/connection/AsyncConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/AsyncConnection.java
@@ -156,11 +156,38 @@ public interface AsyncConnection extends ReferenceCounted {
      * @param resultDecoder   the decoder for the query result documents
      * @param <T>             the query result document type
      * @param callback     the callback to be passed the write result
+     * @deprecated
      */
+    @Deprecated
     <T> void queryAsync(MongoNamespace namespace, BsonDocument queryDocument, BsonDocument fields,
                         int numberToReturn, int skip, boolean slaveOk, boolean tailableCursor, boolean awaitData, boolean noCursorTimeout,
                         boolean partial, boolean oplogReplay, Decoder<T> resultDecoder, SingleResultCallback<QueryResult<T>> callback);
 
+    /**
+     * Execute the query asynchronously.
+     *
+     * @param namespace       the namespace to query
+     * @param queryDocument   the query document
+     * @param fields          the field to include or exclude
+     * @param skip            the number of documents to skip
+     * @param limit           the maximum number of documents to return in all batches
+     * @param batchSize       the maximum number of documents to return in this batch
+     * @param slaveOk         whether the query can run on a secondary
+     * @param tailableCursor  whether to return a tailable cursor
+     * @param awaitData       whether a tailable cursor should wait before returning if no documents are available
+     * @param noCursorTimeout whether the cursor should not timeout
+     * @param partial         whether partial results from sharded clusters are acceptable
+     * @param oplogReplay     whether to replay the oplog
+     * @param resultDecoder   the decoder for the query result documents
+     * @param <T>             the query result document type
+     * @param callback     the callback to be passed the write result
+     *
+     * @since 3.1
+     */
+    <T> void queryAsync(MongoNamespace namespace, BsonDocument queryDocument, BsonDocument fields,
+                        int skip, int limit, int batchSize, boolean slaveOk, boolean tailableCursor, boolean awaitData,
+                        boolean noCursorTimeout, boolean partial, boolean oplogReplay, Decoder<T> resultDecoder,
+                        SingleResultCallback<QueryResult<T>> callback);
     /**
      * Get more result documents from a cursor asynchronously.
      *

--- a/driver-core/src/main/com/mongodb/connection/AsyncConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/AsyncConnection.java
@@ -156,7 +156,8 @@ public interface AsyncConnection extends ReferenceCounted {
      * @param resultDecoder   the decoder for the query result documents
      * @param <T>             the query result document type
      * @param callback     the callback to be passed the write result
-     * @deprecated
+     * @deprecated Replaced by {@link #queryAsync(MongoNamespace, BsonDocument, BsonDocument, int, int, int, boolean, boolean, boolean,
+     * boolean, boolean, boolean, Decoder, SingleResultCallback)}
      */
     @Deprecated
     <T> void queryAsync(MongoNamespace namespace, BsonDocument queryDocument, BsonDocument fields,

--- a/driver-core/src/main/com/mongodb/connection/AsyncConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/AsyncConnection.java
@@ -207,7 +207,7 @@ public interface AsyncConnection extends ReferenceCounted {
      *
      * @param cursors   the cursors
      * @param callback  the callback that is called once the cursors have been killed
-     * @deprecated Replace by {@link #killCursorAsync(MongoNamespace, List, SingleResultCallback)}
+     * @deprecated Replaced by {@link #killCursorAsync(MongoNamespace, List, SingleResultCallback)}
      */
     @Deprecated
     void killCursorAsync(List<Long> cursors, SingleResultCallback<Void> callback);

--- a/driver-core/src/main/com/mongodb/connection/AsyncConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/AsyncConnection.java
@@ -206,6 +206,17 @@ public interface AsyncConnection extends ReferenceCounted {
      *
      * @param cursors   the cursors
      * @param callback  the callback that is called once the cursors have been killed
+     * @deprecated Replace by {@link #killCursorAsync(MongoNamespace, List, SingleResultCallback)}
      */
+    @Deprecated
     void killCursorAsync(List<Long> cursors, SingleResultCallback<Void> callback);
+
+    /**
+     * Asynchronously Kills the given list of cursors.
+     *
+     * @param namespace the namespace in which the cursors live
+     * @param cursors   the cursors
+     * @param callback  the callback that is called once the cursors have been killed
+     */
+    void killCursorAsync(MongoNamespace namespace, List<Long> cursors, SingleResultCallback<Void> callback);
 }

--- a/driver-core/src/main/com/mongodb/connection/BaseWriteCommandMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/BaseWriteCommandMessage.java
@@ -98,11 +98,17 @@ abstract class BaseWriteCommandMessage extends RequestMessage {
 
     @Override
     protected BaseWriteCommandMessage encodeMessageBody(final BsonOutput outputStream, final int messageStartPosition) {
+        return (BaseWriteCommandMessage) encodeMessageBodyWithMetadata(outputStream, messageStartPosition).getNextMessage();
+    }
+
+    @Override
+    protected EncodingMetadata encodeMessageBodyWithMetadata(final BsonOutput outputStream, final int messageStartPosition) {
         BaseWriteCommandMessage nextMessage = null;
 
         writeCommandHeader(outputStream);
 
         int commandStartPosition = outputStream.getPosition();
+        int firstDocumentStartPosition = outputStream.getPosition();
         BsonBinaryWriter writer = new BsonBinaryWriter(new BsonWriterSettings(),
                                                        new BsonBinaryWriterSettings(getSettings().getMaxDocumentSize() + HEADROOM),
                                                        outputStream, getFieldNameValidator());
@@ -114,7 +120,7 @@ abstract class BaseWriteCommandMessage extends RequestMessage {
         } finally {
             writer.close();
         }
-        return nextMessage;
+        return new EncodingMetadata(nextMessage, firstDocumentStartPosition);
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/connection/ByteBufBsonDocument.java
+++ b/driver-core/src/main/com/mongodb/connection/ByteBufBsonDocument.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.mongodb.connection;
+
+import org.bson.BsonBinaryReader;
+import org.bson.BsonDocument;
+import org.bson.BsonType;
+import org.bson.BsonValue;
+import org.bson.ByteBuf;
+import org.bson.RawBsonDocument;
+import org.bson.codecs.BsonDocumentCodec;
+import org.bson.codecs.BsonValueCodecProvider;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.io.ByteBufferBsonInput;
+
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.bson.codecs.BsonValueCodecProvider.getClassForBsonType;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+
+class ByteBufBsonDocument extends BsonDocument implements Cloneable {
+    private static final CodecRegistry REGISTRY = fromProviders(new BsonValueCodecProvider());
+
+    private final ByteBuf byteBuf;
+
+    static List<ByteBufBsonDocument> create(final ResponseBuffers responseBuffers) {
+        int numDocuments = responseBuffers.getReplyHeader().getNumberReturned();
+        ByteBuf documentsBuffer = responseBuffers.getBodyByteBuffer();
+        documentsBuffer.order(ByteOrder.LITTLE_ENDIAN);
+        List<ByteBufBsonDocument> documents = new ArrayList<ByteBufBsonDocument>(numDocuments);
+        while (documents.size() < numDocuments) {
+            int documentSizeInBytes = documentsBuffer.getInt();
+            documentsBuffer.position(documentsBuffer.position() - 4);
+            ByteBuf documentBuffer = documentsBuffer.duplicate();
+            documentBuffer.limit(documentSizeInBytes);
+            documents.add(new ByteBufBsonDocument(documentBuffer));
+            documentsBuffer.position(documentsBuffer.position() + documentSizeInBytes);
+        }
+
+        return documents;
+    }
+
+    static ByteBufBsonDocument createOne(final ByteBufferBsonOutput bsonOutput, final int startPosition) {
+        return create(bsonOutput, startPosition).get(0);
+    }
+
+    static List<ByteBufBsonDocument> create(final ByteBufferBsonOutput bsonOutput, final int startPosition) {
+        CompositeByteBuf outputByteBuf = new CompositeByteBuf(bsonOutput.getByteBuffers());
+        outputByteBuf.position(startPosition);
+        List<ByteBufBsonDocument> documents = new ArrayList<ByteBufBsonDocument>();
+        int curDocumentStartPosition = startPosition;
+        while (outputByteBuf.hasRemaining()) {
+            int documentSizeInBytes = outputByteBuf.getInt();
+            ByteBuf slice = outputByteBuf.duplicate();
+            slice.position(curDocumentStartPosition);
+            slice.limit(curDocumentStartPosition + documentSizeInBytes);
+            documents.add(new ByteBufBsonDocument(slice));
+            curDocumentStartPosition += documentSizeInBytes;
+            outputByteBuf.position(outputByteBuf.position() + documentSizeInBytes - 4);
+        }
+
+        return documents;
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException("RawBsonDocument instances are immutable");
+    }
+
+    @Override
+    public BsonValue put(final String key, final BsonValue value) {
+        throw new UnsupportedOperationException("RawBsonDocument instances are immutable");
+    }
+
+    @Override
+    public BsonDocument append(final String key, final BsonValue value) {
+        throw new UnsupportedOperationException("RawBsonDocument instances are immutable");
+    }
+
+    @Override
+    public void putAll(final Map<? extends String, ? extends BsonValue> m) {
+        throw new UnsupportedOperationException("RawBsonDocument instances are immutable");
+    }
+
+    @Override
+    public BsonValue remove(final Object key) {
+        throw new UnsupportedOperationException("RawBsonDocument instances are immutable");
+    }
+
+    @Override
+    public boolean isEmpty() {
+        BsonBinaryReader bsonReader = createReader();
+        try {
+            bsonReader.readStartDocument();
+            if (bsonReader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+                return false;
+            }
+            bsonReader.readEndDocument();
+        } finally {
+            bsonReader.close();
+        }
+
+        return true;
+    }
+
+    @Override
+    public int size() {
+        int size = 0;
+        BsonBinaryReader bsonReader = createReader();
+        try {
+            bsonReader.readStartDocument();
+            while (bsonReader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+                size++;
+                bsonReader.readName();
+                bsonReader.skipValue();
+            }
+            bsonReader.readEndDocument();
+        } finally {
+            bsonReader.close();
+        }
+
+        return size;
+    }
+
+    @Override
+    public Set<Entry<String, BsonValue>> entrySet() {
+        return toBsonDocument().entrySet();
+    }
+
+    @Override
+    public Collection<BsonValue> values() {
+        return toBsonDocument().values();
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return toBsonDocument().keySet();
+    }
+
+    @Override
+    public boolean containsKey(final Object key) {
+        if (key == null) {
+            throw new IllegalArgumentException("key can not be null");
+        }
+
+        BsonBinaryReader bsonReader = createReader();
+        try {
+            bsonReader.readStartDocument();
+            while (bsonReader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+                if (bsonReader.readName().equals(key)) {
+                    return true;
+                }
+                bsonReader.skipValue();
+            }
+            bsonReader.readEndDocument();
+        } finally {
+            bsonReader.close();
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean containsValue(final Object value) {
+        BsonBinaryReader bsonReader = createReader();
+        try {
+            bsonReader.readStartDocument();
+            while (bsonReader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+                bsonReader.skipName();
+                if (deserializeBsonValue(bsonReader).equals(value)) {
+                    return true;
+                }
+            }
+            bsonReader.readEndDocument();
+        } finally {
+            bsonReader.close();
+        }
+
+        return false;
+    }
+
+    @Override
+    public BsonValue get(final Object key) {
+        if (key == null) {
+            throw new IllegalArgumentException("key can not be null");
+        }
+
+        BsonBinaryReader bsonReader = createReader();
+        try {
+            bsonReader.readStartDocument();
+            while (bsonReader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+                if (bsonReader.readName().equals(key)) {
+                    return deserializeBsonValue(bsonReader);
+                }
+                bsonReader.skipValue();
+            }
+            bsonReader.readEndDocument();
+        } finally {
+            bsonReader.close();
+        }
+
+        return null;
+    }
+
+    /**
+     * Gets the first key in this document, or null if the document is empty.
+     *
+     * @return the first key in this document, or null if the document is empty
+     */
+    public String getFirstKey() {
+        BsonBinaryReader bsonReader = createReader();
+        try {
+            bsonReader.readStartDocument();
+            while (bsonReader.readBsonType() != BsonType.END_OF_DOCUMENT) {
+                return bsonReader.readName();
+            }
+            bsonReader.readEndDocument();
+        } finally {
+            bsonReader.close();
+        }
+
+        return null;
+    }
+
+    @Override
+    public BsonDocument clone() {
+        byte[] clonedBytes = new byte[byteBuf.remaining()];
+        byteBuf.get(byteBuf.position(), clonedBytes);
+        return new RawBsonDocument(clonedBytes);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        return toBsonDocument().equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return toBsonDocument().hashCode();
+    }
+
+    private BsonDocument toBsonDocument() {
+        BsonBinaryReader bsonReader = createReader();
+        try {
+            return new BsonDocumentCodec().decode(bsonReader, DecoderContext.builder().build());
+        } finally {
+            bsonReader.close();
+        }
+    }
+
+    private BsonBinaryReader createReader() {
+        return new BsonBinaryReader(new ByteBufferBsonInput(byteBuf.duplicate()));
+    }
+
+    private BsonValue deserializeBsonValue(final BsonBinaryReader bsonReader) {
+        return REGISTRY.get(getClassForBsonType(bsonReader.getCurrentBsonType())).decode(bsonReader, DecoderContext.builder().build());
+    }
+
+    ByteBufBsonDocument(final ByteBuf byteBuf) {
+        this.byteBuf = byteBuf;
+    }
+}

--- a/driver-core/src/main/com/mongodb/connection/ByteBufBsonDocument.java
+++ b/driver-core/src/main/com/mongodb/connection/ByteBufBsonDocument.java
@@ -30,6 +30,8 @@ import org.bson.codecs.DecoderContext;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.io.ByteBufferBsonInput;
 
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -41,9 +43,11 @@ import static org.bson.codecs.BsonValueCodecProvider.getClassForBsonType;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 
 class ByteBufBsonDocument extends BsonDocument implements Cloneable {
+    private static final long serialVersionUID = 1L;
+
     private static final CodecRegistry REGISTRY = fromProviders(new BsonValueCodecProvider());
 
-    private final ByteBuf byteBuf;
+    private final transient ByteBuf byteBuf;
 
     static List<ByteBufBsonDocument> create(final ResponseBuffers responseBuffers) {
         int numDocuments = responseBuffers.getReplyHeader().getNumberReturned();
@@ -284,5 +288,13 @@ class ByteBufBsonDocument extends BsonDocument implements Cloneable {
 
     ByteBufBsonDocument(final ByteBuf byteBuf) {
         this.byteBuf = byteBuf;
+    }
+
+    private Object writeReplace() {
+        return toBsonDocument();
+    }
+
+    private void readObject(final ObjectInputStream stream) throws InvalidObjectException {
+        throw new InvalidObjectException("Proxy required");
     }
 }

--- a/driver-core/src/main/com/mongodb/connection/ByteBufBsonDocument.java
+++ b/driver-core/src/main/com/mongodb/connection/ByteBufBsonDocument.java
@@ -290,10 +290,12 @@ class ByteBufBsonDocument extends BsonDocument implements Cloneable {
         this.byteBuf = byteBuf;
     }
 
+    // see https://docs.oracle.com/javase/6/docs/platform/serialization/spec/output.html
     private Object writeReplace() {
         return toBsonDocument();
     }
 
+    // see https://docs.oracle.com/javase/6/docs/platform/serialization/spec/input.html
     private void readObject(final ObjectInputStream stream) throws InvalidObjectException {
         throw new InvalidObjectException("Proxy required");
     }

--- a/driver-core/src/main/com/mongodb/connection/ByteBufferBsonOutput.java
+++ b/driver-core/src/main/com/mongodb/connection/ByteBufferBsonOutput.java
@@ -136,8 +136,11 @@ public class ByteBufferBsonOutput extends OutputBuffer {
 
         int total = 0;
         for (final ByteBuf cur : getByteBuffers()) {
-            out.write(cur.array(), 0, cur.limit());
-            total += cur.limit();
+            ByteBuf dup = cur.duplicate();
+            while (dup.hasRemaining()) {
+                out.write(dup.get());
+            }
+            total += dup.limit();
         }
         return total;
     }

--- a/driver-core/src/main/com/mongodb/connection/CommandMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/CommandMessage.java
@@ -62,11 +62,17 @@ class CommandMessage extends RequestMessage {
 
     @Override
     protected RequestMessage encodeMessageBody(final BsonOutput bsonOutput, final int messageStartPosition) {
+        return encodeMessageBodyWithMetadata(bsonOutput, messageStartPosition).getNextMessage();
+    }
+
+    @Override
+    protected EncodingMetadata encodeMessageBodyWithMetadata(final BsonOutput bsonOutput, final int messageStartPosition) {
         bsonOutput.writeInt32(slaveOk ? 1 << 2 : 0);
         bsonOutput.writeCString(getCollectionName());
         bsonOutput.writeInt32(0);
         bsonOutput.writeInt32(-1);
+        int firstDocumentPosition = bsonOutput.getPosition();
         addDocument(command, bsonOutput, validator);
-        return null;
+        return new EncodingMetadata(null, firstDocumentPosition);
     }
 }

--- a/driver-core/src/main/com/mongodb/connection/CommandProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/CommandProtocol.java
@@ -31,9 +31,9 @@ import org.bson.codecs.DecoderContext;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.connection.ByteBufBsonDocument.createOne;
 import static com.mongodb.connection.ProtocolHelper.getCommandFailureException;
-import static com.mongodb.connection.ProtocolHelper.sendCommandCompletedEvent;
 import static com.mongodb.connection.ProtocolHelper.sendCommandFailedEvent;
 import static com.mongodb.connection.ProtocolHelper.sendCommandStartedEvent;
+import static com.mongodb.connection.ProtocolHelper.sendCommandSucceededEvent;
 import static java.lang.String.format;
 
 /**
@@ -106,7 +106,7 @@ class CommandProtocol<T> implements Protocol<T> {
 
             T retval = commandResultDecoder.decode(new BsonDocumentReader(response), DecoderContext.builder().build());
             if (commandListener != null) {
-                sendCommandCompletedEvent(commandMessage, getCommandName(), response, connection.getDescription(), startTimeNanos,
+                sendCommandSucceededEvent(commandMessage, getCommandName(), response, connection.getDescription(), startTimeNanos,
                                           commandListener);
             }
             LOGGER.debug("Command execution completed");

--- a/driver-core/src/main/com/mongodb/connection/CompositeByteBuf.java
+++ b/driver-core/src/main/com/mongodb/connection/CompositeByteBuf.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.connection;
+
+import org.bson.ByteBuf;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.lang.String.format;
+import static org.bson.assertions.Assertions.isTrueArgument;
+import static org.bson.assertions.Assertions.notNull;
+
+class CompositeByteBuf implements ByteBuf {
+    private final List<Component> components;
+    private final AtomicInteger referenceCount = new AtomicInteger(1);
+    private int position;
+    private int limit;
+
+    public CompositeByteBuf(final List<ByteBuf> buffers) {
+        notNull("buffers", buffers);
+        isTrueArgument("buffer list not empty", !buffers.isEmpty());
+        components = new ArrayList<Component>(buffers.size());
+
+        int offset = 0;
+        for (ByteBuf cur : buffers) {
+            Component component = new Component(cur.duplicate().order(ByteOrder.LITTLE_ENDIAN), offset);
+            components.add(component);
+            offset = component.endOffset;
+        }
+        limit = components.get(components.size() - 1).endOffset;
+    }
+
+    CompositeByteBuf(final CompositeByteBuf from) {
+        components = from.components;
+        position = from.position();
+        limit = from.limit();
+    }
+
+    @Override
+    public ByteBuf order(final ByteOrder byteOrder) {
+        if (byteOrder == ByteOrder.BIG_ENDIAN) {
+            throw new UnsupportedOperationException(format("Only %s is supported", ByteOrder.BIG_ENDIAN));
+        }
+        return this;
+    }
+
+    @Override
+    public int capacity() {
+        return components.get(components.size() - 1).endOffset;
+    }
+
+    @Override
+    public int remaining() {
+        return limit() - position();
+    }
+
+    @Override
+    public boolean hasRemaining() {
+        return remaining() > 0;
+    }
+
+    @Override
+    public int position() {
+        return position;
+    }
+
+    @Override
+    public ByteBuf position(final int newPosition) {
+        if (newPosition < 0 || newPosition > limit) {
+            throw new IndexOutOfBoundsException(format("%d is out of bounds", newPosition));
+        }
+        position = newPosition;
+        return this;
+    }
+
+    @Override
+    public ByteBuf clear() {
+        position = 0;
+        limit = capacity();
+        return this;
+    }
+
+    @Override
+    public int limit() {
+        return limit;
+    }
+
+    @Override
+    public byte get() {
+        checkIndex(position);
+        position += 1;
+        return get(position - 1);
+    }
+
+    @Override
+    public byte get(final int index) {
+        checkIndex(index);
+        Component component = findComponent(index);
+        return component.buffer.get(index - component.offset);
+    }
+
+    @Override
+    public ByteBuf get(final byte[] bytes) {
+        checkIndex(position, bytes.length);
+        position += bytes.length;
+        return get(position - bytes.length, bytes);
+    }
+
+    @Override
+    public ByteBuf get(final int index, final byte[] bytes) {
+        return get(index, bytes, 0, bytes.length);
+    }
+
+    @Override
+    public ByteBuf get(final byte[] bytes, final int offset, final int length) {
+        checkIndex(position, length);
+        position += length;
+        return get(position - length, bytes, offset, length);
+    }
+
+    @Override
+    public ByteBuf get(final int index, final byte[] bytes, final int offset, final int length) {
+        checkDstIndex(index, length, offset, bytes.length);
+
+        int i = findComponentIndex(index);
+        int curIndex = index;
+        int curOffset = offset;
+        int curLength = length;
+        while (curLength > 0) {
+            Component c = components.get(i);
+            int localLength = Math.min(curLength, c.buffer.capacity() - (curIndex - c.offset));
+            c.buffer.get(curIndex - c.offset, bytes, curOffset, localLength);
+            curIndex += localLength;
+            curOffset += localLength;
+            curLength -= localLength;
+            i++;
+        }
+
+        return this;
+    }
+
+    @Override
+    public long getLong() {
+        position += 8;
+        return getLong(position - 8);
+    }
+
+    @Override
+    public long getLong(final int index) {
+        checkIndex(index, 8);
+        Component component = findComponent(index);
+        if (index + 8 <= component.endOffset) {
+            return component.buffer.getLong(index - component.offset);
+        } else {
+            return getInt(index) & 0xFFFFFFFFL | (getInt(index + 4) & 0xFFFFFFFFL) << 32;
+        }
+    }
+
+    @Override
+    public double getDouble() {
+        position += 8;
+        return getDouble(position - 8);
+    }
+
+    @Override
+    public double getDouble(final int index) {
+        return Double.longBitsToDouble(getLong(index));
+    }
+
+    @Override
+    public int getInt() {
+        position += 4;
+        return getInt(position - 4);
+    }
+
+    @Override
+    public int getInt(final int index) {
+        checkIndex(index, 4);
+        Component component = findComponent(index);
+        if (index + 4 <= component.endOffset) {
+            return component.buffer.getInt(index - component.offset);
+        } else {
+            return getShort(index) & 0xFFFF | (getShort(index + 2) & 0xFFFF) << 16;
+        }
+    }
+
+    private int getShort(final int index) {
+        checkIndex(index, 2);
+        return (short) (get(index) & 0xff | (get(index + 1) & 0xff) << 8);
+    }
+
+    @Override
+    public byte[] array() {
+        throw new UnsupportedOperationException("Not implemented yet!");
+    }
+
+    @Override
+    public ByteBuf limit(final int newLimit) {
+        if (newLimit < 0 || newLimit > capacity()) {
+            throw new IndexOutOfBoundsException(format("%d is out of bounds", newLimit));
+        }
+        this.limit = newLimit;
+        return this;
+    }
+
+    @Override
+    public ByteBuf put(final int index, final byte b) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ByteBuf put(final byte[] src, final int offset, final int length) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ByteBuf put(final byte b) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ByteBuf flip() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ByteBuf asReadOnly() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ByteBuf duplicate() {
+        return new CompositeByteBuf(this);
+    }
+
+    @Override
+    public ByteBuffer asNIO() {
+        if (components.size() == 1) {
+            ByteBuffer byteBuffer = components.get(0).buffer.asNIO().duplicate();
+            byteBuffer.position(position).limit(limit);
+            return byteBuffer;
+        } else {
+           byte[] bytes = new byte[remaining()];
+           get(position, bytes, 0, bytes.length);
+           return ByteBuffer.wrap(bytes);
+        }
+    }
+
+    @Override
+    public int getReferenceCount() {
+        return referenceCount.get();
+    }
+
+    @Override
+    public ByteBuf retain() {
+        if (referenceCount.incrementAndGet() == 1) {
+            referenceCount.decrementAndGet();
+            throw new IllegalStateException("Attempted to increment the reference count when it is already 0");
+        }
+        return this;
+    }
+
+    @Override
+    public void release() {
+        if (referenceCount.decrementAndGet() < 0) {
+            referenceCount.incrementAndGet();
+            throw new IllegalStateException("Attempted to decrement the reference count below 0");
+        }
+    }
+
+    private Component findComponent(final int index) {
+        return components.get(findComponentIndex(index));
+    }
+
+    private int findComponentIndex(final int index) {
+        for (int i = components.size() - 1; i >= 0; i--) {
+            Component cur = components.get(i);
+            if (index >= cur.offset) {
+                return i;
+            }
+        }
+        throw new IndexOutOfBoundsException(format("%d is out of bounds", index));
+    }
+
+    private void checkIndex(final int index) {
+        ensureAccessible();
+        if (index < 0 || index >= capacity()) {
+            throw new IndexOutOfBoundsException(format("index: %d (expected: range(0, %d))", index, capacity()));
+        }
+    }
+
+    private void checkIndex(final int index, final int fieldLength) {
+        ensureAccessible();
+        if (index < 0 || index > capacity() - fieldLength) {
+            throw new IndexOutOfBoundsException(format("index: %d, length: %d (expected: range(0, %d))", index, fieldLength, capacity()));
+        }
+    }
+
+    private void checkDstIndex(final int index, final int length, final int dstIndex, final int dstCapacity) {
+        checkIndex(index, length);
+        if (dstIndex < 0 || dstIndex > dstCapacity - length) {
+            throw new IndexOutOfBoundsException(format("dstIndex: %d, length: %d (expected: range(0, %d))", dstIndex, length, dstCapacity));
+        }
+    }
+
+    private void ensureAccessible() {
+        if (referenceCount.get() == 0) {
+            throw new IllegalStateException("Reference count is 0");
+        }
+    }
+
+    private static final class Component {
+        private final ByteBuf buffer;
+        private final int length;
+        private final int offset;
+        private final int endOffset;
+
+        Component(final ByteBuf buffer, final int offset) {
+            this.buffer = buffer;
+            length = buffer.limit() - buffer.position();
+            this.offset = offset;
+            this.endOffset = offset + length;
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/connection/Connection.java
+++ b/driver-core/src/main/com/mongodb/connection/Connection.java
@@ -205,7 +205,6 @@ public interface Connection extends ReferenceCounted {
      *
      * @param cursors the cursors
      * @deprecated Replaced by {@link #killCursor(MongoNamespace, List)}
-     * @see #killCursor(MongoNamespace, List)
      */
     @Deprecated
     void killCursor(List<Long> cursors);

--- a/driver-core/src/main/com/mongodb/connection/Connection.java
+++ b/driver-core/src/main/com/mongodb/connection/Connection.java
@@ -151,9 +151,38 @@ public interface Connection extends ReferenceCounted {
      * @param resultDecoder   the decoder for the query result documents
      * @param <T>             the query result document type
      * @return the query results
+     * @deprecated
      */
+    @Deprecated
     <T> QueryResult<T> query(MongoNamespace namespace, BsonDocument queryDocument, BsonDocument fields,
                              int numberToReturn, int skip,
+                             boolean slaveOk, boolean tailableCursor, boolean awaitData, boolean noCursorTimeout,
+                             boolean partial, boolean oplogReplay,
+                             Decoder<T> resultDecoder);
+
+    /**
+     * Execute the query.
+     *
+     * @param namespace       the namespace to query
+     * @param queryDocument   the query document
+     * @param fields          the field to include or exclude
+     * @param skip            the number of documents to skip
+     * @param limit           the maximum number of documents to return in all batches
+     * @param batchSize       the maximum number of documents to return in this batch
+     * @param slaveOk         whether the query can run on a secondary
+     * @param tailableCursor  whether to return a tailable cursor
+     * @param awaitData       whether a tailable cursor should wait before returning if no documents are available
+     * @param noCursorTimeout whether the cursor should not timeout
+     * @param partial         whether partial results from sharded clusters are acceptable
+     * @param oplogReplay     whether to replay the oplog
+     * @param resultDecoder   the decoder for the query result documents
+     * @param <T>             the query result document type
+     * @return the query results
+     *
+     * @since 3.1
+     */
+    <T> QueryResult<T> query(MongoNamespace namespace, BsonDocument queryDocument, BsonDocument fields,
+                             int skip, int limit, int batchSize,
                              boolean slaveOk, boolean tailableCursor, boolean awaitData, boolean noCursorTimeout,
                              boolean partial, boolean oplogReplay,
                              Decoder<T> resultDecoder);

--- a/driver-core/src/main/com/mongodb/connection/Connection.java
+++ b/driver-core/src/main/com/mongodb/connection/Connection.java
@@ -151,7 +151,8 @@ public interface Connection extends ReferenceCounted {
      * @param resultDecoder   the decoder for the query result documents
      * @param <T>             the query result document type
      * @return the query results
-     * @deprecated
+     * @deprecated Replaced by {@link #query(MongoNamespace, BsonDocument, BsonDocument, int, int, int, boolean, boolean, boolean,
+     * boolean, boolean, boolean, Decoder)}
      */
     @Deprecated
     <T> QueryResult<T> query(MongoNamespace namespace, BsonDocument queryDocument, BsonDocument fields,

--- a/driver-core/src/main/com/mongodb/connection/Connection.java
+++ b/driver-core/src/main/com/mongodb/connection/Connection.java
@@ -203,6 +203,17 @@ public interface Connection extends ReferenceCounted {
      * Kills the given list of cursors.
      *
      * @param cursors the cursors
+     * @deprecated Replaced by {@link #killCursor(MongoNamespace, List)}
+     * @see #killCursor(MongoNamespace, List)
      */
+    @Deprecated
     void killCursor(List<Long> cursors);
+
+    /**
+     * Kills the given list of cursors.
+     *
+     * @param namespace the namespace to in which the cursors live
+     * @param cursors   the cursors
+     */
+    void killCursor(MongoNamespace namespace, List<Long> cursors);
 }

--- a/driver-core/src/main/com/mongodb/connection/DefaultClusterFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/DefaultClusterFactory.java
@@ -59,6 +59,8 @@ public final class DefaultClusterFactory implements ClusterFactory {
      * @param connectionListener     an optional listener for connection-related events
      * @param commandListener        an optional listener for command-related events
      * @return the cluster
+     *
+     * @since 3.1
      */
     public Cluster create(final ClusterSettings settings, final ServerSettings serverSettings,
                           final ConnectionPoolSettings connectionPoolSettings, final StreamFactory streamFactory,

--- a/driver-core/src/main/com/mongodb/connection/DefaultClusterableServerFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/DefaultClusterableServerFactory.java
@@ -20,6 +20,7 @@ import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
 import com.mongodb.event.ConnectionListener;
 import com.mongodb.event.ConnectionPoolListener;
+import com.mongodb.event.CommandListener;
 
 import java.util.List;
 
@@ -33,6 +34,7 @@ class DefaultClusterableServerFactory implements ClusterableServerFactory {
     private final ConnectionPoolListener connectionPoolListener;
     private final ConnectionListener connectionListener;
     private final StreamFactory heartbeatStreamFactory;
+    private final CommandListener commandListener;
 
     public DefaultClusterableServerFactory(final ClusterId clusterId, final ClusterSettings clusterSettings, final ServerSettings settings,
                                            final ConnectionPoolSettings connectionPoolSettings,
@@ -40,7 +42,7 @@ class DefaultClusterableServerFactory implements ClusterableServerFactory {
                                            final StreamFactory heartbeatStreamFactory,
                                            final List<MongoCredential> credentialList,
                                            final ConnectionListener connectionListener,
-                                           final ConnectionPoolListener connectionPoolListener) {
+                                           final ConnectionPoolListener connectionPoolListener, final CommandListener commandListener) {
         this.clusterId = clusterId;
         this.clusterSettings = clusterSettings;
         this.settings = settings;
@@ -50,6 +52,7 @@ class DefaultClusterableServerFactory implements ClusterableServerFactory {
         this.connectionPoolListener = connectionPoolListener;
         this.connectionListener = connectionListener;
         this.heartbeatStreamFactory = heartbeatStreamFactory;
+        this.commandListener = commandListener;
     }
 
     @Override
@@ -66,7 +69,7 @@ class DefaultClusterableServerFactory implements ClusterableServerFactory {
                                                                                 connectionListener),
                                             connectionPool);
         return new DefaultServer(serverAddress, clusterSettings.getMode(), connectionPool, new DefaultConnectionFactory(),
-                                 serverMonitorFactory);
+                                 serverMonitorFactory, commandListener);
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/connection/DefaultServer.java
+++ b/driver-core/src/main/com/mongodb/connection/DefaultServer.java
@@ -24,6 +24,7 @@ import com.mongodb.MongoSocketException;
 import com.mongodb.MongoSocketReadTimeoutException;
 import com.mongodb.ServerAddress;
 import com.mongodb.async.SingleResultCallback;
+import com.mongodb.event.CommandListener;
 
 import java.util.Collections;
 import java.util.Set;
@@ -43,6 +44,7 @@ class DefaultServer implements ClusterableServer {
     private final Set<ChangeListener<ServerDescription>> changeListeners =
     Collections.newSetFromMap(new ConcurrentHashMap<ChangeListener<ServerDescription>, Boolean>());
     private final ChangeListener<ServerDescription> serverStateListener;
+    private final CommandListener commandListener;
     private volatile ServerDescription description;
     private volatile boolean isClosed;
 
@@ -50,7 +52,8 @@ class DefaultServer implements ClusterableServer {
                          final ClusterConnectionMode clusterConnectionMode,
                          final ConnectionPool connectionPool,
                          final ConnectionFactory connectionFactory,
-                         final ServerMonitorFactory serverMonitorFactory) {
+                         final ServerMonitorFactory serverMonitorFactory, final CommandListener commandListener) {
+        this.commandListener = commandListener;
         notNull("serverMonitorFactory", serverMonitorFactory);
         this.clusterConnectionMode = notNull("clusterConnectionMode", clusterConnectionMode);
         this.connectionFactory = notNull("connectionFactory", connectionFactory);
@@ -152,6 +155,7 @@ class DefaultServer implements ClusterableServer {
         @Override
         public <T> T execute(final Protocol<T> protocol, final InternalConnection connection) {
             try {
+                protocol.setCommandListener(commandListener);
                 return protocol.execute(connection);
             } catch (MongoException e) {
                 handleThrowable(e);

--- a/driver-core/src/main/com/mongodb/connection/DefaultServerConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/DefaultServerConnection.java
@@ -34,6 +34,7 @@ import static com.mongodb.assertions.Assertions.isTrue;
 import static com.mongodb.connection.ServerType.SHARD_ROUTER;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 
+@SuppressWarnings("deprecation")  // because this class implements deprecated methods
 class DefaultServerConnection extends AbstractReferenceCounted implements Connection, AsyncConnection {
     private final InternalConnection wrapped;
     private final ProtocolExecutor protocolExecutor;

--- a/driver-core/src/main/com/mongodb/connection/DefaultServerConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/DefaultServerConnection.java
@@ -173,6 +173,22 @@ class DefaultServerConnection extends AbstractReferenceCounted implements Connec
     }
 
     @Override
+    public <T> QueryResult<T> query(final MongoNamespace namespace, final BsonDocument queryDocument, final BsonDocument fields,
+                                    final int skip, final int limit, final int batchSize,
+                                    final boolean slaveOk, final boolean tailableCursor,
+                                    final boolean awaitData, final boolean noCursorTimeout,
+                                    final boolean partial, final boolean oplogReplay,
+                                    final Decoder<T> resultDecoder) {
+        return executeProtocol(new QueryProtocol<T>(namespace, skip, limit, batchSize, queryDocument, fields, resultDecoder)
+                               .tailableCursor(tailableCursor)
+                               .slaveOk(getSlaveOk(slaveOk))
+                               .oplogReplay(oplogReplay)
+                               .noCursorTimeout(noCursorTimeout)
+                               .awaitData(awaitData)
+                               .partial(partial));
+    }
+
+    @Override
     public <T> void queryAsync(final MongoNamespace namespace, final BsonDocument queryDocument, final BsonDocument fields,
                                final int numberToReturn, final int skip,
                                final boolean slaveOk, final boolean tailableCursor, final boolean awaitData, final boolean noCursorTimeout,
@@ -180,6 +196,20 @@ class DefaultServerConnection extends AbstractReferenceCounted implements Connec
                                final boolean oplogReplay, final Decoder<T> resultDecoder,
                                final SingleResultCallback<QueryResult<T>> callback) {
         executeProtocolAsync(new QueryProtocol<T>(namespace, skip, numberToReturn, queryDocument, fields, resultDecoder)
+                             .tailableCursor(tailableCursor)
+                             .slaveOk(getSlaveOk(slaveOk))
+                             .oplogReplay(oplogReplay)
+                             .noCursorTimeout(noCursorTimeout)
+                             .awaitData(awaitData)
+                             .partial(partial), callback);
+    }
+
+    @Override
+    public <T> void queryAsync(final MongoNamespace namespace, final BsonDocument queryDocument, final BsonDocument fields, final int skip,
+                               final int limit, final int batchSize, final boolean slaveOk, final boolean tailableCursor,
+                               final boolean awaitData, final boolean noCursorTimeout, final boolean partial, final boolean oplogReplay,
+                               final Decoder<T> resultDecoder, final SingleResultCallback<QueryResult<T>> callback) {
+        executeProtocolAsync(new QueryProtocol<T>(namespace, skip, limit, batchSize, queryDocument, fields, resultDecoder)
                              .tailableCursor(tailableCursor)
                              .slaveOk(getSlaveOk(slaveOk))
                              .oplogReplay(oplogReplay)

--- a/driver-core/src/main/com/mongodb/connection/DefaultServerConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/DefaultServerConnection.java
@@ -233,12 +233,22 @@ class DefaultServerConnection extends AbstractReferenceCounted implements Connec
 
     @Override
     public void killCursor(final List<Long> cursors) {
-        executeProtocol(new KillCursorProtocol(cursors));
+        killCursor(null, cursors);
+    }
+
+    @Override
+    public void killCursor(final MongoNamespace namespace, final List<Long> cursors) {
+        executeProtocol(new KillCursorProtocol(namespace, cursors));
     }
 
     @Override
     public void killCursorAsync(final List<Long> cursors, final SingleResultCallback<Void> callback) {
-        executeProtocolAsync(new KillCursorProtocol(cursors), callback);
+        killCursorAsync(null, cursors, callback);
+    }
+
+    @Override
+    public void killCursorAsync(final MongoNamespace namespace, final List<Long> cursors, final SingleResultCallback<Void> callback) {
+        executeProtocolAsync(new KillCursorProtocol(namespace, cursors), callback);
     }
 
     private boolean getSlaveOk(final boolean slaveOk) {

--- a/driver-core/src/main/com/mongodb/connection/DeleteMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/DeleteMessage.java
@@ -45,15 +45,12 @@ class DeleteMessage extends RequestMessage {
 
     @Override
     protected RequestMessage encodeMessageBody(final BsonOutput bsonOutput, final int messageStartPosition) {
-        writeDelete(deleteRequests.get(0), bsonOutput);
-        if (deleteRequests.size() == 1) {
-            return null;
-        } else {
-            return new DeleteMessage(getCollectionName(), deleteRequests.subList(1, deleteRequests.size()), getSettings());
-        }
+        return encodeMessageBodyWithMetadata(bsonOutput, messageStartPosition).getNextMessage();
     }
 
-    private void writeDelete(final DeleteRequest deleteRequest, final BsonOutput bsonOutput) {
+    @Override
+    protected EncodingMetadata encodeMessageBodyWithMetadata(final BsonOutput bsonOutput, final int messageStartPosition) {
+        DeleteRequest deleteRequest = deleteRequests.get(0);
         bsonOutput.writeInt32(0); // reserved
         bsonOutput.writeCString(getCollectionName());
 
@@ -63,7 +60,17 @@ class DeleteMessage extends RequestMessage {
             bsonOutput.writeInt32(1);
         }
 
+        int firstDocumentStartPosition = bsonOutput.getPosition();
+
         addDocument(deleteRequest.getFilter(), bsonOutput, new NoOpFieldNameValidator());
+        if (deleteRequests.size() == 1) {
+            return new EncodingMetadata(null, firstDocumentStartPosition);
+        } else {
+            return new EncodingMetadata(new DeleteMessage(getCollectionName(), deleteRequests.subList(1, deleteRequests.size()),
+                                                          getSettings()),
+                                        firstDocumentStartPosition);
+        }
     }
+
 }
 

--- a/driver-core/src/main/com/mongodb/connection/DeleteProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/DeleteProtocol.java
@@ -109,6 +109,12 @@ class DeleteProtocol extends WriteProtocol {
     }
 
     @Override
+    protected void appendToWriteCommandResponseDocument(final RequestMessage curMessage, final RequestMessage nextMessage,
+                                                        final WriteConcernResult writeConcernResult, final BsonDocument response) {
+        response.append("n", new BsonInt32(writeConcernResult.getCount()));
+    }
+
+    @Override
     protected Logger getLogger() {
         return LOGGER;
     }

--- a/driver-core/src/main/com/mongodb/connection/DeleteProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/DeleteProtocol.java
@@ -23,10 +23,15 @@ import com.mongodb.async.SingleResultCallback;
 import com.mongodb.bulk.DeleteRequest;
 import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
 
 import java.util.List;
 
+import static com.mongodb.connection.ByteBufBsonDocument.createOne;
 import static java.lang.String.format;
+import static java.util.Collections.singletonList;
 
 /**
  * An implementation of the MongoDB OP_DELETE wire protocol.
@@ -84,6 +89,18 @@ class DeleteProtocol extends WriteProtocol {
         } catch (Throwable t) {
             callback.onResult(null, t);
         }
+    }
+
+    @Override
+    protected BsonDocument getAsWriteCommand(final ByteBufferBsonOutput bsonOutput, final int firstDocumentPosition) {
+        BsonDocument deleteDocument = new BsonDocument("q", createOne(bsonOutput, firstDocumentPosition))
+                                      .append("limit", deletes.get(0).isMulti() ? new BsonInt32(0) : new BsonInt32(1));
+        return getBaseCommandDocument().append("deletes", new BsonArray(singletonList(deleteDocument)));
+    }
+
+    @Override
+    protected String getCommandName() {
+        return "delete";
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/connection/GenericWriteProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/GenericWriteProtocol.java
@@ -18,6 +18,7 @@ package com.mongodb.connection;
 
 import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
+import org.bson.BsonDocument;
 
 class GenericWriteProtocol extends WriteProtocol {
     private final RequestMessage requestMessage;
@@ -26,6 +27,17 @@ class GenericWriteProtocol extends WriteProtocol {
                                 final WriteConcern writeConcern) {
         super(namespace, ordered, writeConcern);
         this.requestMessage = requestMessage;
+    }
+
+    @Override
+    protected BsonDocument getAsWriteCommand(final ByteBufferBsonOutput bsonOutput, final int firstDocumentPosition) {
+        throw new UnsupportedOperationException("Not implemented yet!");
+    }
+
+    @Override
+    protected String getCommandName() {
+        throw new UnsupportedOperationException("Not implemented yet!");
+
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/connection/GenericWriteProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/GenericWriteProtocol.java
@@ -18,6 +18,7 @@ package com.mongodb.connection;
 
 import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
+import com.mongodb.WriteConcernResult;
 import org.bson.BsonDocument;
 
 class GenericWriteProtocol extends WriteProtocol {
@@ -27,6 +28,12 @@ class GenericWriteProtocol extends WriteProtocol {
                                 final WriteConcern writeConcern) {
         super(namespace, ordered, writeConcern);
         this.requestMessage = requestMessage;
+    }
+
+    @Override
+    protected void appendToWriteCommandResponseDocument(final RequestMessage curMessage, final RequestMessage nextMessage,
+                                                        final WriteConcernResult writeConcernResult, final BsonDocument response) {
+        throw new UnsupportedOperationException("Not implemented yet!");
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/connection/GetMoreMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/GetMoreMessage.java
@@ -51,8 +51,13 @@ class GetMoreMessage extends RequestMessage {
 
     @Override
     protected RequestMessage encodeMessageBody(final BsonOutput bsonOutput, final int messageStartPosition) {
+        return encodeMessageBodyWithMetadata(bsonOutput, messageStartPosition).getNextMessage();
+    }
+
+    @Override
+    protected EncodingMetadata encodeMessageBodyWithMetadata(final BsonOutput bsonOutput, final int messageStartPosition) {
         writeGetMore(bsonOutput);
-        return null;
+        return new EncodingMetadata(null, bsonOutput.getPosition());
     }
 
     private void writeGetMore(final BsonOutput buffer) {

--- a/driver-core/src/main/com/mongodb/connection/GetMoreProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/GetMoreProtocol.java
@@ -21,11 +21,20 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.async.SingleResultCallback;
 import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
+import com.mongodb.event.CommandListener;
+import org.bson.BsonArray;
 import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonString;
 import org.bson.codecs.BsonDocumentCodec;
 import org.bson.codecs.Decoder;
 
 import static com.mongodb.connection.ProtocolHelper.getQueryFailureException;
+import static com.mongodb.connection.ProtocolHelper.sendCommandCompletedEvent;
+import static com.mongodb.connection.ProtocolHelper.sendCommandFailedEvent;
+import static com.mongodb.connection.ProtocolHelper.sendCommandStartedEvent;
 import static java.lang.String.format;
 
 /**
@@ -37,11 +46,13 @@ import static java.lang.String.format;
 class GetMoreProtocol<T> implements Protocol<QueryResult<T>> {
 
     public static final Logger LOGGER = Loggers.getLogger("protocol.getmore");
+    private static final String COMMAND_NAME = "getMore";
 
     private final Decoder<T> resultDecoder;
     private final MongoNamespace namespace;
     private final long cursorId;
     private final int numberToReturn;
+    private CommandListener commandListener;
 
     /**
      * Construct an instance.
@@ -65,9 +76,43 @@ class GetMoreProtocol<T> implements Protocol<QueryResult<T>> {
                                 namespace, cursorId, connection.getDescription().getConnectionId(),
                                 connection.getDescription().getServerAddress()));
         }
-        QueryResult<T> queryResult = receiveMessage(connection, sendMessage(connection));
-        LOGGER.debug("Get-more completed");
-        return queryResult;
+        long startTimeNanos = System.nanoTime();
+        GetMoreMessage message = null;
+        QueryResult<T> queryResult = null;
+        try {
+            message = sendMessage(connection);
+            ResponseBuffers responseBuffers = connection.receiveMessage(message.getId());
+            try {
+                if (responseBuffers.getReplyHeader().isCursorNotFound()) {
+                    throw new MongoCursorNotFoundException(message.getCursorId(), connection.getDescription().getServerAddress());
+                }
+
+                if (responseBuffers.getReplyHeader().isQueryFailure()) {
+                    BsonDocument errorDocument = new ReplyMessage<BsonDocument>(responseBuffers, new BsonDocumentCodec(),
+                                                                                message.getId()).getDocuments().get(0);
+                    throw getQueryFailureException(errorDocument, connection.getDescription().getServerAddress());
+                }
+
+
+                queryResult = new QueryResult<T>(namespace, new ReplyMessage<T>(responseBuffers, resultDecoder, message.getId()),
+                                                 connection.getDescription().getServerAddress());
+
+                if (commandListener != null) {
+                    sendCommandCompletedEvent(message, COMMAND_NAME,
+                                              asGetMoreCommandResponseDocument(queryResult, responseBuffers), connection.getDescription(),
+                                              startTimeNanos, commandListener);
+                }
+            } finally {
+                responseBuffers.close();
+            }
+            LOGGER.debug("Get-more completed");
+            return queryResult;
+        } catch (RuntimeException e) {
+            if (commandListener != null) {
+                sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), startTimeNanos, e, commandListener);
+            }
+            throw e;
+        }
     }
 
     @Override
@@ -96,10 +141,19 @@ class GetMoreProtocol<T> implements Protocol<QueryResult<T>> {
         }
     }
 
+    @Override
+    public void setCommandListener(final CommandListener commandListener) {
+        this.commandListener = commandListener;
+    }
+
     private GetMoreMessage sendMessage(final InternalConnection connection) {
         ByteBufferBsonOutput bsonOutput = new ByteBufferBsonOutput(connection);
         try {
             GetMoreMessage message = new GetMoreMessage(namespace.getFullName(), cursorId, numberToReturn);
+            if (commandListener != null) {
+                sendCommandStartedEvent(message, namespace.getDatabaseName(), COMMAND_NAME, asGetMoreCommandDocument(),
+                                        connection.getDescription(), commandListener);
+            }
             message.encode(bsonOutput);
             connection.sendMessage(bsonOutput.getByteBuffers(), message.getId());
             return message;
@@ -108,23 +162,26 @@ class GetMoreProtocol<T> implements Protocol<QueryResult<T>> {
         }
     }
 
-    private QueryResult<T> receiveMessage(final InternalConnection connection, final GetMoreMessage message) {
-        ResponseBuffers responseBuffers = connection.receiveMessage(message.getId());
-        try {
-            if (responseBuffers.getReplyHeader().isCursorNotFound()) {
-                throw new MongoCursorNotFoundException(message.getCursorId(), connection.getDescription().getServerAddress());
-            }
-
-            if (responseBuffers.getReplyHeader().isQueryFailure()) {
-                BsonDocument errorDocument = new ReplyMessage<BsonDocument>(responseBuffers, new BsonDocumentCodec(),
-                                                                            message.getId()).getDocuments().get(0);
-                throw getQueryFailureException(errorDocument, connection.getDescription().getServerAddress());
-            }
-
-            return new QueryResult<T>(namespace, new ReplyMessage<T>(responseBuffers, resultDecoder, message.getId()),
-                                      connection.getDescription().getServerAddress());
-        } finally {
-            responseBuffers.close();
-        }
+    private BsonDocument asGetMoreCommandDocument() {
+        return new BsonDocument(COMMAND_NAME, new BsonInt64(cursorId))
+               .append("collection", new BsonString(namespace.getCollectionName()))
+               .append("batchSize", new BsonInt32(numberToReturn));
     }
+
+
+    private BsonDocument asGetMoreCommandResponseDocument(final QueryResult<T> queryResult, final ResponseBuffers responseBuffers) {
+        if (responseBuffers.getReplyHeader().getNumberReturned() != 0) {
+            responseBuffers.getBodyByteBuffer().position(0);
+        }
+
+        BsonDocument cursorDocument = new BsonDocument("id",
+                                                       queryResult.getCursor() == null
+                                                       ? new BsonInt64(0) : new BsonInt64(queryResult.getCursor().getId()))
+                                      .append("ns", new BsonString(namespace.getFullName()))
+                                      .append("nextBatch", new BsonArray(ByteBufBsonDocument.create(responseBuffers)));
+
+        return new BsonDocument("cursor", cursorDocument)
+               .append("ok", new BsonDouble(1));
+    }
+
 }

--- a/driver-core/src/main/com/mongodb/connection/GetMoreProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/GetMoreProtocol.java
@@ -35,9 +35,9 @@ import java.util.Collections;
 import java.util.List;
 
 import static com.mongodb.connection.ProtocolHelper.getQueryFailureException;
-import static com.mongodb.connection.ProtocolHelper.sendCommandCompletedEvent;
 import static com.mongodb.connection.ProtocolHelper.sendCommandFailedEvent;
 import static com.mongodb.connection.ProtocolHelper.sendCommandStartedEvent;
+import static com.mongodb.connection.ProtocolHelper.sendCommandSucceededEvent;
 import static java.lang.String.format;
 
 /**
@@ -101,7 +101,7 @@ class GetMoreProtocol<T> implements Protocol<QueryResult<T>> {
                                                  connection.getDescription().getServerAddress());
 
                 if (commandListener != null) {
-                    sendCommandCompletedEvent(message, COMMAND_NAME,
+                    sendCommandSucceededEvent(message, COMMAND_NAME,
                                               asGetMoreCommandResponseDocument(queryResult, responseBuffers), connection.getDescription(),
                                               startTimeNanos, commandListener);
                 }

--- a/driver-core/src/main/com/mongodb/connection/InsertMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/InsertMessage.java
@@ -56,18 +56,25 @@ class InsertMessage extends RequestMessage {
 
     @Override
     protected RequestMessage encodeMessageBody(final BsonOutput outputStream, final int messageStartPosition) {
+        return encodeMessageBodyWithMetadata(outputStream, messageStartPosition).getNextMessage();
+    }
+
+    @Override
+    protected EncodingMetadata encodeMessageBodyWithMetadata(final BsonOutput outputStream, final int messageStartPosition) {
         writeInsertPrologue(outputStream);
+        int firstDocumentPosition = outputStream.getPosition();
         for (int i = 0; i < insertRequestList.size(); i++) {
             BsonDocument document = insertRequestList.get(i).getDocument();
             int pos = outputStream.getPosition();
             addCollectibleDocument(document, outputStream, createValidator());
             if (outputStream.getPosition() - messageStartPosition > getSettings().getMaxMessageSize()) {
                 outputStream.truncateToPosition(pos);
-                return new InsertMessage(getCollectionName(), ordered, writeConcern,
-                                         insertRequestList.subList(i, insertRequestList.size()), getSettings());
+                return new EncodingMetadata(new InsertMessage(getCollectionName(), ordered, writeConcern,
+                                                          insertRequestList.subList(i, insertRequestList.size()), getSettings()),
+                                            firstDocumentPosition);
             }
         }
-        return null;
+        return new EncodingMetadata(null, firstDocumentPosition);
     }
 
     private FieldNameValidator createValidator() {

--- a/driver-core/src/main/com/mongodb/connection/InsertMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/InsertMessage.java
@@ -54,6 +54,10 @@ class InsertMessage extends RequestMessage {
         this.insertRequestList = insertRequestList;
     }
 
+    public List<InsertRequest> getInsertRequestList() {
+        return insertRequestList;
+    }
+
     @Override
     protected RequestMessage encodeMessageBody(final BsonOutput outputStream, final int messageStartPosition) {
         return encodeMessageBodyWithMetadata(outputStream, messageStartPosition).getNextMessage();

--- a/driver-core/src/main/com/mongodb/connection/InsertProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/InsertProtocol.java
@@ -24,6 +24,8 @@ import com.mongodb.async.SingleResultCallback;
 import com.mongodb.bulk.InsertRequest;
 import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
 
 import java.util.List;
 
@@ -90,6 +92,18 @@ class InsertProtocol extends WriteProtocol {
         } catch (Throwable t) {
             callback.onResult(null, t);
         }
+    }
+
+    @Override
+    protected BsonDocument getAsWriteCommand(final ByteBufferBsonOutput bsonOutput, final int firstDocumentPosition) {
+        return getBaseCommandDocument()
+               .append("documents", new BsonArray(ByteBufBsonDocument.create(bsonOutput, firstDocumentPosition)));
+
+    }
+
+    @Override
+    protected String getCommandName() {
+        return "insert";
     }
 
     protected RequestMessage createRequestMessage(final MessageSettings settings) {

--- a/driver-core/src/main/com/mongodb/connection/InsertProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/InsertProtocol.java
@@ -26,6 +26,7 @@ import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
+import org.bson.BsonInt32;
 
 import java.util.List;
 
@@ -108,6 +109,14 @@ class InsertProtocol extends WriteProtocol {
 
     protected RequestMessage createRequestMessage(final MessageSettings settings) {
         return new InsertMessage(getNamespace().getFullName(), isOrdered(), getWriteConcern(), insertRequestList, settings);
+    }
+
+    @Override
+    protected void appendToWriteCommandResponseDocument(final RequestMessage curMessage, final RequestMessage nextMessage,
+                                                        final WriteConcernResult writeConcernResult, final BsonDocument response) {
+        response.append("n", new BsonInt32(nextMessage == null ? ((InsertMessage) curMessage).getInsertRequestList().size()
+                                                               : ((InsertMessage) curMessage).getInsertRequestList().size()
+                                                                 - ((InsertMessage) nextMessage).getInsertRequestList().size()));
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/connection/KillCursorProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/KillCursorProtocol.java
@@ -71,7 +71,8 @@ class KillCursorProtocol implements Protocol<Void> {
             message.encode(bsonOutput);
             connection.sendMessage(bsonOutput.getByteBuffers(), message.getId());
             if (commandListener != null) {
-                sendCommandSucceededEvent(message, COMMAND_NAME, new BsonDocument("ok", new BsonDouble(1)), connection.getDescription(),
+                sendCommandSucceededEvent(message, COMMAND_NAME, asCommandResponseDocument(),
+                                          connection.getDescription(),
                                           startTimeNanos, commandListener);
             }
             return null;
@@ -119,6 +120,16 @@ class KillCursorProtocol implements Protocol<Void> {
             array.add(new BsonInt64(cursor));
         }
         return new BsonDocument(COMMAND_NAME, array);
+    }
+
+    private BsonDocument asCommandResponseDocument() {
+        BsonArray cursorIdArray = new BsonArray();
+        for (long cursorId : cursors) {
+            cursorIdArray.add(new BsonInt64(cursorId));
+        }
+        return new BsonDocument("ok", new BsonDouble(1))
+               .append("cursorsUnknown", cursorIdArray);
+
     }
 
     private String getCursorIdListAsString() {

--- a/driver-core/src/main/com/mongodb/connection/KillCursorProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/KillCursorProtocol.java
@@ -27,9 +27,9 @@ import org.bson.BsonInt64;
 
 import java.util.List;
 
-import static com.mongodb.connection.ProtocolHelper.sendCommandCompletedEvent;
 import static com.mongodb.connection.ProtocolHelper.sendCommandFailedEvent;
 import static com.mongodb.connection.ProtocolHelper.sendCommandStartedEvent;
+import static com.mongodb.connection.ProtocolHelper.sendCommandSucceededEvent;
 import static java.lang.String.format;
 
 /**
@@ -71,7 +71,7 @@ class KillCursorProtocol implements Protocol<Void> {
             message.encode(bsonOutput);
             connection.sendMessage(bsonOutput.getByteBuffers(), message.getId());
             if (commandListener != null) {
-                sendCommandCompletedEvent(message, COMMAND_NAME, new BsonDocument("ok", new BsonDouble(1)), connection.getDescription(),
+                sendCommandSucceededEvent(message, COMMAND_NAME, new BsonDocument("ok", new BsonDouble(1)), connection.getDescription(),
                                           startTimeNanos, commandListener);
             }
             return null;

--- a/driver-core/src/main/com/mongodb/connection/KillCursorsMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/KillCursorsMessage.java
@@ -42,11 +42,16 @@ class KillCursorsMessage extends RequestMessage {
 
     @Override
     protected RequestMessage encodeMessageBody(final BsonOutput bsonOutput, final int messageStartPosition) {
+        return encodeMessageBodyWithMetadata(bsonOutput, messageStartPosition).getNextMessage();
+    }
+
+    @Override
+    protected EncodingMetadata encodeMessageBodyWithMetadata(final BsonOutput bsonOutput, final int messageStartPosition) {
         writeKillCursorsPrologue(cursors.size(), bsonOutput);
         for (final Long cur : cursors) {
             bsonOutput.writeInt64(cur);
         }
-        return null;
+        return new EncodingMetadata(null, bsonOutput.getPosition());
     }
 
     private void writeKillCursorsPrologue(final int numCursors, final BsonOutput bsonOutput) {

--- a/driver-core/src/main/com/mongodb/connection/Protocol.java
+++ b/driver-core/src/main/com/mongodb/connection/Protocol.java
@@ -17,6 +17,7 @@
 package com.mongodb.connection;
 
 import com.mongodb.async.SingleResultCallback;
+import com.mongodb.event.CommandListener;
 
 /**
  * An interface for the execution of a MongoDB wire protocol conversation
@@ -39,4 +40,6 @@ interface Protocol<T> {
      * @param callback   the callback that is passed the result of the execution
      */
     void executeAsync(final InternalConnection connection, SingleResultCallback<T> callback);
+
+    void setCommandListener(CommandListener commandListener);
 }

--- a/driver-core/src/main/com/mongodb/connection/ProtocolHelper.java
+++ b/driver-core/src/main/com/mongodb/connection/ProtocolHelper.java
@@ -27,10 +27,10 @@ import com.mongodb.MongoQueryException;
 import com.mongodb.ServerAddress;
 import com.mongodb.WriteConcernException;
 import com.mongodb.WriteConcernResult;
-import com.mongodb.event.CommandCompletedEvent;
 import com.mongodb.event.CommandFailedEvent;
 import com.mongodb.event.CommandListener;
 import com.mongodb.event.CommandStartedEvent;
+import com.mongodb.event.CommandSucceededEvent;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
@@ -160,11 +160,11 @@ final class ProtocolHelper {
         }
     }
 
-    static void sendCommandCompletedEvent(final RequestMessage message, final String commandName, final BsonDocument response,
+    static void sendCommandSucceededEvent(final RequestMessage message, final String commandName, final BsonDocument response,
                                           final ConnectionDescription connectionDescription, final long startTimeNanos,
                                           final CommandListener commandListener) {
         try {
-            commandListener.commandCompleted(new CommandCompletedEvent(message.getId(), connectionDescription,
+            commandListener.commandSucceeded(new CommandSucceededEvent(message.getId(), connectionDescription,
                                                                        commandName,
                                                                        response, System.nanoTime() - startTimeNanos));
         } catch (Exception e) {

--- a/driver-core/src/main/com/mongodb/connection/ProtocolHelper.java
+++ b/driver-core/src/main/com/mongodb/connection/ProtocolHelper.java
@@ -27,6 +27,8 @@ import com.mongodb.MongoQueryException;
 import com.mongodb.ServerAddress;
 import com.mongodb.WriteConcernException;
 import com.mongodb.WriteConcernResult;
+import com.mongodb.diagnostics.logging.Logger;
+import com.mongodb.diagnostics.logging.Loggers;
 import com.mongodb.event.CommandFailedEvent;
 import com.mongodb.event.CommandListener;
 import com.mongodb.event.CommandStartedEvent;
@@ -38,7 +40,10 @@ import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.bson.io.BsonOutput;
 
+import static java.lang.String.format;
+
 final class ProtocolHelper {
+    private static final Logger PROTOCOL_EVENT_LOGGER = Loggers.getLogger("protocol.event");
 
     static WriteConcernResult getWriteResult(final BsonDocument result, final ServerAddress serverAddress) {
         if (!isCommandOk(result)) {
@@ -156,7 +161,9 @@ final class ProtocolHelper {
             commandListener.commandStarted(new CommandStartedEvent(message.getId(), connectionDescription,
                                                                    databaseName, commandName, command));
         } catch (Exception e) {
-            // ignore
+            if (PROTOCOL_EVENT_LOGGER.isWarnEnabled()) {
+                PROTOCOL_EVENT_LOGGER.warn(format("Exception thrown raising command started event to listener %s", commandListener), e);
+            }
         }
     }
 
@@ -168,7 +175,9 @@ final class ProtocolHelper {
                                                                        commandName,
                                                                        response, System.nanoTime() - startTimeNanos));
         } catch (Exception e) {
-            // ignore
+            if (PROTOCOL_EVENT_LOGGER.isWarnEnabled()) {
+                PROTOCOL_EVENT_LOGGER.warn(format("Exception thrown raising command succeeded event to listener %s", commandListener), e);
+            }
         }
     }
 
@@ -179,7 +188,9 @@ final class ProtocolHelper {
             commandListener.commandFailed(new CommandFailedEvent(message.getId(), connectionDescription, commandName,
                                                                  System.nanoTime() - startTimeNanos, throwable));
         } catch (Exception e) {
-            // ignore
+            if (PROTOCOL_EVENT_LOGGER.isWarnEnabled()) {
+                PROTOCOL_EVENT_LOGGER.warn(format("Exception thrown raising command failed event to listener %s", commandListener), e);
+            }
         }
     }
 

--- a/driver-core/src/main/com/mongodb/connection/QueryMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/QueryMessage.java
@@ -49,11 +49,17 @@ class QueryMessage extends BaseQueryMessage {
 
     @Override
     protected RequestMessage encodeMessageBody(final BsonOutput bsonOutput, final int messageStartPosition) {
+       return encodeMessageBodyWithMetadata(bsonOutput, messageStartPosition).getNextMessage();
+    }
+
+    @Override
+    protected EncodingMetadata encodeMessageBodyWithMetadata(final BsonOutput bsonOutput, final int messageStartPosition) {
         writeQueryPrologue(bsonOutput);
+        int firstDocumentStartPosition = bsonOutput.getPosition();
         addDocument(queryDocument, bsonOutput, new NoOpFieldNameValidator());
         if (fields != null) {
             addDocument(fields, bsonOutput, new NoOpFieldNameValidator());
         }
-        return null;
+        return new EncodingMetadata(null, firstDocumentStartPosition);
     }
 }

--- a/driver-core/src/main/com/mongodb/connection/QueryProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/QueryProtocol.java
@@ -40,9 +40,9 @@ import java.util.Map;
 import static com.mongodb.connection.ProtocolHelper.encodeMessage;
 import static com.mongodb.connection.ProtocolHelper.getMessageSettings;
 import static com.mongodb.connection.ProtocolHelper.getQueryFailureException;
-import static com.mongodb.connection.ProtocolHelper.sendCommandCompletedEvent;
 import static com.mongodb.connection.ProtocolHelper.sendCommandFailedEvent;
 import static com.mongodb.connection.ProtocolHelper.sendCommandStartedEvent;
+import static com.mongodb.connection.ProtocolHelper.sendCommandSucceededEvent;
 import static java.lang.String.format;
 
 /**
@@ -310,7 +310,7 @@ class QueryProtocol<T> implements Protocol<QueryResult<T>> {
 
                 if (commandListener != null) {
                     BsonDocument response = asFindCommandResponseDocument(responseBuffers, queryResult, isExplain);
-                    sendCommandCompletedEvent(message,
+                    sendCommandSucceededEvent(message,
                                               isExplain ? EXPLAIN_COMMAND_NAME : FIND_COMMAND_NAME,
                                               response, connection.getDescription(),
                                               startTimeNanos, commandListener);

--- a/driver-core/src/main/com/mongodb/connection/QueryProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/QueryProtocol.java
@@ -20,13 +20,23 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.async.SingleResultCallback;
 import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
+import com.mongodb.event.CommandListener;
+import org.bson.BsonArray;
+import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonString;
 import org.bson.codecs.BsonDocumentCodec;
 import org.bson.codecs.Decoder;
 
 import static com.mongodb.connection.ProtocolHelper.encodeMessage;
 import static com.mongodb.connection.ProtocolHelper.getMessageSettings;
 import static com.mongodb.connection.ProtocolHelper.getQueryFailureException;
+import static com.mongodb.connection.ProtocolHelper.sendCommandCompletedEvent;
+import static com.mongodb.connection.ProtocolHelper.sendCommandFailedEvent;
+import static com.mongodb.connection.ProtocolHelper.sendCommandStartedEvent;
 import static java.lang.String.format;
 
 /**
@@ -38,6 +48,7 @@ import static java.lang.String.format;
 class QueryProtocol<T> implements Protocol<QueryResult<T>> {
 
     public static final Logger LOGGER = Loggers.getLogger("protocol.query");
+    private static final String COMMAND_NAME = "find";
     private final int skip;
     private final int numberToReturn;
     private final BsonDocument queryDocument;
@@ -50,6 +61,7 @@ class QueryProtocol<T> implements Protocol<QueryResult<T>> {
     private boolean noCursorTimeout;
     private boolean awaitData;
     private boolean partial;
+    private CommandListener commandListener;
 
     /**
      * Construct an instance.
@@ -70,6 +82,14 @@ class QueryProtocol<T> implements Protocol<QueryResult<T>> {
         this.queryDocument = queryDocument;
         this.fields = fields;
         this.resultDecoder = resultDecoder;
+    }
+
+    public void setCommandListener(final CommandListener commandListener) {
+        this.commandListener = commandListener;
+    }
+
+    public CommandListener getCommandListener() {
+        return commandListener;
     }
 
     /**
@@ -226,9 +246,40 @@ class QueryProtocol<T> implements Protocol<QueryResult<T>> {
             LOGGER.debug(format("Sending query of namespace %s on connection [%s] to server %s", namespace,
                                 connection.getDescription().getConnectionId(), connection.getDescription().getServerAddress()));
         }
-        QueryResult<T> queryResult = receiveMessage(connection, sendMessage(connection));
-        LOGGER.debug("Query completed");
-        return queryResult;
+        long startTimeNanos = System.nanoTime();
+        QueryMessage message = null;
+        try {
+            message = sendMessage(connection);
+            ResponseBuffers responseBuffers = connection.receiveMessage(message.getId());
+            try {
+                if (responseBuffers.getReplyHeader().isQueryFailure()) {
+                    BsonDocument errorDocument = new ReplyMessage<BsonDocument>(responseBuffers,
+                                                                                new BsonDocumentCodec(),
+                                                                                message.getId()).getDocuments().get(0);
+                    throw getQueryFailureException(errorDocument, connection.getDescription().getServerAddress());
+                }
+                ReplyMessage<T> replyMessage = new ReplyMessage<T>(responseBuffers, resultDecoder, message.getId());
+
+                QueryResult<T> queryResult = new QueryResult<T>(namespace, replyMessage, connection.getDescription().getServerAddress());
+
+                LOGGER.debug("Query completed");
+
+                if (commandListener != null) {
+                    BsonDocument response = asFindCommandResponseDocument(responseBuffers, queryResult);
+                    sendCommandCompletedEvent(message, COMMAND_NAME, response, connection.getDescription(),
+                                              startTimeNanos, commandListener);
+                }
+                return queryResult;
+            } finally {
+                responseBuffers.close();
+            }
+
+        } catch (RuntimeException e) {
+            if (commandListener != null) {
+                sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), startTimeNanos, e, commandListener);
+            }
+            throw e;
+        }
     }
 
     @Override
@@ -270,7 +321,12 @@ class QueryProtocol<T> implements Protocol<QueryResult<T>> {
         ByteBufferBsonOutput bsonOutput = new ByteBufferBsonOutput(connection);
         try {
             QueryMessage message = createQueryMessage(connection.getDescription());
+            if (commandListener != null) {
+                sendCommandStartedEvent(message, namespace.getDatabaseName(), COMMAND_NAME, asFindCommandDocument(),
+                                        connection.getDescription(), commandListener);
+            }
             message.encode(bsonOutput);
+
             connection.sendMessage(bsonOutput.getByteBuffers(), message.getId());
             return message;
         } finally {
@@ -278,20 +334,58 @@ class QueryProtocol<T> implements Protocol<QueryResult<T>> {
         }
     }
 
-    private QueryResult<T> receiveMessage(final InternalConnection connection, final QueryMessage message) {
-        ResponseBuffers responseBuffers = connection.receiveMessage(message.getId());
-        try {
-            if (responseBuffers.getReplyHeader().isQueryFailure()) {
-                BsonDocument errorDocument = new ReplyMessage<BsonDocument>(responseBuffers,
-                                                                            new BsonDocumentCodec(),
-                                                                            message.getId()).getDocuments().get(0);
-                throw getQueryFailureException(errorDocument, connection.getDescription().getServerAddress());
-            }
-            ReplyMessage<T> replyMessage = new ReplyMessage<T>(responseBuffers, resultDecoder, message.getId());
+    // TODO: This is going to require an API change, since at this point we only have 'numberToReturn' and not 'limit' and 'batchSize'
+    // TODO: as separate values.  It would also be better if each piece of the query document was pre-split.  Currently this code is not
+    // TODO: pulling out most of the special $-prefixed fields from the query document.
+    private BsonDocument asFindCommandDocument() {
+        BsonDocument command = new BsonDocument(COMMAND_NAME, new BsonString(namespace.getCollectionName()));
 
-            return new QueryResult<T>(namespace, replyMessage, connection.getDescription().getServerAddress());
-        } finally {
-            responseBuffers.close();
+        if (queryDocument.containsKey("$query")) {
+            command.append("filter", queryDocument.getDocument("$query"));
+        } else {
+            command.append("filter", queryDocument);
         }
+
+        if (queryDocument.containsKey("$sort")) {
+            command.append("sort", queryDocument.getDocument("$sort"));
+        }
+
+        if (fields != null) {
+            command.append("projection", fields);
+        }
+
+        if (skip != 0) {
+            command.append("skip", new BsonInt32(skip));
+        }
+        if (tailableCursor) {
+            command.append("tailable", BsonBoolean.valueOf(tailableCursor));
+        }
+        if (noCursorTimeout) {
+            command.append("noCursorTimeout", BsonBoolean.valueOf(noCursorTimeout));
+        }
+        if (oplogReplay) {
+            command.append("oplogReplay", BsonBoolean.valueOf(oplogReplay));
+        }
+        if (awaitData) {
+            command.append("awaitData", BsonBoolean.valueOf(awaitData));
+        }
+        if (partial) {
+            command.append("partial", BsonBoolean.valueOf(partial));
+        }
+
+        return command;
+    }
+
+    private BsonDocument asFindCommandResponseDocument(final ResponseBuffers responseBuffers, final QueryResult<T> queryResult) {
+        responseBuffers.getBodyByteBuffer().position(0);
+
+        BsonDocument cursorDocument = new BsonDocument("id",
+                                                       queryResult.getCursor() == null
+                                                       ? new BsonInt64(0) : new BsonInt64(queryResult.getCursor().getId()))
+                                      .append("ns", new BsonString(namespace.getFullName()))
+                                      .append("firstBatch", new BsonArray(ByteBufBsonDocument.create(responseBuffers)));
+
+        return new BsonDocument("cursor", cursorDocument)
+               .append("ok", new BsonDouble(1));
     }
 }

--- a/driver-core/src/main/com/mongodb/connection/RequestMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/RequestMessage.java
@@ -50,6 +50,23 @@ abstract class RequestMessage {
     private final int id;
     private final OpCode opCode;
 
+    static class EncodingMetadata {
+        private final RequestMessage nextMessage;
+        private final int firstDocumentPosition;
+
+        EncodingMetadata(final RequestMessage nextMessage, final int firstDocumentPosition) {
+            this.nextMessage = nextMessage;
+            this.firstDocumentPosition = firstDocumentPosition;
+        }
+
+        public RequestMessage getNextMessage() {
+            return nextMessage;
+        }
+
+        public int getFirstDocumentPosition() {
+            return firstDocumentPosition;
+        }
+    }
     /**
      * Gets the next available unique message identifier.
      *
@@ -127,11 +144,22 @@ abstract class RequestMessage {
      * being exceeded
      */
     public RequestMessage encode(final BsonOutput bsonOutput) {
+        return encodeWithMetadata(bsonOutput).getNextMessage();
+    }
+
+    /**
+     * Encoded the message to the given output.
+     *
+     * @param bsonOutput the output
+     * @return the next message to encode, if the current message is unable to fit all of its contents in a single message due to limits
+     * being exceeded
+     */
+    public EncodingMetadata encodeWithMetadata(final BsonOutput bsonOutput) {
         int messageStartPosition = bsonOutput.getPosition();
         writeMessagePrologue(bsonOutput);
-        RequestMessage nextMessage = encodeMessageBody(bsonOutput, messageStartPosition);
+        EncodingMetadata encodingMetadata = encodeMessageBodyWithMetadata(bsonOutput, messageStartPosition);
         backpatchMessageLength(messageStartPosition, bsonOutput);
-        return nextMessage;
+        return encodingMetadata;
     }
 
     /**
@@ -154,6 +182,15 @@ abstract class RequestMessage {
      * @return the next message to encode, if the contents of this message need to overflow into the next
      */
     protected abstract RequestMessage encodeMessageBody(final BsonOutput bsonOutput, final int messageStartPosition);
+
+    /**
+     * Encode the message body to the given output.
+     *
+     * @param bsonOutput the output
+     * @param messageStartPosition the start position of the message
+     * @return the encoding metadata
+     */
+    protected abstract EncodingMetadata encodeMessageBodyWithMetadata(final BsonOutput bsonOutput, final int messageStartPosition);
 
     /**
      * Appends a document to the message.

--- a/driver-core/src/main/com/mongodb/connection/UpdateMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/UpdateMessage.java
@@ -48,6 +48,11 @@ class UpdateMessage extends RequestMessage {
 
     @Override
     protected RequestMessage encodeMessageBody(final BsonOutput bsonOutput, final int messageStartPosition) {
+        return encodeMessageBodyWithMetadata(bsonOutput, messageStartPosition).getNextMessage();
+    }
+
+    @Override
+    protected EncodingMetadata encodeMessageBodyWithMetadata(final BsonOutput bsonOutput, final int messageStartPosition) {
         bsonOutput.writeInt32(0); // reserved
         bsonOutput.writeCString(getCollectionName());
 
@@ -61,6 +66,8 @@ class UpdateMessage extends RequestMessage {
         }
         bsonOutput.writeInt32(flags);
 
+        int firstDocumentStartPosition = bsonOutput.getPosition();
+
         addDocument(updateRequest.getFilter(), bsonOutput, new NoOpFieldNameValidator());
         if (updateRequest.getType() == REPLACE) {
             addCollectibleDocument(updateRequest.getUpdate(), bsonOutput, new CollectibleDocumentFieldNameValidator());
@@ -73,9 +80,10 @@ class UpdateMessage extends RequestMessage {
         }
 
         if (updates.size() == 1) {
-            return null;
+            return new EncodingMetadata(null, firstDocumentStartPosition);
         } else {
-            return new UpdateMessage(getCollectionName(), updates.subList(1, updates.size()), getSettings());
+            return new EncodingMetadata(new UpdateMessage(getCollectionName(), updates.subList(1, updates.size()), getSettings()),
+                                    firstDocumentStartPosition);
         }
     }
 

--- a/driver-core/src/main/com/mongodb/connection/UpdateMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/UpdateMessage.java
@@ -46,6 +46,10 @@ class UpdateMessage extends RequestMessage {
         this.updates = updates;
     }
 
+    public List<UpdateRequest> getUpdateRequests() {
+        return updates;
+    }
+
     @Override
     protected RequestMessage encodeMessageBody(final BsonOutput bsonOutput, final int messageStartPosition) {
         return encodeMessageBodyWithMetadata(bsonOutput, messageStartPosition).getNextMessage();

--- a/driver-core/src/main/com/mongodb/connection/UpdateProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/UpdateProtocol.java
@@ -26,6 +26,8 @@ import com.mongodb.diagnostics.logging.Loggers;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonValue;
 
 import java.util.List;
 
@@ -112,6 +114,29 @@ class UpdateProtocol extends WriteProtocol {
     @Override
     protected RequestMessage createRequestMessage(final MessageSettings settings) {
         return new UpdateMessage(getNamespace().getFullName(), updates, settings);
+    }
+
+    @Override
+    protected void appendToWriteCommandResponseDocument(final RequestMessage curMessage, final RequestMessage nextMessage,
+                                                        final WriteConcernResult writeConcernResult, final BsonDocument response) {
+        response.append("n", new BsonInt32(writeConcernResult.getCount()));
+
+        UpdateMessage updateMessage = (UpdateMessage) curMessage;
+        UpdateRequest updateRequest = updateMessage.getUpdateRequests().get(0);
+        BsonValue upsertedId = null;
+        if (writeConcernResult.getUpsertedId() != null) {
+            upsertedId = writeConcernResult.getUpsertedId();
+        } else if (!writeConcernResult.isUpdateOfExisting() && updateRequest.isUpsert()) {
+            if (updateRequest.getUpdate().containsKey("_id")) {
+                upsertedId = updateRequest.getUpdate().get("_id");
+            } else if (updateRequest.getFilter().containsKey("_id")) {
+                upsertedId = updateRequest.getFilter().get("_id");
+            }
+        }
+        if (upsertedId != null) {
+            response.append("upserted", new BsonArray(singletonList(new BsonDocument("index", new BsonInt32(0))
+                                                                    .append("_id", upsertedId))));
+        }
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/connection/WriteCommandProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/WriteCommandProtocol.java
@@ -100,16 +100,12 @@ abstract class WriteCommandProtocol implements Protocol<BulkWriteResult> {
                     MongoBulkWriteException bulkWriteException = getBulkWriteException(getType(), result,
                                                                                        connection.getDescription().getServerAddress());
                     bulkWriteBatchCombiner.addErrorResult(bulkWriteException, indexMap);
-                    if (commandListener != null) {
-                        sendCommandSucceededEvent(message, message.getCommandName(), result, connection.getDescription(),
-                                                  startTimeNanos, commandListener);
-                    }
                 } else {
                     bulkWriteBatchCombiner.addResult(getBulkWriteResult(getType(), result), indexMap);
-                    if (commandListener != null) {
-                        sendCommandSucceededEvent(message, message.getCommandName(), result, connection.getDescription(),
-                                                  startTimeNanos, commandListener);
-                    }
+                }
+                if (commandListener != null) {
+                    sendCommandSucceededEvent(message, message.getCommandName(), result, connection.getDescription(),
+                                              startTimeNanos, commandListener);
                 }
                 currentRangeStartIndex += itemCount;
                 message = nextMessage;

--- a/driver-core/src/main/com/mongodb/connection/WriteCommandProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/WriteCommandProtocol.java
@@ -30,9 +30,9 @@ import org.bson.codecs.BsonDocumentCodec;
 import static com.mongodb.connection.ByteBufBsonDocument.createOne;
 import static com.mongodb.connection.ProtocolHelper.getCommandFailureException;
 import static com.mongodb.connection.ProtocolHelper.getMessageSettings;
-import static com.mongodb.connection.ProtocolHelper.sendCommandCompletedEvent;
 import static com.mongodb.connection.ProtocolHelper.sendCommandFailedEvent;
 import static com.mongodb.connection.ProtocolHelper.sendCommandStartedEvent;
+import static com.mongodb.connection.ProtocolHelper.sendCommandSucceededEvent;
 import static com.mongodb.connection.WriteCommandResultHelper.getBulkWriteException;
 import static com.mongodb.connection.WriteCommandResultHelper.getBulkWriteResult;
 import static java.lang.String.format;
@@ -107,7 +107,7 @@ abstract class WriteCommandProtocol implements Protocol<BulkWriteResult> {
                 } else {
                     bulkWriteBatchCombiner.addResult(getBulkWriteResult(getType(), result), indexMap);
                     if (commandListener != null) {
-                        sendCommandCompletedEvent(message, message.getCommandName(), result, connection.getDescription(),
+                        sendCommandSucceededEvent(message, message.getCommandName(), result, connection.getDescription(),
                                                   startTimeNanos, commandListener);
                     }
                 }

--- a/driver-core/src/main/com/mongodb/connection/WriteCommandProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/WriteCommandProtocol.java
@@ -16,17 +16,23 @@
 
 package com.mongodb.connection;
 
+import com.mongodb.MongoBulkWriteException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
 import com.mongodb.async.SingleResultCallback;
 import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.bulk.WriteRequest;
+import com.mongodb.event.CommandListener;
 import com.mongodb.internal.connection.IndexMap;
 import org.bson.BsonDocument;
 import org.bson.codecs.BsonDocumentCodec;
 
+import static com.mongodb.connection.ByteBufBsonDocument.createOne;
 import static com.mongodb.connection.ProtocolHelper.getCommandFailureException;
 import static com.mongodb.connection.ProtocolHelper.getMessageSettings;
+import static com.mongodb.connection.ProtocolHelper.sendCommandCompletedEvent;
+import static com.mongodb.connection.ProtocolHelper.sendCommandFailedEvent;
+import static com.mongodb.connection.ProtocolHelper.sendCommandStartedEvent;
 import static com.mongodb.connection.WriteCommandResultHelper.getBulkWriteException;
 import static com.mongodb.connection.WriteCommandResultHelper.getBulkWriteResult;
 import static java.lang.String.format;
@@ -38,6 +44,7 @@ abstract class WriteCommandProtocol implements Protocol<BulkWriteResult> {
     private final MongoNamespace namespace;
     private final boolean ordered;
     private final WriteConcern writeConcern;
+    private CommandListener commandListener;
 
     /**
      * Construct an instance.
@@ -52,6 +59,11 @@ abstract class WriteCommandProtocol implements Protocol<BulkWriteResult> {
         this.writeConcern = writeConcern;
     }
 
+    @Override
+    public void setCommandListener(final CommandListener commandListener) {
+        this.commandListener = commandListener;
+    }
+
     /**
      * Gets the write concern.
      *
@@ -64,34 +76,55 @@ abstract class WriteCommandProtocol implements Protocol<BulkWriteResult> {
     @Override
     public BulkWriteResult execute(final InternalConnection connection) {
         BaseWriteCommandMessage message = createRequestMessage(getMessageSettings(connection.getDescription()));
-        BulkWriteBatchCombiner bulkWriteBatchCombiner = new BulkWriteBatchCombiner(connection.getDescription().getServerAddress(),
-                                                                                   ordered, writeConcern);
-        int batchNum = 0;
-        int currentRangeStartIndex = 0;
-        do {
-            batchNum++;
-            BaseWriteCommandMessage nextMessage = sendMessage(connection, message, batchNum);
-            int itemCount = nextMessage != null ? message.getItemCount() - nextMessage.getItemCount() : message.getItemCount();
-            IndexMap indexMap = IndexMap.create(currentRangeStartIndex, itemCount);
-            BsonDocument result = receiveMessage(connection, message);
+        long startTimeNanos = System.nanoTime();
+        try {
+            BulkWriteBatchCombiner bulkWriteBatchCombiner = new BulkWriteBatchCombiner(connection.getDescription().getServerAddress(),
+                                                                                       ordered, writeConcern);
+            int batchNum = 0;
+            int currentRangeStartIndex = 0;
+            do {
+                batchNum++;
+                startTimeNanos = System.nanoTime();
+                BaseWriteCommandMessage nextMessage = sendMessage(connection, message, batchNum);
+                int itemCount = nextMessage != null ? message.getItemCount() - nextMessage.getItemCount() : message.getItemCount();
+                IndexMap indexMap = IndexMap.create(currentRangeStartIndex, itemCount);
+                BsonDocument result = receiveMessage(connection, message);
 
-            if (nextMessage != null || batchNum > 1) {
-                if (getLogger().isDebugEnabled()) {
-                    getLogger().debug(format("Received response for batch %d", batchNum));
+                if (nextMessage != null || batchNum > 1) {
+                    if (getLogger().isDebugEnabled()) {
+                        getLogger().debug(format("Received response for batch %d", batchNum));
+                    }
                 }
-            }
 
-            if (WriteCommandResultHelper.hasError(result)) {
-                bulkWriteBatchCombiner.addErrorResult(getBulkWriteException(getType(), result,
-                                                                            connection.getDescription().getServerAddress()), indexMap);
-            } else {
-                bulkWriteBatchCombiner.addResult(getBulkWriteResult(getType(), result), indexMap);
-            }
-            currentRangeStartIndex += itemCount;
-            message = nextMessage;
-        } while (message != null && !bulkWriteBatchCombiner.shouldStopSendingMoreBatches());
+                if (WriteCommandResultHelper.hasError(result)) {
+                    MongoBulkWriteException bulkWriteException = getBulkWriteException(getType(), result,
+                                                                                       connection.getDescription().getServerAddress());
+                    bulkWriteBatchCombiner.addErrorResult(bulkWriteException, indexMap);
+                    if (commandListener != null) {
+                        sendCommandFailedEvent(message, message.getCommandName(), connection.getDescription(),
+                                               startTimeNanos, bulkWriteException, commandListener);
+                    }
+                } else {
+                    bulkWriteBatchCombiner.addResult(getBulkWriteResult(getType(), result), indexMap);
+                    if (commandListener != null) {
+                        sendCommandCompletedEvent(message, message.getCommandName(), result, connection.getDescription(),
+                                                  startTimeNanos, commandListener);
+                    }
+                }
+                currentRangeStartIndex += itemCount;
+                message = nextMessage;
+            } while (message != null && !bulkWriteBatchCombiner.shouldStopSendingMoreBatches());
 
-        return bulkWriteBatchCombiner.getResult();
+            return bulkWriteBatchCombiner.getResult();
+        } catch (MongoBulkWriteException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            if (commandListener != null) {
+                sendCommandFailedEvent(message, message.getCommandName(), connection.getDescription(), startTimeNanos,
+                                       e, commandListener);
+            }
+            throw e;
+        }
     }
 
     @Override
@@ -167,7 +200,15 @@ abstract class WriteCommandProtocol implements Protocol<BulkWriteResult> {
                                                 final int batchNum) {
         ByteBufferBsonOutput bsonOutput = new ByteBufferBsonOutput(connection);
         try {
-            BaseWriteCommandMessage nextMessage = message.encode(bsonOutput);
+            RequestMessage.EncodingMetadata encodingMetadata = message.encodeWithMetadata(bsonOutput);
+            BaseWriteCommandMessage nextMessage = (BaseWriteCommandMessage) encodingMetadata.getNextMessage();
+
+            if (commandListener != null) {
+                sendCommandStartedEvent(message, namespace.getDatabaseName(), message.getCommandName(),
+                                        createOne(bsonOutput, encodingMetadata.getFirstDocumentPosition()),
+                                        connection.getDescription(), commandListener);
+            }
+
             if (nextMessage != null || batchNum > 1) {
                 if (getLogger().isDebugEnabled()) {
                     getLogger().debug(format("Sending batch %d", batchNum));
@@ -233,4 +274,5 @@ abstract class WriteCommandProtocol implements Protocol<BulkWriteResult> {
     protected boolean isOrdered() {
         return ordered;
     }
+
 }

--- a/driver-core/src/main/com/mongodb/connection/WriteCommandProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/WriteCommandProtocol.java
@@ -101,8 +101,8 @@ abstract class WriteCommandProtocol implements Protocol<BulkWriteResult> {
                                                                                        connection.getDescription().getServerAddress());
                     bulkWriteBatchCombiner.addErrorResult(bulkWriteException, indexMap);
                     if (commandListener != null) {
-                        sendCommandFailedEvent(message, message.getCommandName(), connection.getDescription(),
-                                               startTimeNanos, bulkWriteException, commandListener);
+                        sendCommandSucceededEvent(message, message.getCommandName(), result, connection.getDescription(),
+                                                  startTimeNanos, commandListener);
                     }
                 } else {
                     bulkWriteBatchCombiner.addResult(getBulkWriteResult(getType(), result), indexMap);

--- a/driver-core/src/main/com/mongodb/connection/WriteProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/WriteProtocol.java
@@ -18,6 +18,7 @@ package com.mongodb.connection;
 
 import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
+import com.mongodb.WriteConcernException;
 import com.mongodb.WriteConcernResult;
 import com.mongodb.async.SingleResultCallback;
 import com.mongodb.diagnostics.logging.Logger;
@@ -114,6 +115,12 @@ abstract class WriteProtocol implements Protocol<WriteConcernResult> {
                                                                                              messageId);
                     writeConcernResult = ProtocolHelper.getWriteResult(replyMessage.getDocuments().get(0),
                                                                        connection.getDescription().getServerAddress());
+                } catch (WriteConcernException e) {
+                    if (commandListener != null) {
+                        sendCommandSucceededEvent(nextMessage, getCommandName(), new BsonDocument("ok", new BsonInt32(1)),
+                                                  connection.getDescription(), 0, commandListener);
+                    }
+                    throw e;
                 } catch (RuntimeException e) {
                     if (commandListener != null) {
                         sendCommandFailedEvent(nextMessage, getCommandName(), connection.getDescription(), 0, e, commandListener);

--- a/driver-core/src/main/com/mongodb/connection/WriteProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/WriteProtocol.java
@@ -31,9 +31,9 @@ import org.bson.codecs.BsonDocumentCodec;
 import static com.mongodb.MongoNamespace.COMMAND_COLLECTION_NAME;
 import static com.mongodb.connection.ProtocolHelper.encodeMessage;
 import static com.mongodb.connection.ProtocolHelper.getMessageSettings;
-import static com.mongodb.connection.ProtocolHelper.sendCommandCompletedEvent;
 import static com.mongodb.connection.ProtocolHelper.sendCommandFailedEvent;
 import static com.mongodb.connection.ProtocolHelper.sendCommandStartedEvent;
+import static com.mongodb.connection.ProtocolHelper.sendCommandSucceededEvent;
 
 /**
  * Base class for wire protocol messages that perform writes.  In particular, it handles the write followed by the getlasterror command to
@@ -126,7 +126,7 @@ abstract class WriteProtocol implements Protocol<WriteConcernResult> {
 
             if (commandListener != null) {
                 // TODO: send full write result if writeConcern.isAcknowledged()
-                sendCommandCompletedEvent(nextMessage, getCommandName(), new BsonDocument("ok", new BsonInt32(1)),
+                sendCommandSucceededEvent(nextMessage, getCommandName(), new BsonDocument("ok", new BsonInt32(1)),
                                           connection.getDescription(), startTimeNanos, commandListener);
             }
 

--- a/driver-core/src/main/com/mongodb/connection/netty/NettyByteBuf.java
+++ b/driver-core/src/main/com/mongodb/connection/netty/NettyByteBuf.java
@@ -124,8 +124,19 @@ final class NettyByteBuf implements ByteBuf {
     }
 
     @Override
+    public byte get(final int index) {
+        return proxied.getByte(index);
+    }
+
+    @Override
     public ByteBuf get(final byte[] bytes) {
         proxied.readBytes(bytes);
+        return this;
+    }
+
+    @Override
+    public ByteBuf get(final int index, final byte[] bytes) {
+        proxied.getBytes(index, bytes);
         return this;
     }
 
@@ -136,8 +147,19 @@ final class NettyByteBuf implements ByteBuf {
     }
 
     @Override
+    public ByteBuf get(final int index, final byte[] bytes, final int offset, final int length) {
+        proxied.getBytes(index, bytes, offset, length);
+        return this;
+    }
+
+    @Override
     public long getLong() {
         return proxied.readLong();
+    }
+
+    @Override
+    public long getLong(final int index) {
+        return proxied.getLong(index);
     }
 
     @Override
@@ -146,8 +168,18 @@ final class NettyByteBuf implements ByteBuf {
     }
 
     @Override
+    public double getDouble(final int index) {
+        return proxied.getDouble(index);
+    }
+
+    @Override
     public int getInt() {
         return proxied.readInt();
+    }
+
+    @Override
+    public int getInt(final int index) {
+        return proxied.getInt(index);
     }
 
     @Override
@@ -161,7 +193,8 @@ final class NettyByteBuf implements ByteBuf {
 
     @Override
     public ByteBuf limit(final int newLimit) {
-        throw new UnsupportedOperationException("This method should be unused!");
+        proxied = proxied.slice(proxied.readerIndex(), newLimit);
+        return this;
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/event/CommandCompletedEvent.java
+++ b/driver-core/src/main/com/mongodb/event/CommandCompletedEvent.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.event;
+
+import com.mongodb.connection.ConnectionDescription;
+import org.bson.BsonDocument;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An event representing the completion of a MongoDB database command.
+ *
+ * @since 3.1
+ */
+public final class CommandCompletedEvent extends CommandEvent {
+    private final BsonDocument response;
+    private final long elapsedTimeNanos;
+
+    /**
+     * Construct an instance.
+     * @param requestId the request id
+     * @param connectionDescription the connection description
+     * @param commandName the command name
+     * @param response the command response
+     * @param elapsedTimeNanos the elapsed time in nanoseconds for the operation to complete
+     */
+    public CommandCompletedEvent(final int requestId, final ConnectionDescription connectionDescription,
+                                 final String commandName, final BsonDocument response, final long elapsedTimeNanos) {
+        super(requestId, connectionDescription, commandName);
+        this.response = response;
+        this.elapsedTimeNanos = elapsedTimeNanos;
+    }
+
+    /**
+     * Gets the elapsed time in the given unit of time.
+     *
+     * @param timeUnit the time unit in which to get the elapsed time
+     * @return the elapsed time
+     */
+    public long getElapsedTime(final TimeUnit timeUnit) {
+        return timeUnit.convert(elapsedTimeNanos, TimeUnit.NANOSECONDS);
+    }
+
+    /**
+     * Gets the response document. The document is only usable within the method that delivered the event.  If it's needed for longer, it
+     * must be cloned via {@link Object#clone()}.
+     *
+     * @return the response document
+     */
+    public BsonDocument getResponse() {
+        return response;
+    }
+}

--- a/driver-core/src/main/com/mongodb/event/CommandEvent.java
+++ b/driver-core/src/main/com/mongodb/event/CommandEvent.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.event;
+
+import com.mongodb.connection.ConnectionDescription;
+
+/**
+ * An event representing a MongoDB database command.
+ *
+ * @since 3.1
+ */
+public abstract class CommandEvent {
+    private final int requestId;
+    private final ConnectionDescription connectionDescription;
+    private final String commandName;
+
+    /**
+     * Construct an instance.
+     * @param requestId the request id
+     * @param connectionDescription the connection description
+     * @param commandName the command name
+     */
+    public CommandEvent(final int requestId, final ConnectionDescription connectionDescription,
+                        final String commandName) {
+        this.requestId = requestId;
+        this.connectionDescription = connectionDescription;
+        this.commandName = commandName;
+    }
+
+    /**
+     * Gets the request identifier
+     *
+     * @return the request identifier
+     */
+    public int getRequestId() {
+        return requestId;
+    }
+
+    /**
+     * Gets the description of the connection to which the operation will be sent.
+     *
+     * @return the connection description
+     */
+    public ConnectionDescription getConnectionDescription() {
+        return connectionDescription;
+    }
+
+    /**
+     * Gets the name of the command.
+     *
+     * @return the command name
+     */
+    public String getCommandName() {
+        return commandName;
+    }
+}
+
+

--- a/driver-core/src/main/com/mongodb/event/CommandFailedEvent.java
+++ b/driver-core/src/main/com/mongodb/event/CommandFailedEvent.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.event;
+
+import com.mongodb.connection.ConnectionDescription;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An event representing the failure of a MongoDB database command.
+ *
+ * @since 3.1
+ */
+public final class CommandFailedEvent extends CommandEvent {
+
+    private final long elapsedTimeNanos;
+    private final Throwable throwable;
+
+    /**
+     * Construct an instance.
+     * @param requestId the requestId
+     * @param connectionDescription the connection description
+     * @param commandName the command name
+     * @param elapsedTimeNanos the elapsed time in nanoseconds for the operation to complete
+     * @param throwable the throwable cause of the failure
+     */
+    public CommandFailedEvent(final int requestId, final ConnectionDescription connectionDescription, final String commandName,
+                              final long elapsedTimeNanos, final Throwable throwable) {
+        super(requestId, connectionDescription, commandName);
+        this.elapsedTimeNanos = elapsedTimeNanos;
+        this.throwable = throwable;
+    }
+
+    /**
+     * Gets the elapsed time in the given unit of time.
+     *
+     * @param timeUnit the time unit in which to get the elapsed time
+     * @return the elapsed time
+     */
+    public long getElapsedTime(final TimeUnit timeUnit) {
+        return timeUnit.convert(elapsedTimeNanos, TimeUnit.NANOSECONDS);
+    }
+
+    /**
+     * Gets the throwable cause of the failure
+     *
+     * @return the throwable cause of the failuer
+     */
+    public Throwable getThrowable() {
+        return throwable;
+    }
+}

--- a/driver-core/src/main/com/mongodb/event/CommandListener.java
+++ b/driver-core/src/main/com/mongodb/event/CommandListener.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.event;
+
+/**
+ * A listener for command events
+ *
+ * @since 3.1
+ */
+public interface CommandListener {
+    /**
+     * Listener for command started events.
+     *
+     * @param event the event
+     */
+    void commandStarted(CommandStartedEvent event);
+
+    /**
+     * Listener for command completed events
+     *
+     * @param event the event
+     */
+    void commandCompleted(CommandCompletedEvent event);
+
+    /**
+     * Listener for command failure events
+     *
+     * @param event the event
+     */
+    void commandFailed(CommandFailedEvent event);
+}

--- a/driver-core/src/main/com/mongodb/event/CommandListener.java
+++ b/driver-core/src/main/com/mongodb/event/CommandListener.java
@@ -32,7 +32,7 @@ public interface CommandListener {
      *
      * @param event the event
      */
-    void commandCompleted(CommandCompletedEvent event);
+    void commandSucceeded(CommandSucceededEvent event);
 
     /**
      * Listener for command failure events

--- a/driver-core/src/main/com/mongodb/event/CommandListenerMulticaster.java
+++ b/driver-core/src/main/com/mongodb/event/CommandListenerMulticaster.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.event;
+
+import com.mongodb.annotations.Immutable;
+import com.mongodb.diagnostics.logging.Logger;
+import com.mongodb.diagnostics.logging.Loggers;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static com.mongodb.assertions.Assertions.notNull;
+import static java.lang.String.format;
+
+/**
+ * A multicaster for connection events. Any Exception thrown by one of the listeners will be caught and not re-thrown, but may be
+ * logged.
+ *
+ * @since 3.1
+ *
+ */
+@Immutable
+public class CommandListenerMulticaster implements CommandListener {
+    private static final Logger LOGGER = Loggers.getLogger("protocol.event");
+
+    private final List<CommandListener> commandListeners;
+
+    /**
+     * Construct an instance with the given list of command listeners
+     *
+     * @param commandListeners the non-null list of command listeners, none of which may be null
+     */
+    public CommandListenerMulticaster(final List<CommandListener> commandListeners) {
+        notNull("commandListeners", commandListeners);
+        for (CommandListener cur : commandListeners) {
+            notNull("commandListener", cur);
+        }
+        this.commandListeners = new ArrayList<CommandListener>(commandListeners);
+    }
+
+    /**
+     * Gets the command listeners.
+     *
+     * @return the unmodifiable set of command listeners
+     */
+    public List<CommandListener> getCommandListeners() {
+        return Collections.unmodifiableList(commandListeners);
+    }
+
+    @Override
+    public void commandStarted(final CommandStartedEvent event) {
+        for (CommandListener cur : commandListeners) {
+            try {
+                cur.commandStarted(event);
+            } catch (Exception e) {
+                if (LOGGER.isWarnEnabled()) {
+                    LOGGER.warn(format("Exception thrown raising command started event to listener %s", cur), e);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void commandSucceeded(final CommandSucceededEvent event) {
+        for (CommandListener cur : commandListeners) {
+            try {
+                cur.commandSucceeded(event);
+            } catch (Exception e) {
+                if (LOGGER.isWarnEnabled()) {
+                    LOGGER.warn(format("Exception thrown raising command succeeded event to listener %s", cur), e);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void commandFailed(final CommandFailedEvent event) {
+        for (CommandListener cur : commandListeners) {
+            try {
+                cur.commandFailed(event);
+            } catch (Exception e) {
+                if (LOGGER.isWarnEnabled()) {
+                    LOGGER.warn(format("Exception thrown raising command failed event to listener %s", cur), e);
+                }
+            }
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/event/CommandStartedEvent.java
+++ b/driver-core/src/main/com/mongodb/event/CommandStartedEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.event;
+
+import com.mongodb.connection.ConnectionDescription;
+import org.bson.BsonDocument;
+
+/**
+ * An event representing the start of a command execution.
+ *
+ * @since 3.1
+ */
+public final class CommandStartedEvent extends CommandEvent {
+    private final String databaseName;
+    private final BsonDocument command;
+
+    /**
+     * Construct an instance.
+     *
+     * @param requestId             the request id
+     * @param connectionDescription the connection description
+     * @param databaseName          the database name
+     * @param commandName           the command name
+     * @param command the command as a BSON document
+     */
+    public CommandStartedEvent(final int requestId, final ConnectionDescription connectionDescription,
+                               final String databaseName, final String commandName, final BsonDocument command) {
+        super(requestId, connectionDescription, commandName);
+        this.command = command;
+        this.databaseName = databaseName;
+    }
+
+    /**
+     * Gets the database on which the operation will be executed.
+     *
+     * @return the database name
+     */
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    /**
+     * Gets the command document. The document is only usable within the method that delivered the event.  If it's needed for longer, it
+     * must be cloned via {@link Object#clone()}.
+     *
+     * @return the command document
+     */
+    public BsonDocument getCommand() {
+        return command;
+    }
+}

--- a/driver-core/src/main/com/mongodb/event/CommandSucceededEvent.java
+++ b/driver-core/src/main/com/mongodb/event/CommandSucceededEvent.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @since 3.1
  */
-public final class CommandCompletedEvent extends CommandEvent {
+public final class CommandSucceededEvent extends CommandEvent {
     private final BsonDocument response;
     private final long elapsedTimeNanos;
 
@@ -36,7 +36,7 @@ public final class CommandCompletedEvent extends CommandEvent {
      * @param response the command response
      * @param elapsedTimeNanos the elapsed time in nanoseconds for the operation to complete
      */
-    public CommandCompletedEvent(final int requestId, final ConnectionDescription connectionDescription,
+    public CommandSucceededEvent(final int requestId, final ConnectionDescription connectionDescription,
                                  final String commandName, final BsonDocument response, final long elapsedTimeNanos) {
         super(requestId, connectionDescription, commandName);
         this.response = response;

--- a/driver-core/src/main/com/mongodb/operation/AsyncQueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/AsyncQueryBatchCursor.java
@@ -143,7 +143,7 @@ class AsyncQueryBatchCursor<T> implements AsyncBatchCursor<T> {
                 @Override
                 public void onResult(final AsyncConnection connection, final Throwable connectionException) {
                     if (connection != null) {
-                        connection.killCursorAsync(singletonList(localCursor.getId()), new SingleResultCallback<Void>() {
+                        connection.killCursorAsync(namespace, singletonList(localCursor.getId()), new SingleResultCallback<Void>() {
                             @Override
                             public void onResult(final Void result, final Throwable t) {
                                 connection.release();

--- a/driver-core/src/main/com/mongodb/operation/BsonArrayWrapper.java
+++ b/driver-core/src/main/com/mongodb/operation/BsonArrayWrapper.java
@@ -199,4 +199,9 @@ class BsonArrayWrapper<T> extends BsonArray {
                 + "wrappedArray=" + wrappedArray
                 + '}';
     }
+
+    @Override
+    public BsonArray clone() {
+        throw new UnsupportedOperationException("This should never be called on an instance of this type");
+    }
 }

--- a/driver-core/src/main/com/mongodb/operation/BsonArrayWrapper.java
+++ b/driver-core/src/main/com/mongodb/operation/BsonArrayWrapper.java
@@ -28,7 +28,6 @@ import static org.bson.assertions.Assertions.notNull;
 
 
 class BsonArrayWrapper<T> extends BsonArray {
-    private static final long serialVersionUID = 3213553338060799471L;
 
     private final List<T> wrappedArray;
 

--- a/driver-core/src/main/com/mongodb/operation/FindOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/FindOperation.java
@@ -397,8 +397,9 @@ public class FindOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>
                 QueryResult<T> queryResult = connection.query(namespace,
                                                               asDocument(connection.getDescription(), binding.getReadPreference()),
                                                               projection,
-                                                              getNumberToReturn(),
                                                               skip,
+                                                              limit,
+                                                              batchSize,
                                                               isSlaveOk() || binding.getReadPreference().isSlaveOk(),
                                                               isTailableCursor(),
                                                               isAwaitData(),
@@ -422,7 +423,7 @@ public class FindOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>
                     final SingleResultCallback<AsyncBatchCursor<T>> wrappedCallback = releasingCallback(errorHandlingCallback(callback),
                                                                                                         source, connection);
                     connection.queryAsync(namespace, asDocument(connection.getDescription(), binding.getReadPreference()), projection,
-                                          getNumberToReturn(), skip, isSlaveOk() || binding.getReadPreference().isSlaveOk(),
+                                          skip, limit, batchSize, isSlaveOk() || binding.getReadPreference().isSlaveOk(),
                                           isTailableCursor(), isAwaitData(), isNoCursorTimeout(), isPartial(), isOplogReplay(),
                                           decoder, new SingleResultCallback<QueryResult<T>>() {
                         @Override
@@ -508,32 +509,6 @@ public class FindOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>
                              .limit(Math.abs(limit) * -1)
                              .modifiers(explainModifiers);
 
-    }
-
-    /**
-     * Gets the limit of the number of documents in the first OP_REPLY response to the query.
-     *
-     * <p>A value of zero tells the server to use the default size. A negative value tells the server to return no more than that number
-     * and immediately close the cursor.  Otherwise, the server will return no more than that number and return a cursorId to allow the
-     * rest of the documents to be fetched, if it turns out there are more documents.</p>
-     *
-     * <p>The value returned by this method is based on the limit and the batch size, both of which can be positive, negative, or zero.</p>
-     *
-     * @return the value for numberToReturn in the OP_QUERY wire protocol message.
-     * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-query OP_QUERY
-     */
-    private int getNumberToReturn() {
-        if (limit < 0) {
-            return limit;
-        } else if (limit == 0) {
-            return batchSize;
-        } else if (batchSize == 0) {
-            return limit;
-        } else if (limit < Math.abs(batchSize)) {
-            return limit;
-        } else {
-            return batchSize;
-        }
     }
 
     private BsonDocument asDocument(final ConnectionDescription connectionDescription, final ReadPreference readPreference) {

--- a/driver-core/src/main/com/mongodb/operation/ListCollectionsOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ListCollectionsOperation.java
@@ -182,7 +182,7 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
                     }
                 } else {
                     return new ProjectingBatchCursor(new QueryBatchCursor<BsonDocument>(connection.query(getNamespace(),
-                            asQueryDocument(connection.getDescription(), binding.getReadPreference()), null, batchSize, 0,
+                            asQueryDocument(connection.getDescription(), binding.getReadPreference()), null, 0, 0, batchSize,
                             binding.getReadPreference().isSlaveOk(), false, false,  false, false, false, new BsonDocumentCodec()), 0,
                             batchSize, new BsonDocumentCodec(), source));
                 }
@@ -215,7 +215,7 @@ public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatc
                                 });
                     } else {
                         connection.queryAsync(getNamespace(), asQueryDocument(connection.getDescription(), binding.getReadPreference()),
-                                null, batchSize, 0, binding.getReadPreference().isSlaveOk(), false, false, false, false, false,
+                                null, 0, 0, batchSize, binding.getReadPreference().isSlaveOk(), false, false, false, false, false,
                                 new BsonDocumentCodec(), new SingleResultCallback<QueryResult<BsonDocument>>() {
                                     @Override
                                     public void onResult(final QueryResult<BsonDocument> result, final Throwable t) {

--- a/driver-core/src/main/com/mongodb/operation/ListIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ListIndexesOperation.java
@@ -146,7 +146,7 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
                     }
                 } else {
                     return new QueryBatchCursor<T>(connection.query(getIndexNamespace(),
-                            asQueryDocument(connection.getDescription(), binding.getReadPreference()), null, batchSize, 0,
+                            asQueryDocument(connection.getDescription(), binding.getReadPreference()), null, 0, 0, batchSize,
                             binding.getReadPreference().isSlaveOk(), false, false, false, false, false, decoder), 0, batchSize, decoder,
                             source);
                 }
@@ -182,7 +182,7 @@ public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCur
                                                            });
                     } else {
                         connection.queryAsync(getIndexNamespace(),
-                                asQueryDocument(connection.getDescription(), binding.getReadPreference()), null, batchSize, 0,
+                                asQueryDocument(connection.getDescription(), binding.getReadPreference()), null, 0, 0, batchSize,
                                 binding.getReadPreference().isSlaveOk(), false, false, false, false, false, decoder,
                                 new SingleResultCallback<QueryResult<T>>() {
                                     @Override

--- a/driver-core/src/main/com/mongodb/operation/QueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/QueryBatchCursor.java
@@ -227,7 +227,7 @@ class QueryBatchCursor<T> implements BatchCursor<T> {
 
     private void killCursor(final Connection connection) {
         if (serverCursor != null) {
-            connection.killCursor(singletonList(serverCursor.getId()));
+            connection.killCursor(namespace, singletonList(serverCursor.getId()));
             serverCursor = null;
         }
     }

--- a/driver-core/src/main/com/mongodb/operation/UserExistsOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/UserExistsOperation.java
@@ -68,7 +68,7 @@ public class UserExistsOperation implements AsyncReadOperation<Boolean>, ReadOpe
                                                          transformer());
                 } else {
                     return transformQueryResult().apply(connection.query(new MongoNamespace(databaseName, "system.users"),
-                                                                         new BsonDocument("user", new BsonString(userName)), null, 1, 0,
+                                                                         new BsonDocument("user", new BsonString(userName)), null, 0, 1, 0,
                                                                          binding.getReadPreference().isSlaveOk(), false,
                                                                          false, false, false, false,
                                                                          new BsonDocumentCodec()));
@@ -90,7 +90,7 @@ public class UserExistsOperation implements AsyncReadOperation<Boolean>, ReadOpe
                         executeWrappedCommandProtocolAsync(databaseName, getCommand(), connection, transformer(), wrappedCallback);
                     } else {
                         connection.queryAsync(new MongoNamespace(databaseName, "system.users"),
-                                              new BsonDocument("user", new BsonString(userName)), null, 1, 0,
+                                              new BsonDocument("user", new BsonString(userName)), null, 0, 1, 0,
                                               binding.getReadPreference().isSlaveOk(), false,
                                               false, false, false, false,
                                               new BsonDocumentCodec(),

--- a/driver-core/src/test/functional/com/mongodb/connection/CommandProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/CommandProtocolCommandEventSpecification.groovy
@@ -21,9 +21,9 @@ package com.mongodb.connection
 import com.mongodb.MongoCommandException
 import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.connection.netty.NettyStreamFactory
-import com.mongodb.event.CommandCompletedEvent
 import com.mongodb.event.CommandFailedEvent
 import com.mongodb.event.CommandStartedEvent
+import com.mongodb.event.CommandSucceededEvent
 import com.mongodb.internal.validator.NoOpFieldNameValidator
 import org.bson.BsonDocument
 import org.bson.BsonDouble
@@ -62,7 +62,7 @@ class CommandProtocolCommandEventSpecification extends OperationFunctionalSpecif
         then:
         commandListener.eventsWereDelivered([new CommandStartedEvent(1, connection.getDescription(), 'admin', 'ping',
                                                                      pingCommand),
-                                             new CommandCompletedEvent(1, connection.getDescription(), 'ping',
+                                             new CommandSucceededEvent(1, connection.getDescription(), 'ping',
                                                                        new BsonDocument('ok', new BsonDouble(1)), 1000)])
     }
 

--- a/driver-core/src/test/functional/com/mongodb/connection/CommandProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/CommandProtocolCommandEventSpecification.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.mongodb.connection
+
+import com.mongodb.MongoCommandException
+import com.mongodb.OperationFunctionalSpecification
+import com.mongodb.connection.netty.NettyStreamFactory
+import com.mongodb.event.CommandCompletedEvent
+import com.mongodb.event.CommandFailedEvent
+import com.mongodb.event.CommandStartedEvent
+import com.mongodb.internal.validator.NoOpFieldNameValidator
+import org.bson.BsonDocument
+import org.bson.BsonDouble
+import org.bson.BsonInt32
+import org.bson.codecs.DocumentCodec
+
+import static com.mongodb.ClusterFixture.getCredentialList
+import static com.mongodb.ClusterFixture.getPrimary
+import static com.mongodb.ClusterFixture.getSslSettings
+
+class CommandProtocolCommandEventSpecification extends OperationFunctionalSpecification {
+    static InternalStreamConnection connection;
+
+    def setupSpec() {
+        connection = new InternalStreamConnectionFactory(new NettyStreamFactory(SocketSettings.builder().build(), getSslSettings()),
+                                                         getCredentialList(), new NoOpConnectionListener())
+                .create(new ServerId(new ClusterId(), getPrimary()))
+        connection.open();
+    }
+
+    def cleanupSpec() {
+        connection?.close()
+    }
+
+    def 'should deliver start and completed command events'() {
+        given:
+        def pingCommand = new BsonDocument('ping', new BsonInt32(1))
+        def protocol = new CommandProtocol('admin', pingCommand, new NoOpFieldNameValidator(), new DocumentCodec())
+
+        def commandListener = new TestCommandListener()
+        protocol.commandListener = commandListener
+
+        when:
+        protocol.execute(connection)
+
+        then:
+        commandListener.eventsWereDelivered([new CommandStartedEvent(1, connection.getDescription(), 'admin', 'ping',
+                                                                     pingCommand),
+                                             new CommandCompletedEvent(1, connection.getDescription(), 'ping',
+                                                                       new BsonDocument('ok', new BsonDouble(1)), 1000)])
+    }
+
+    def 'should deliver start and failed command events'() {
+        given:
+        def unknownCommand = new BsonDocument('unknown', new BsonInt32(1))
+        def protocol = new CommandProtocol('admin', unknownCommand, new NoOpFieldNameValidator(), new DocumentCodec())
+
+        def commandListener = new TestCommandListener()
+        protocol.commandListener = commandListener
+
+        when:
+        protocol.execute(connection)
+
+        then:
+        def e = thrown(MongoCommandException)
+        commandListener.eventsWereDelivered([new CommandStartedEvent(1, connection.getDescription(), 'admin', 'unknown',
+                                                                     unknownCommand),
+                                             new CommandFailedEvent(1, connection.getDescription(), 'unknown', 0, e)])
+    }
+}

--- a/driver-core/src/test/functional/com/mongodb/connection/GetMoreProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/GetMoreProtocolCommandEventSpecification.groovy
@@ -21,9 +21,9 @@ package com.mongodb.connection
 import com.mongodb.MongoQueryException
 import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.connection.netty.NettyStreamFactory
-import com.mongodb.event.CommandCompletedEvent
 import com.mongodb.event.CommandFailedEvent
 import com.mongodb.event.CommandStartedEvent
+import com.mongodb.event.CommandSucceededEvent
 import org.bson.BsonArray
 import org.bson.BsonDocument
 import org.bson.BsonDouble
@@ -79,7 +79,7 @@ class GetMoreProtocolCommandEventSpecification extends OperationFunctionalSpecif
                                                                      new BsonDocument('getMore', new BsonInt64(result.cursor.id))
                                                                              .append('collection', new BsonString(getCollectionName()))
                                                                              .append('batchSize', new BsonInt32(2))),
-                                             new CommandCompletedEvent(1, connection.getDescription(), 'getMore',
+                                             new CommandSucceededEvent(1, connection.getDescription(), 'getMore',
                                                                        response,
                                                                        0)])
     }

--- a/driver-core/src/test/functional/com/mongodb/connection/GetMoreProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/GetMoreProtocolCommandEventSpecification.groovy
@@ -66,12 +66,12 @@ class GetMoreProtocolCommandEventSpecification extends OperationFunctionalSpecif
         protocol.commandListener = commandListener
 
         when:
-        protocol.execute(connection)
-
+        def getMoreResult = protocol.execute(connection)
 
         then:
         def response = new BsonDocument('cursor',
-                                        new BsonDocument('id', new BsonInt64(result.cursor.id))
+                                        new BsonDocument('id', getMoreResult.cursor ? new BsonInt64(getMoreResult.cursor.id)
+                                                                                    : new BsonInt64(0))
                                                 .append('ns', new BsonString(getNamespace().getFullName()))
                                                 .append('nextBatch', new BsonArray(documents.subList(3, 5))))
                 .append('ok', new BsonDouble(1.0))

--- a/driver-core/src/test/functional/com/mongodb/connection/GetMoreProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/GetMoreProtocolCommandEventSpecification.groovy
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.mongodb.connection
+
+import com.mongodb.MongoQueryException
+import com.mongodb.OperationFunctionalSpecification
+import com.mongodb.connection.netty.NettyStreamFactory
+import com.mongodb.event.CommandCompletedEvent
+import com.mongodb.event.CommandFailedEvent
+import com.mongodb.event.CommandStartedEvent
+import org.bson.BsonArray
+import org.bson.BsonDocument
+import org.bson.BsonDouble
+import org.bson.BsonInt32
+import org.bson.BsonInt64
+import org.bson.BsonString
+import org.bson.Document
+import org.bson.codecs.BsonDocumentCodec
+
+import static com.mongodb.ClusterFixture.getCredentialList
+import static com.mongodb.ClusterFixture.getPrimary
+import static com.mongodb.ClusterFixture.getSslSettings
+
+class GetMoreProtocolCommandEventSpecification extends OperationFunctionalSpecification {
+    static InternalStreamConnection connection;
+
+    def setupSpec() {
+        connection = new InternalStreamConnectionFactory(new NettyStreamFactory(SocketSettings.builder().build(), getSslSettings()),
+                                                         getCredentialList(), new NoOpConnectionListener())
+                .create(new ServerId(new ClusterId(), getPrimary()))
+        connection.open();
+    }
+
+    def cleanupSpec() {
+        connection?.close()
+    }
+
+    def 'should deliver start and completed command events'() {
+        given:
+        def documents = [new BsonDocument('_id', new BsonInt32(1)),
+                         new BsonDocument('_id', new BsonInt32(2)),
+                         new BsonDocument('_id', new BsonInt32(3)),
+                         new BsonDocument('_id', new BsonInt32(4)),
+                         new BsonDocument('_id', new BsonInt32(5))]
+        collectionHelper.insertDocuments(documents)
+        def result = new QueryProtocol(getNamespace(), 1, 2, new BsonDocument(), null, new BsonDocumentCodec()).execute(connection)
+        def protocol = new GetMoreProtocol(getNamespace(), result.cursor.id, 2, new BsonDocumentCodec())
+
+        def commandListener = new TestCommandListener()
+        protocol.commandListener = commandListener
+
+        when:
+        protocol.execute(connection)
+
+
+        then:
+        def response = new BsonDocument('cursor',
+                                        new BsonDocument('id', new BsonInt64(result.cursor.id))
+                                                .append('ns', new BsonString(getNamespace().getFullName()))
+                                                .append('nextBatch', new BsonArray(documents.subList(3, 5))))
+                .append('ok', new BsonDouble(1.0))
+        commandListener.eventsWereDelivered([new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'getMore',
+                                                                     new BsonDocument('getMore', new BsonInt64(result.cursor.id))
+                                                                             .append('collection', new BsonString(getCollectionName()))
+                                                                             .append('batchSize', new BsonInt32(2))),
+                                             new CommandCompletedEvent(1, connection.getDescription(), 'getMore',
+                                                                       response,
+                                                                       0)])
+    }
+
+    def 'should deliver start and failed command events'() {
+        given:
+        collectionHelper.insertDocuments(new Document(), new Document(), new Document(), new Document(), new Document())
+        def result = new QueryProtocol(getNamespace(), 1, 2, new BsonDocument(), null, new BsonDocumentCodec())
+                .execute(connection)
+        new KillCursorProtocol([result.cursor.id]).execute(connection)
+        def protocol = new GetMoreProtocol(getNamespace(), result.cursor.id, 2, new BsonDocumentCodec())
+
+        def commandListener = new TestCommandListener()
+        protocol.commandListener = commandListener
+
+        when:
+        protocol.execute(connection)
+
+        then:
+        def e = thrown(MongoQueryException)
+        commandListener.eventsWereDelivered([new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'getMore',
+                                                                     new BsonDocument('getMore', new BsonInt64(result.cursor.id))
+                                                                             .append('collection', new BsonString(getCollectionName()))
+                                                                             .append('batchSize', new BsonInt32(2))),
+                                             new CommandFailedEvent(1, connection.getDescription(), 'getMore', 0, e)
+        ])
+    }
+}

--- a/driver-core/src/test/functional/com/mongodb/connection/GetMoreProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/GetMoreProtocolCommandEventSpecification.groovy
@@ -89,7 +89,7 @@ class GetMoreProtocolCommandEventSpecification extends OperationFunctionalSpecif
         collectionHelper.insertDocuments(new Document(), new Document(), new Document(), new Document(), new Document())
         def result = new QueryProtocol(getNamespace(), 1, 2, new BsonDocument(), null, new BsonDocumentCodec())
                 .execute(connection)
-        new KillCursorProtocol([result.cursor.id]).execute(connection)
+        new KillCursorProtocol(getNamespace(), [result.cursor.id]).execute(connection)
         def protocol = new GetMoreProtocol(getNamespace(), result.cursor.id, 2, new BsonDocumentCodec())
 
         def commandListener = new TestCommandListener()

--- a/driver-core/src/test/functional/com/mongodb/connection/KillCursorProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/KillCursorProtocolCommandEventSpecification.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.mongodb.connection
+
+import com.mongodb.OperationFunctionalSpecification
+import com.mongodb.connection.netty.NettyStreamFactory
+import com.mongodb.event.CommandCompletedEvent
+import com.mongodb.event.CommandStartedEvent
+import org.bson.BsonArray
+import org.bson.BsonDocument
+import org.bson.BsonDouble
+import org.bson.BsonInt64
+import org.bson.Document
+import org.bson.codecs.BsonDocumentCodec
+
+import static com.mongodb.ClusterFixture.getCredentialList
+import static com.mongodb.ClusterFixture.getPrimary
+import static com.mongodb.ClusterFixture.getSslSettings
+
+class KillCursorProtocolCommandEventSpecification extends OperationFunctionalSpecification {
+    static InternalStreamConnection connection;
+
+    def setupSpec() {
+        connection = new InternalStreamConnectionFactory(new NettyStreamFactory(SocketSettings.builder().build(), getSslSettings()),
+                                                         getCredentialList(), new NoOpConnectionListener())
+                .create(new ServerId(new ClusterId(), getPrimary()))
+        connection.open();
+    }
+
+    def cleanupSpec() {
+        connection?.close()
+    }
+
+    def 'should deliver start and completed command events'() {
+        given:
+        collectionHelper.insertDocuments(new Document(), new Document(), new Document(), new Document(), new Document())
+        def result = new QueryProtocol(getNamespace(), 1, 2, new BsonDocument(), null, new BsonDocumentCodec())
+                .execute(connection)
+        def protocol = new KillCursorProtocol([result.cursor.id])
+
+        def commandListener = new TestCommandListener()
+        protocol.commandListener = commandListener
+
+        when:
+        protocol.execute(connection)
+
+        then:
+        commandListener.eventsWereDelivered([new CommandStartedEvent(1, connection.getDescription(), 'admin', 'killCursors',
+                                                                     new BsonDocument('killCursors',
+                                                                                      new BsonArray([new BsonInt64(result.cursor.id)]))),
+                                             new CommandCompletedEvent(1, connection.getDescription(), 'killCursors',
+                                                                       new BsonDocument('ok', new BsonDouble(1.0)), 0)])
+    }
+}

--- a/driver-core/src/test/functional/com/mongodb/connection/KillCursorProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/KillCursorProtocolCommandEventSpecification.groovy
@@ -20,8 +20,8 @@ package com.mongodb.connection
 
 import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.connection.netty.NettyStreamFactory
-import com.mongodb.event.CommandCompletedEvent
 import com.mongodb.event.CommandStartedEvent
+import com.mongodb.event.CommandSucceededEvent
 import org.bson.BsonArray
 import org.bson.BsonDocument
 import org.bson.BsonDouble
@@ -64,7 +64,7 @@ class KillCursorProtocolCommandEventSpecification extends OperationFunctionalSpe
         commandListener.eventsWereDelivered([new CommandStartedEvent(1, connection.getDescription(), 'admin', 'killCursors',
                                                                      new BsonDocument('killCursors',
                                                                                       new BsonArray([new BsonInt64(result.cursor.id)]))),
-                                             new CommandCompletedEvent(1, connection.getDescription(), 'killCursors',
+                                             new CommandSucceededEvent(1, connection.getDescription(), 'killCursors',
                                                                        new BsonDocument('ok', new BsonDouble(1.0)), 0)])
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/connection/KillCursorProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/KillCursorProtocolCommandEventSpecification.groovy
@@ -65,6 +65,9 @@ class KillCursorProtocolCommandEventSpecification extends OperationFunctionalSpe
                                                                      new BsonDocument('killCursors',
                                                                                       new BsonArray([new BsonInt64(result.cursor.id)]))),
                                              new CommandSucceededEvent(1, connection.getDescription(), 'killCursors',
-                                                                       new BsonDocument('ok', new BsonDouble(1.0)), 0)])
+                                                                       new BsonDocument('ok', new BsonDouble(1.0))
+                                                                               .append('cursorsUnknown',
+                                                                                       new BsonArray([new BsonInt64(result.cursor.id)])),
+                                                                       0)])
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/connection/QueryProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/QueryProtocolCommandEventSpecification.groovy
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.mongodb.connection
+
+import com.mongodb.MongoQueryException
+import com.mongodb.OperationFunctionalSpecification
+import com.mongodb.connection.netty.NettyStreamFactory
+import com.mongodb.event.CommandCompletedEvent
+import com.mongodb.event.CommandFailedEvent
+import com.mongodb.event.CommandStartedEvent
+import org.bson.BsonArray
+import org.bson.BsonDocument
+import org.bson.BsonDouble
+import org.bson.BsonInt32
+import org.bson.BsonInt64
+import org.bson.BsonString
+import org.bson.codecs.BsonDocumentCodec
+
+import static com.mongodb.ClusterFixture.getCredentialList
+import static com.mongodb.ClusterFixture.getPrimary
+import static com.mongodb.ClusterFixture.getSslSettings
+import static org.bson.BsonDocument.parse
+
+class QueryProtocolCommandEventSpecification extends OperationFunctionalSpecification {
+    static InternalStreamConnection connection;
+
+    def setupSpec() {
+        connection = new InternalStreamConnectionFactory(new NettyStreamFactory(SocketSettings.builder().build(), getSslSettings()),
+                                                         getCredentialList(), new NoOpConnectionListener())
+                .create(new ServerId(new ClusterId(), getPrimary()))
+        connection.open();
+    }
+
+    def cleanupSpec() {
+        connection?.close()
+    }
+
+    def 'should deliver start and completed command events'() {
+        given:
+        def documents = [new BsonDocument('_id', new BsonInt32(1)),
+                         new BsonDocument('_id', new BsonInt32(2)),
+                         new BsonDocument('_id', new BsonInt32(3)),
+                         new BsonDocument('_id', new BsonInt32(4)),
+                         new BsonDocument('_id', new BsonInt32(5))]
+        collectionHelper.insertDocuments(documents)
+
+        def filter = parse('{_id : {$gt : 0}}')
+        def projection = parse('{_id : 1}')
+        def skip = 1
+        def protocol = new QueryProtocol(getNamespace(), skip, 2, filter, projection, new BsonDocumentCodec())
+
+        def commandListener = new TestCommandListener()
+        protocol.commandListener = commandListener
+
+        when:
+        def result = protocol.execute(connection)
+
+        then:
+        def response = new BsonDocument('cursor',
+                                        new BsonDocument('id', new BsonInt64(result.cursor.id))
+                                                .append('ns', new BsonString(getNamespace().getFullName()))
+                                                .append('firstBatch', new BsonArray(documents.subList(1, 3))))
+                .append('ok', new BsonDouble(1.0))
+        commandListener.eventsWereDelivered([new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'find',
+                                                                     new BsonDocument('find', new BsonString(getCollectionName()))
+                                                                             .append('filter', filter)
+                                                                             .append('projection', projection)
+                                                                             .append('skip', new BsonInt32(skip))),
+                                             new CommandCompletedEvent(1, connection.getDescription(), 'find', response, 0)])
+    }
+
+    def 'should deliver start and failed command events'() {
+        given:
+        def filter = parse('{_id : {$fakeOp : 1}}')
+        def projection = parse('{_id : 1}')
+        def skip = 5
+        def protocol = new QueryProtocol(getNamespace(), skip, 5, filter, projection, new BsonDocumentCodec())
+
+        def commandListener = new TestCommandListener()
+        protocol.commandListener = commandListener
+
+        when:
+        protocol.execute(connection)
+
+        then:
+        def e = thrown(MongoQueryException)
+        commandListener.eventsWereDelivered([new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'find',
+                                                                     new BsonDocument('find', new BsonString(getCollectionName()))
+                                                                             .append('filter', filter)
+                                                                             .append('projection', projection)
+                                                                             .append('skip', new BsonInt32(skip))),
+                                             new CommandFailedEvent(1, connection.getDescription(), 'find', 0, e)])
+    }
+}

--- a/driver-core/src/test/functional/com/mongodb/connection/QueryProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/QueryProtocolCommandEventSpecification.groovy
@@ -23,9 +23,9 @@ import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.ReadPreference
 import com.mongodb.client.model.CreateCollectionOptions
 import com.mongodb.connection.netty.NettyStreamFactory
-import com.mongodb.event.CommandCompletedEvent
 import com.mongodb.event.CommandFailedEvent
 import com.mongodb.event.CommandStartedEvent
+import com.mongodb.event.CommandSucceededEvent
 import org.bson.BsonArray
 import org.bson.BsonBoolean
 import org.bson.BsonDocument
@@ -88,7 +88,7 @@ class QueryProtocolCommandEventSpecification extends OperationFunctionalSpecific
                                                                              .append('filter', filter)
                                                                              .append('projection', projection)
                                                                              .append('skip', new BsonInt32(skip))),
-                                             new CommandCompletedEvent(1, connection.getDescription(), 'find', response, 0)])
+                                             new CommandSucceededEvent(1, connection.getDescription(), 'find', response, 0)])
     }
 
     def 'should deliver start and completed command events with limit and batchSize'() {
@@ -126,7 +126,7 @@ class QueryProtocolCommandEventSpecification extends OperationFunctionalSpecific
                                                                              .append('skip', new BsonInt32(skip))
                                                                              .append('limit', new BsonInt32(limit))
                                                                              .append('batchSize', new BsonInt32(batchSize))),
-                                             new CommandCompletedEvent(1, connection.getDescription(), 'find', response, 0)])
+                                             new CommandSucceededEvent(1, connection.getDescription(), 'find', response, 0)])
     }
 
     def 'should deliver start and completed command events when there is no projection'() {
@@ -153,7 +153,7 @@ class QueryProtocolCommandEventSpecification extends OperationFunctionalSpecific
         commandListener.eventsWereDelivered([new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'find',
                                                                      new BsonDocument('find', new BsonString(getCollectionName()))
                                                                              .append('filter', filter)),
-                                             new CommandCompletedEvent(1, connection.getDescription(), 'find', response, 0)])
+                                             new CommandSucceededEvent(1, connection.getDescription(), 'find', response, 0)])
     }
 
     def 'should deliver start and completed command events when there are boolean options'() {
@@ -192,7 +192,7 @@ class QueryProtocolCommandEventSpecification extends OperationFunctionalSpecific
                                                                              .append('noCursorTimeout', BsonBoolean.TRUE)
                                                                              .append('awaitData', BsonBoolean.TRUE)
                                                                              .append('allowPartialResults', BsonBoolean.TRUE)),
-                                             new CommandCompletedEvent(1, connection.getDescription(), 'find', response, 0)])
+                                             new CommandSucceededEvent(1, connection.getDescription(), 'find', response, 0)])
     }
 
     @IgnoreIf({ !serverVersionAtLeast([2, 6, 0]) })
@@ -266,7 +266,7 @@ class QueryProtocolCommandEventSpecification extends OperationFunctionalSpecific
                                                                              .append('skip', new BsonInt32(skip))
                                                                              .append('limit', new BsonInt32(limit))
                                                                              .append('batchSize', new BsonInt32(batchSize))),
-                                             new CommandCompletedEvent(1, connection.getDescription(), 'find', response, 0)])
+                                             new CommandSucceededEvent(1, connection.getDescription(), 'find', response, 0)])
     }
 
     def 'should deliver start and completed command events for an explain command when there is a $explain meta operator'() {
@@ -296,7 +296,7 @@ class QueryProtocolCommandEventSpecification extends OperationFunctionalSpecific
                                                                                               .append('skip', new BsonInt32(skip))
                                                                                               .append('limit', new BsonInt32(limit))
                                                                                               .append('projection', projection))),
-                                             new CommandCompletedEvent(1, connection.getDescription(), 'explain', expectedResponse, 0)])
+                                             new CommandSucceededEvent(1, connection.getDescription(), 'explain', expectedResponse, 0)])
     }
 
     def 'should deliver start and failed command events'() {

--- a/driver-core/src/test/functional/com/mongodb/connection/SingleServerClusterTest.java
+++ b/driver-core/src/test/functional/com/mongodb/connection/SingleServerClusterTest.java
@@ -50,7 +50,7 @@ public class SingleServerClusterTest {
                                                                               streamFactory,
                                                                               getCredentialList(),
                                                                               new NoOpConnectionListener(),
-                                                                              new NoOpConnectionPoolListener()),
+                                                                              new NoOpConnectionPoolListener(), null),
                                           new NoOpClusterListener());
     }
 

--- a/driver-core/src/test/functional/com/mongodb/connection/TestCommandListener.java
+++ b/driver-core/src/test/functional/com/mongodb/connection/TestCommandListener.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.mongodb.connection;
+
+import com.mongodb.event.CommandCompletedEvent;
+import com.mongodb.event.CommandEvent;
+import com.mongodb.event.CommandFailedEvent;
+import com.mongodb.event.CommandListener;
+import com.mongodb.event.CommandStartedEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class TestCommandListener implements CommandListener {
+    private final List<CommandEvent> events = new ArrayList<CommandEvent>();
+    private final int firstRequestId = RequestMessage.getCurrentGlobalId();
+    @Override
+    public void commandStarted(final CommandStartedEvent event) {
+        events.add(new CommandStartedEvent(event.getRequestId(), event.getConnectionDescription(), event.getDatabaseName(),
+                                           event.getCommandName(), event.getCommand() == null ? null : event.getCommand().clone()));
+    }
+
+    @Override
+    public void commandCompleted(final CommandCompletedEvent event) {
+        events.add(new CommandCompletedEvent(event.getRequestId(), event.getConnectionDescription(), event.getCommandName(),
+                                             event.getResponse() == null ? null : event.getResponse().clone(),
+                                             event.getElapsedTime(TimeUnit.NANOSECONDS)));
+    }
+
+    @Override
+    public void commandFailed(final CommandFailedEvent event) {
+        events.add(event);
+    }
+
+    boolean eventsWereDelivered(final List<CommandEvent> expectedEvents) {
+        if (expectedEvents.size() != events.size()) {
+            return false;
+        }
+        int currentlyExpectedRequestId = firstRequestId;
+        for (int i = 0; i < events.size(); i++) {
+            CommandEvent actual = events.get(i);
+            CommandEvent expected = expectedEvents.get(i);
+            if (!actual.getClass().equals(expected.getClass())) {
+                return false;
+            }
+
+            if (actual.getRequestId() != currentlyExpectedRequestId) {
+                return false;
+            }
+
+            if (!(actual instanceof CommandStartedEvent)) {
+                currentlyExpectedRequestId++;
+            }
+
+            if (!actual.getConnectionDescription().equals(expected.getConnectionDescription())) {
+                return false;
+            }
+
+            if (!actual.getCommandName().equals(expected.getCommandName())) {
+                return false;
+            }
+
+            if (actual.getClass().equals(CommandStartedEvent.class)) {
+                if (!isEquivalent((CommandStartedEvent) actual, (CommandStartedEvent) expected)) {
+                    return false;
+                }
+            } else if (actual.getClass().equals(CommandCompletedEvent.class)) {
+                if (!isEquivalent((CommandCompletedEvent) actual, (CommandCompletedEvent) expected)) {
+                    return false;
+                }
+            } else if (actual.getClass().equals(CommandFailedEvent.class)) {
+                if (!isEquivalent((CommandFailedEvent) actual, (CommandFailedEvent) expected)) {
+                    return false;
+                }
+            } else {
+                throw new UnsupportedOperationException("Unsupported event type: " + actual.getClass());
+            }
+        }
+
+        return true;
+    }
+
+    private boolean isEquivalent(final CommandFailedEvent actual, final CommandFailedEvent expected) {
+        if (!actual.getThrowable().equals(expected.getThrowable())) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isEquivalent(final CommandCompletedEvent actual, final CommandCompletedEvent expected) {
+        if (actual.getResponse() == null) {
+            return expected.getResponse() == null;
+        }
+        if (!actual.getResponse().equals(expected.getResponse())) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isEquivalent(final CommandStartedEvent actual, final CommandStartedEvent expected) {
+        if (!actual.getDatabaseName().equals(expected.getDatabaseName())) {
+            return false;
+        }
+        if (!actual.getCommand().equals(expected.getCommand())) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/driver-core/src/test/functional/com/mongodb/connection/TestCommandListener.java
+++ b/driver-core/src/test/functional/com/mongodb/connection/TestCommandListener.java
@@ -18,11 +18,11 @@
 
 package com.mongodb.connection;
 
-import com.mongodb.event.CommandCompletedEvent;
 import com.mongodb.event.CommandEvent;
 import com.mongodb.event.CommandFailedEvent;
 import com.mongodb.event.CommandListener;
 import com.mongodb.event.CommandStartedEvent;
+import com.mongodb.event.CommandSucceededEvent;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,8 +38,8 @@ public class TestCommandListener implements CommandListener {
     }
 
     @Override
-    public void commandCompleted(final CommandCompletedEvent event) {
-        events.add(new CommandCompletedEvent(event.getRequestId(), event.getConnectionDescription(), event.getCommandName(),
+    public void commandSucceeded(final CommandSucceededEvent event) {
+        events.add(new CommandSucceededEvent(event.getRequestId(), event.getConnectionDescription(), event.getCommandName(),
                                              event.getResponse() == null ? null : event.getResponse().clone(),
                                              event.getElapsedTime(TimeUnit.NANOSECONDS)));
     }
@@ -81,8 +81,8 @@ public class TestCommandListener implements CommandListener {
                 if (!isEquivalent((CommandStartedEvent) actual, (CommandStartedEvent) expected)) {
                     return false;
                 }
-            } else if (actual.getClass().equals(CommandCompletedEvent.class)) {
-                if (!isEquivalent((CommandCompletedEvent) actual, (CommandCompletedEvent) expected)) {
+            } else if (actual.getClass().equals(CommandSucceededEvent.class)) {
+                if (!isEquivalent((CommandSucceededEvent) actual, (CommandSucceededEvent) expected)) {
                     return false;
                 }
             } else if (actual.getClass().equals(CommandFailedEvent.class)) {
@@ -104,7 +104,7 @@ public class TestCommandListener implements CommandListener {
         return true;
     }
 
-    private boolean isEquivalent(final CommandCompletedEvent actual, final CommandCompletedEvent expected) {
+    private boolean isEquivalent(final CommandSucceededEvent actual, final CommandSucceededEvent expected) {
         if (actual.getResponse() == null) {
             return expected.getResponse() == null;
         }

--- a/driver-core/src/test/functional/com/mongodb/connection/WriteCommandProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/WriteCommandProtocolCommandEventSpecification.groovy
@@ -22,9 +22,9 @@ import com.mongodb.MongoBulkWriteException
 import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.bulk.InsertRequest
 import com.mongodb.connection.netty.NettyStreamFactory
-import com.mongodb.event.CommandCompletedEvent
 import com.mongodb.event.CommandFailedEvent
 import com.mongodb.event.CommandStartedEvent
+import com.mongodb.event.CommandSucceededEvent
 import org.bson.BsonArray
 import org.bson.BsonBoolean
 import org.bson.BsonDocument
@@ -72,7 +72,7 @@ class WriteCommandProtocolCommandEventSpecification extends OperationFunctionalS
                                                                              .append('ordered', BsonBoolean.TRUE)
                                                                              .append('documents', new BsonArray(
                                                                              [new BsonDocument('_id', new BsonInt32(1))]))),
-                                             new CommandCompletedEvent(1, connection.getDescription(), 'insert',
+                                             new CommandSucceededEvent(1, connection.getDescription(), 'insert',
                                                                        new BsonDocument('ok', new BsonInt32(1))
                                                                                .append('n', new BsonInt32(1)),
                                                                        0)])

--- a/driver-core/src/test/functional/com/mongodb/connection/WriteCommandProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/WriteCommandProtocolCommandEventSpecification.groovy
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.mongodb.connection
+
+import com.mongodb.MongoBulkWriteException
+import com.mongodb.OperationFunctionalSpecification
+import com.mongodb.bulk.InsertRequest
+import com.mongodb.connection.netty.NettyStreamFactory
+import com.mongodb.event.CommandCompletedEvent
+import com.mongodb.event.CommandFailedEvent
+import com.mongodb.event.CommandStartedEvent
+import org.bson.BsonArray
+import org.bson.BsonBoolean
+import org.bson.BsonDocument
+import org.bson.BsonInt32
+import org.bson.BsonString
+import spock.lang.IgnoreIf
+
+import static com.mongodb.ClusterFixture.getCredentialList
+import static com.mongodb.ClusterFixture.getPrimary
+import static com.mongodb.ClusterFixture.getSslSettings
+import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.WriteConcern.ACKNOWLEDGED
+
+@IgnoreIf({ !serverVersionAtLeast([2, 6, 0]) })
+class WriteCommandProtocolCommandEventSpecification extends OperationFunctionalSpecification {
+    static InternalStreamConnection connection;
+
+    def setupSpec() {
+        connection = new InternalStreamConnectionFactory(new NettyStreamFactory(SocketSettings.builder().build(), getSslSettings()),
+                                                         getCredentialList(), new NoOpConnectionListener())
+                .create(new ServerId(new ClusterId(), getPrimary()))
+        connection.open();
+    }
+
+    def cleanupSpec() {
+        connection?.close()
+    }
+
+    def 'should deliver start and completed command events'() {
+        given:
+        def document = new BsonDocument('_id', new BsonInt32(1))
+
+        def insertRequest = [new InsertRequest(document)]
+        def protocol = new InsertCommandProtocol(getNamespace(), true, ACKNOWLEDGED, insertRequest)
+
+        def commandListener = new TestCommandListener()
+        protocol.commandListener = commandListener
+
+        when:
+        protocol.execute(connection)
+
+        then:
+        commandListener.eventsWereDelivered([new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'insert',
+                                                                     new BsonDocument('insert', new BsonString(getCollectionName()))
+                                                                             .append('ordered', BsonBoolean.TRUE)
+                                                                             .append('documents', new BsonArray(
+                                                                             [new BsonDocument('_id', new BsonInt32(1))]))),
+                                             new CommandCompletedEvent(1, connection.getDescription(), 'insert',
+                                                                       new BsonDocument('ok', new BsonInt32(1))
+                                                                               .append('n', new BsonInt32(1)),
+                                                                       0)])
+    }
+
+    def 'should deliver start and failed command events'() {
+        given:
+        def document = new BsonDocument('_id', new BsonInt32(1))
+
+        def insertRequest = [new InsertRequest(document)]
+        def protocol = new InsertCommandProtocol(getNamespace(), true, ACKNOWLEDGED, insertRequest)
+        protocol.execute(connection)  // insert here, to force a duplicate key error on the second time
+
+        def commandListener = new TestCommandListener()
+        protocol.commandListener = commandListener
+
+        when:
+        protocol.execute(connection)
+
+        then:
+        def e = thrown(MongoBulkWriteException)
+        commandListener.eventsWereDelivered([new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'insert',
+                                                                     new BsonDocument('insert', new BsonString(getCollectionName()))
+                                                                             .append('ordered', BsonBoolean.TRUE)
+                                                                             .append('documents', new BsonArray(
+                                                                             [new BsonDocument('_id', new BsonInt32(1))]))),
+                                             new CommandFailedEvent(1, connection.getDescription(), 'insert', 0, e)])
+    }
+}

--- a/driver-core/src/test/functional/com/mongodb/connection/WriteCommandProtocolSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/WriteCommandProtocolSpecification.groovy
@@ -18,8 +18,8 @@
 package com.mongodb.connection
 
 import category.Slow
-import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.MongoBulkWriteException
+import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.bulk.BulkWriteUpsert
 import com.mongodb.bulk.InsertRequest
 import com.mongodb.bulk.UpdateRequest
@@ -41,16 +41,16 @@ import static com.mongodb.WriteConcern.ACKNOWLEDGED
 @IgnoreIf({ !serverVersionAtLeast([2, 6, 0]) })
 class WriteCommandProtocolSpecification extends OperationFunctionalSpecification {
 
-    InternalStreamConnection connection;
+    static InternalStreamConnection connection;
 
-    def setup() {
+    def setupSpec() {
         connection = new InternalStreamConnectionFactory(new NettyStreamFactory(SocketSettings.builder().build(), getSslSettings()),
                                                          getCredentialList(), new NoOpConnectionListener())
                 .create(new ServerId(new ClusterId(), getPrimary()))
         connection.open();
     }
 
-    def cleanup() {
+    def cleanupSpec() {
         connection?.close()
     }
 

--- a/driver-core/src/test/functional/com/mongodb/connection/WriteProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/WriteProtocolCommandEventSpecification.groovy
@@ -28,11 +28,11 @@ import com.mongodb.event.CommandCompletedEvent
 import com.mongodb.event.CommandFailedEvent
 import com.mongodb.event.CommandStartedEvent
 import org.bson.BsonArray
+import org.bson.BsonBinary
 import org.bson.BsonBoolean
 import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.BsonString
-import spock.lang.Ignore
 
 import static com.mongodb.ClusterFixture.getCredentialList
 import static com.mongodb.ClusterFixture.getPrimary
@@ -55,7 +55,7 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
         connection?.close()
     }
 
-    def 'should deliver start and completed command events for a single unacknowleded insert'() {
+    def 'should deliver started and completed command events for a single unacknowleded insert'() {
         given:
         def document = new BsonDocument('_id', new BsonInt32(1))
 
@@ -75,10 +75,49 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
                                                                                      new BsonDocument('w', new BsonInt32(0)))
                                                                              .append('documents', new BsonArray(
                                                                              [new BsonDocument('_id', new BsonInt32(1))]))),
-                                             new CommandCompletedEvent(1, connection.getDescription(), 'insert', null, 0)])
+                                             new CommandCompletedEvent(1, connection.getDescription(), 'insert',
+                                                                       new BsonDocument('ok', new BsonInt32(1)), 0)])
     }
 
-    def 'should deliver start and failed command events'() {
+    def 'should deliver started and completed command events for split unacknowleded inserts'() {
+        given:
+        def binary = new BsonBinary(new byte[15000000])
+        def documentOne = new BsonDocument('_id', new BsonInt32(1)).append('b', binary)
+        def documentTwo = new BsonDocument('_id', new BsonInt32(2)).append('b', binary)
+        def documentThree = new BsonDocument('_id', new BsonInt32(3)).append('b', binary)
+        def documentFour = new BsonDocument('_id', new BsonInt32(4)).append('b', binary)
+
+        def insertRequest = [new InsertRequest(documentOne), new InsertRequest(documentTwo),
+                             new InsertRequest(documentThree), new InsertRequest(documentFour)]
+        def protocol = new InsertProtocol(getNamespace(), true, UNACKNOWLEDGED, insertRequest)
+        def commandListener = new TestCommandListener()
+        protocol.commandListener = commandListener
+
+        when:
+        protocol.execute(connection)
+
+        then:
+        commandListener.eventsWereDelivered([new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'insert',
+                                                                     new BsonDocument('insert', new BsonString(getCollectionName()))
+                                                                             .append('ordered', BsonBoolean.TRUE)
+                                                                             .append('writeConcern',
+                                                                                     new BsonDocument('w', new BsonInt32(0)))
+                                                                             .append('documents',
+                                                                                     new BsonArray([documentOne, documentTwo,
+                                                                                                    documentThree]))),
+                                             new CommandCompletedEvent(1, connection.getDescription(), 'insert',
+                                                                       new BsonDocument('ok', new BsonInt32(1)), 0),
+                                             new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'insert',
+                                                                     new BsonDocument('insert', new BsonString(getCollectionName()))
+                                                                             .append('ordered', BsonBoolean.TRUE)
+                                                                             .append('writeConcern',
+                                                                                     new BsonDocument('w', new BsonInt32(0)))
+                                                                             .append('documents', new BsonArray([documentFour]))),
+                                             new CommandCompletedEvent(1, connection.getDescription(), 'insert',
+                                                                       new BsonDocument('ok', new BsonInt32(1)), 0)])
+    }
+
+    def 'should deliver started and failed command events'() {
         given:
         def document = new BsonDocument('_id', new BsonInt32(1))
 
@@ -102,7 +141,7 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
                                              new CommandFailedEvent(1, connection.getDescription(), 'insert', 0, e)])
     }
 
-    def 'should deliver start and completed command events for a single unacknowleded update'() {
+    def 'should deliver started and completed command events for a single unacknowleded update'() {
         given:
         def filter = new BsonDocument('_id', new BsonInt32(1))
         def update = new BsonDocument('$set', new BsonDocument('x', new BsonInt32(1)))
@@ -125,10 +164,11 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
                                                                                       .append('u', update)
                                                                                       .append('multi', BsonBoolean.TRUE)
                                                                                       .append('upsert', BsonBoolean.TRUE)]))),
-                                             new CommandCompletedEvent(1, connection.getDescription(), 'update', null, 0)])
+                                             new CommandCompletedEvent(1, connection.getDescription(), 'update',
+                                                                       new BsonDocument('ok', new BsonInt32(1)), 0)])
     }
 
-    def 'should deliver start and completed command events for a single unacknowleded delete'() {
+    def 'should deliver started and completed command events for a single unacknowleded delete'() {
         given:
         def filter = new BsonDocument('_id', new BsonInt32(1))
         def deleteRequest = [new DeleteRequest(filter).multi(true)]
@@ -148,12 +188,11 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
                                                                              .append('deletes', new BsonArray(
                                                                              [new BsonDocument('q', filter)
                                                                                       .append('limit', new BsonInt32(0))]))),
-                                             new CommandCompletedEvent(1, connection.getDescription(), 'delete', null, 0)])
+                                             new CommandCompletedEvent(1, connection.getDescription(), 'delete',
+                                                                       new BsonDocument('ok', new BsonInt32(1)), 0)])
     }
 
-    // TODO: implement this
-    @Ignore
-    def 'should deliver start and completed command events for a single acknowleded insert'() {
+    def 'should deliver started and completed command events for a single acknowleded insert'() {
         given:
         def document = new BsonDocument('_id', new BsonInt32(1))
 
@@ -172,7 +211,6 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
                                                                              .append('documents', new BsonArray(
                                                                              [new BsonDocument('_id', new BsonInt32(1))]))),
                                              new CommandCompletedEvent(1, connection.getDescription(), 'insert',
-                                                                       new BsonDocument('ok', new BsonInt32(1))
-                                                                       , 0)])
+                                                                       new BsonDocument('ok', new BsonInt32(1)), 0)])
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/connection/WriteProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/WriteProtocolCommandEventSpecification.groovy
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.mongodb.connection
+
+import com.mongodb.DuplicateKeyException
+import com.mongodb.OperationFunctionalSpecification
+import com.mongodb.bulk.DeleteRequest
+import com.mongodb.bulk.InsertRequest
+import com.mongodb.bulk.UpdateRequest
+import com.mongodb.connection.netty.NettyStreamFactory
+import com.mongodb.event.CommandCompletedEvent
+import com.mongodb.event.CommandFailedEvent
+import com.mongodb.event.CommandStartedEvent
+import org.bson.BsonArray
+import org.bson.BsonBoolean
+import org.bson.BsonDocument
+import org.bson.BsonInt32
+import org.bson.BsonString
+import spock.lang.Ignore
+
+import static com.mongodb.ClusterFixture.getCredentialList
+import static com.mongodb.ClusterFixture.getPrimary
+import static com.mongodb.ClusterFixture.getSslSettings
+import static com.mongodb.WriteConcern.ACKNOWLEDGED
+import static com.mongodb.WriteConcern.UNACKNOWLEDGED
+import static com.mongodb.bulk.WriteRequest.Type.UPDATE
+
+class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecification {
+    static InternalStreamConnection connection;
+
+    def setupSpec() {
+        connection = new InternalStreamConnectionFactory(new NettyStreamFactory(SocketSettings.builder().build(), getSslSettings()),
+                                                         getCredentialList(), new NoOpConnectionListener())
+                .create(new ServerId(new ClusterId(), getPrimary()))
+        connection.open();
+    }
+
+    def cleanupSpec() {
+        connection?.close()
+    }
+
+    def 'should deliver start and completed command events for a single unacknowleded insert'() {
+        given:
+        def document = new BsonDocument('_id', new BsonInt32(1))
+
+        def insertRequest = [new InsertRequest(document)]
+        def protocol = new InsertProtocol(getNamespace(), true, UNACKNOWLEDGED, insertRequest)
+        def commandListener = new TestCommandListener()
+        protocol.commandListener = commandListener
+
+        when:
+        protocol.execute(connection)
+
+        then:
+        commandListener.eventsWereDelivered([new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'insert',
+                                                                     new BsonDocument('insert', new BsonString(getCollectionName()))
+                                                                             .append('ordered', BsonBoolean.TRUE)
+                                                                             .append('writeConcern',
+                                                                                     new BsonDocument('w', new BsonInt32(0)))
+                                                                             .append('documents', new BsonArray(
+                                                                             [new BsonDocument('_id', new BsonInt32(1))]))),
+                                             new CommandCompletedEvent(1, connection.getDescription(), 'insert', null, 0)])
+    }
+
+    def 'should deliver start and failed command events'() {
+        given:
+        def document = new BsonDocument('_id', new BsonInt32(1))
+
+        def insertRequest = [new InsertRequest(document)]
+        def protocol = new InsertProtocol(getNamespace(), true, ACKNOWLEDGED, insertRequest)
+        protocol.execute(connection)  // insert here, to force a duplicate key error on the second time
+
+        def commandListener = new TestCommandListener()
+        protocol.commandListener = commandListener
+
+        when:
+        protocol.execute(connection)
+
+        then:
+        def e = thrown(DuplicateKeyException)
+        commandListener.eventsWereDelivered([new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'insert',
+                                                                     new BsonDocument('insert', new BsonString(getCollectionName()))
+                                                                             .append('ordered', BsonBoolean.TRUE)
+                                                                             .append('documents', new BsonArray(
+                                                                             [new BsonDocument('_id', new BsonInt32(1))]))),
+                                             new CommandFailedEvent(1, connection.getDescription(), 'insert', 0, e)])
+    }
+
+    def 'should deliver start and completed command events for a single unacknowleded update'() {
+        given:
+        def filter = new BsonDocument('_id', new BsonInt32(1))
+        def update = new BsonDocument('$set', new BsonDocument('x', new BsonInt32(1)))
+        def updateRequest = [new UpdateRequest(filter, update, UPDATE).multi(true).upsert(true)]
+        def protocol = new UpdateProtocol(getNamespace(), true, UNACKNOWLEDGED, updateRequest)
+        def commandListener = new TestCommandListener()
+        protocol.commandListener = commandListener
+
+        when:
+        protocol.execute(connection)
+
+        then:
+        commandListener.eventsWereDelivered([new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'update',
+                                                                     new BsonDocument('update', new BsonString(getCollectionName()))
+                                                                             .append('ordered', BsonBoolean.TRUE)
+                                                                             .append('writeConcern',
+                                                                                     new BsonDocument('w', new BsonInt32(0)))
+                                                                             .append('updates', new BsonArray(
+                                                                             [new BsonDocument('q', filter)
+                                                                                      .append('u', update)
+                                                                                      .append('multi', BsonBoolean.TRUE)
+                                                                                      .append('upsert', BsonBoolean.TRUE)]))),
+                                             new CommandCompletedEvent(1, connection.getDescription(), 'update', null, 0)])
+    }
+
+    def 'should deliver start and completed command events for a single unacknowleded delete'() {
+        given:
+        def filter = new BsonDocument('_id', new BsonInt32(1))
+        def deleteRequest = [new DeleteRequest(filter).multi(true)]
+        def protocol = new DeleteProtocol(getNamespace(), true, UNACKNOWLEDGED, deleteRequest)
+        def commandListener = new TestCommandListener()
+        protocol.commandListener = commandListener
+
+        when:
+        protocol.execute(connection)
+
+        then:
+        commandListener.eventsWereDelivered([new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'delete',
+                                                                     new BsonDocument('delete', new BsonString(getCollectionName()))
+                                                                             .append('ordered', BsonBoolean.TRUE)
+                                                                             .append('writeConcern',
+                                                                                     new BsonDocument('w', new BsonInt32(0)))
+                                                                             .append('deletes', new BsonArray(
+                                                                             [new BsonDocument('q', filter)
+                                                                                      .append('limit', new BsonInt32(0))]))),
+                                             new CommandCompletedEvent(1, connection.getDescription(), 'delete', null, 0)])
+    }
+
+    // TODO: implement this
+    @Ignore
+    def 'should deliver start and completed command events for a single acknowleded insert'() {
+        given:
+        def document = new BsonDocument('_id', new BsonInt32(1))
+
+        def insertRequest = [new InsertRequest(document)]
+        def protocol = new InsertProtocol(getNamespace(), true, ACKNOWLEDGED, insertRequest)
+        def commandListener = new TestCommandListener()
+        protocol.commandListener = commandListener
+
+        when:
+        protocol.execute(connection)
+
+        then:
+        commandListener.eventsWereDelivered([new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'insert',
+                                                                     new BsonDocument('insert', new BsonString(getCollectionName()))
+                                                                             .append('ordered', BsonBoolean.TRUE)
+                                                                             .append('documents', new BsonArray(
+                                                                             [new BsonDocument('_id', new BsonInt32(1))]))),
+                                             new CommandCompletedEvent(1, connection.getDescription(), 'insert',
+                                                                       new BsonDocument('ok', new BsonInt32(1))
+                                                                       , 0)])
+    }
+}

--- a/driver-core/src/test/functional/com/mongodb/connection/WriteProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/WriteProtocolCommandEventSpecification.groovy
@@ -24,9 +24,9 @@ import com.mongodb.bulk.DeleteRequest
 import com.mongodb.bulk.InsertRequest
 import com.mongodb.bulk.UpdateRequest
 import com.mongodb.connection.netty.NettyStreamFactory
-import com.mongodb.event.CommandCompletedEvent
 import com.mongodb.event.CommandFailedEvent
 import com.mongodb.event.CommandStartedEvent
+import com.mongodb.event.CommandSucceededEvent
 import org.bson.BsonArray
 import org.bson.BsonBinary
 import org.bson.BsonBoolean
@@ -75,7 +75,7 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
                                                                                      new BsonDocument('w', new BsonInt32(0)))
                                                                              .append('documents', new BsonArray(
                                                                              [new BsonDocument('_id', new BsonInt32(1))]))),
-                                             new CommandCompletedEvent(1, connection.getDescription(), 'insert',
+                                             new CommandSucceededEvent(1, connection.getDescription(), 'insert',
                                                                        new BsonDocument('ok', new BsonInt32(1)), 0)])
     }
 
@@ -105,7 +105,7 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
                                                                              .append('documents',
                                                                                      new BsonArray([documentOne, documentTwo,
                                                                                                     documentThree]))),
-                                             new CommandCompletedEvent(1, connection.getDescription(), 'insert',
+                                             new CommandSucceededEvent(1, connection.getDescription(), 'insert',
                                                                        new BsonDocument('ok', new BsonInt32(1)), 0),
                                              new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'insert',
                                                                      new BsonDocument('insert', new BsonString(getCollectionName()))
@@ -113,7 +113,7 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
                                                                              .append('writeConcern',
                                                                                      new BsonDocument('w', new BsonInt32(0)))
                                                                              .append('documents', new BsonArray([documentFour]))),
-                                             new CommandCompletedEvent(1, connection.getDescription(), 'insert',
+                                             new CommandSucceededEvent(1, connection.getDescription(), 'insert',
                                                                        new BsonDocument('ok', new BsonInt32(1)), 0)])
     }
 
@@ -164,7 +164,7 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
                                                                                       .append('u', update)
                                                                                       .append('multi', BsonBoolean.TRUE)
                                                                                       .append('upsert', BsonBoolean.TRUE)]))),
-                                             new CommandCompletedEvent(1, connection.getDescription(), 'update',
+                                             new CommandSucceededEvent(1, connection.getDescription(), 'update',
                                                                        new BsonDocument('ok', new BsonInt32(1)), 0)])
     }
 
@@ -188,7 +188,7 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
                                                                              .append('deletes', new BsonArray(
                                                                              [new BsonDocument('q', filter)
                                                                                       .append('limit', new BsonInt32(0))]))),
-                                             new CommandCompletedEvent(1, connection.getDescription(), 'delete',
+                                             new CommandSucceededEvent(1, connection.getDescription(), 'delete',
                                                                        new BsonDocument('ok', new BsonInt32(1)), 0)])
     }
 
@@ -210,7 +210,7 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
                                                                              .append('ordered', BsonBoolean.TRUE)
                                                                              .append('documents', new BsonArray(
                                                                              [new BsonDocument('_id', new BsonInt32(1))]))),
-                                             new CommandCompletedEvent(1, connection.getDescription(), 'insert',
+                                             new CommandSucceededEvent(1, connection.getDescription(), 'insert',
                                                                        new BsonDocument('ok', new BsonInt32(1)), 0)])
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/connection/WriteProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/WriteProtocolCommandEventSpecification.groovy
@@ -135,7 +135,7 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
         protocol.execute(connection)
 
         then:
-        def e = thrown(DuplicateKeyException)
+        thrown(DuplicateKeyException)
         commandListener.eventsWereDelivered([new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'insert',
                                                                      new BsonDocument('insert', new BsonString(getCollectionName()))
                                                                              .append('ordered', BsonBoolean.TRUE)
@@ -244,6 +244,70 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
                                                                              .append('documents', new BsonArray(
                                                                              [new BsonDocument('_id', new BsonInt32(1))]))),
                                              new CommandSucceededEvent(1, connection.getDescription(), 'insert',
-                                                                       new BsonDocument('ok', new BsonInt32(1)), 0)])
+                                                                       new BsonDocument('ok', new BsonInt32(1))
+                                                                               .append('n', new BsonInt32(1)),
+                                                                       0)])
     }
+
+    def 'should deliver started and completed command events for a single acknowleded delete'() {
+        given:
+        def document = new BsonDocument('_id', new BsonInt32(1))
+
+        def insertRequest = [new InsertRequest(document)]
+        def protocol = new InsertProtocol(getNamespace(), true, ACKNOWLEDGED, insertRequest)
+        protocol.execute(connection)
+
+        def deleteRequest = [new DeleteRequest(document)]
+        protocol = new DeleteProtocol(getNamespace(), true, ACKNOWLEDGED, deleteRequest)
+        def commandListener = new TestCommandListener()
+        protocol.commandListener = commandListener
+
+        when:
+        protocol.execute(connection)
+
+        then:
+        commandListener.eventsWereDelivered([new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'delete',
+                                                                     new BsonDocument('delete', new BsonString(getCollectionName()))
+                                                                             .append('ordered', BsonBoolean.TRUE)
+                                                                             .append('deletes', new BsonArray(
+                                                                             [new BsonDocument('q', document)
+                                                                                      .append('limit', new BsonInt32(0))]))),
+                                             new CommandSucceededEvent(1, connection.getDescription(), 'delete',
+                                                                       new BsonDocument('ok', new BsonInt32(1))
+                                                                               .append('n', new BsonInt32(1)),
+                                                                       0)])
+    }
+
+    def 'should deliver started and completed command events for a single acknowleded update'() {
+        given:
+        def filter = new BsonDocument('_id', new BsonInt32(1))
+        def update = new BsonDocument('$set', new BsonDocument('x', new BsonInt32(1)))
+        def updateRequest = [new UpdateRequest(filter, update, UPDATE).multi(true).upsert(true)]
+        def protocol = new UpdateProtocol(getNamespace(), true, ACKNOWLEDGED, updateRequest)
+        def commandListener = new TestCommandListener()
+        protocol.commandListener = commandListener
+
+        when:
+        protocol.execute(connection)
+
+        then:
+        commandListener.eventsWereDelivered([new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'update',
+                                                                     new BsonDocument('update', new BsonString(getCollectionName()))
+                                                                             .append('ordered', BsonBoolean.TRUE)
+                                                                             .append('updates', new BsonArray(
+                                                                             [new BsonDocument('q', filter)
+                                                                                      .append('u', update)
+                                                                                      .append('multi', BsonBoolean.TRUE)
+                                                                                      .append('upsert', BsonBoolean.TRUE)]))),
+                                             new CommandSucceededEvent(1, connection.getDescription(), 'update',
+                                                                       new BsonDocument('ok', new BsonInt32(1))
+                                                                               .append('n', new BsonInt32(1))
+                                                                               .append('upserted',
+                                                                                       new BsonArray([new BsonDocument('index',
+                                                                                                                       new BsonInt32(0))
+                                                                                                              .append('_id',
+                                                                                                                      filter.get('_id'))])),
+                                                                       0)])
+    }
+
 }

--- a/driver-core/src/test/functional/com/mongodb/operation/FindOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/FindOperationSpecification.groovy
@@ -314,7 +314,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
                                                                 new ServerVersion(2, 6), ServerType.STANDALONE, 1000, 100000, 100000)
 
         1 * connection.query(getNamespace(), findOperation.filter,
-                             findOperation.projection, 0, 0, false, false, false, false, false, false, _) >>
+                             findOperation.projection, 0, 0, 0, false, false, false, false, false, false, _) >>
         new QueryResult(getNamespace(), [new BsonDocument('n', new BsonInt32(1))], 0, new ServerAddress())
 
         1 * connection.release()
@@ -346,7 +346,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
         1 * connection.query(getNamespace(),
                              new BsonDocument('$query', findOperation.filter).append('$explain', BsonBoolean.TRUE)
                                                                              .append('$orderby', findOperation.sort),
-                             findOperation.projection, -20, 0, false, false, false, false, false, false, _) >>
+                             findOperation.projection, 0, -20, 0, false, false, false, false, false, false, _) >>
         new QueryResult(getNamespace(), [new BsonDocument('n', new BsonInt32(1))], 0, new ServerAddress())
 
         1 * connection.release()

--- a/driver-core/src/test/unit/com/mongodb/WriteConcernSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/WriteConcernSpecification.groovy
@@ -88,6 +88,7 @@ class WriteConcernSpecification extends Specification {
 
         where:
         wc                                | commandDocument
+        WriteConcern.UNACKNOWLEDGED       | new BsonDocument('w', new BsonInt32(0))
         WriteConcern.ACKNOWLEDGED         | new BsonDocument('w', new BsonInt32(1))
         WriteConcern.REPLICA_ACKNOWLEDGED | new BsonDocument('w', new BsonInt32(2))
         WriteConcern.JOURNALED            | new BsonDocument('w', new BsonInt32(1)).append('j', BsonBoolean.TRUE)

--- a/driver-core/src/test/unit/com/mongodb/connection/ByteBufBsonDocumentSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/ByteBufBsonDocumentSpecification.groovy
@@ -201,6 +201,21 @@ class ByteBufBsonDocumentSpecification extends Specification {
         cloned == rawDocument
     }
 
+    def 'should serialize and deserialize'() {
+        given:
+        def baos = new ByteArrayOutputStream()
+        def oos = new ObjectOutputStream(baos)
+
+        when:
+        oos.writeObject(rawDocument)
+        def bais = new ByteArrayInputStream(baos.toByteArray())
+        def ois = new ObjectInputStream(bais)
+        def deserializedDocument = ois.readObject()
+
+        then:
+        rawDocument == deserializedDocument
+    }
+
     class TestEntry implements Map.Entry<String, BsonValue> {
 
         private final String key;

--- a/driver-core/src/test/unit/com/mongodb/connection/ByteBufBsonDocumentSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/ByteBufBsonDocumentSpecification.groovy
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.connection
+
+import org.bson.BsonArray
+import org.bson.BsonBinaryWriter
+import org.bson.BsonBoolean
+import org.bson.BsonDocument
+import org.bson.BsonInt32
+import org.bson.BsonNull
+import org.bson.BsonValue
+import org.bson.ByteBufNIO
+import org.bson.codecs.BsonDocumentCodec
+import org.bson.codecs.EncoderContext
+import org.bson.io.BasicOutputBuffer
+import spock.lang.Specification
+
+import java.nio.ByteBuffer
+
+import static java.util.Arrays.asList
+import static util.GroovyHelpers.areEqual
+
+class ByteBufBsonDocumentSpecification extends Specification {
+    ByteBufBsonDocument emptyRawDocument = new ByteBufBsonDocument(new ByteBufNIO(ByteBuffer.wrap([5, 0, 0, 0, 0] as byte[])));
+    def document = new BsonDocument()
+            .append('a', new BsonInt32(1))
+            .append('b', new BsonInt32(2))
+            .append('c', new BsonDocument('x', BsonBoolean.TRUE))
+            .append('d', new BsonArray(asList(new BsonDocument('y', BsonBoolean.FALSE), new BsonInt32(1))))
+
+    ByteBufBsonDocument rawDocument
+
+    def setup() {
+        def buffer = new BasicOutputBuffer()
+        new BsonDocumentCodec().encode(new BsonBinaryWriter(buffer), document, EncoderContext.builder().build());
+        rawDocument = new ByteBufBsonDocument(new CompositeByteBuf(buffer.byteBuffers));
+    }
+
+    def 'get should get the value of the given key'() {
+        expect:
+        emptyRawDocument.get('a') == null
+        rawDocument.get('z') == null
+        rawDocument.get('a') == new BsonInt32(1)
+        rawDocument.get('b') == new BsonInt32(2)
+
+    }
+
+    def 'get should throw if the key is null'() {
+        when:
+        rawDocument.get(null)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def 'containKey should throw if the key name is null'() {
+        when:
+        rawDocument.containsKey(null)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def 'containsKey should find an existing key'() {
+        expect:
+        rawDocument.containsKey('a')
+        rawDocument.containsKey('b')
+        rawDocument.containsKey('c')
+        rawDocument.containsKey('d')
+    }
+
+    def 'containsKey should not find a non-existing key'() {
+        expect:
+        !rawDocument.containsKey('e')
+        !rawDocument.containsKey('x')
+        !rawDocument.containsKey('y')
+    }
+
+    def 'containValue should find an existing value'() {
+        expect:
+        rawDocument.containsValue(document.get('a'))
+        rawDocument.containsValue(document.get('b'))
+        rawDocument.containsValue(document.get('c'))
+        rawDocument.containsValue(document.get('d'))
+    }
+
+    def 'containValue should not find a non-existing value'() {
+        expect:
+        !rawDocument.containsValue(new BsonInt32(3))
+        !rawDocument.containsValue(new BsonDocument('e', BsonBoolean.FALSE))
+        !rawDocument.containsValue(new BsonArray(asList(new BsonInt32(2), new BsonInt32(4))))
+    }
+
+    def 'isEmpty should return false when the document is not empty'() {
+        expect:
+        !rawDocument.isEmpty()
+    }
+
+    def 'isEmpty should return true when the document is empty'() {
+        expect:
+        emptyRawDocument.isEmpty()
+    }
+
+    def 'should get correct size'() {
+        expect:
+        emptyRawDocument.size() == 0
+        rawDocument.size() == 4
+    }
+
+    def 'should get correct key set'() {
+        expect:
+        emptyRawDocument.keySet().isEmpty()
+        rawDocument.keySet() == ['a', 'b', 'c', 'd'] as Set
+    }
+
+    def 'should get correct values set'() {
+        expect:
+        emptyRawDocument.values().isEmpty()
+        rawDocument.values() as Set == [document.get('a'), document.get('b'), document.get('c'), document.get('d')] as Set
+    }
+
+    def 'should get correct entry set'() {
+        expect:
+        emptyRawDocument.entrySet().isEmpty()
+        rawDocument.entrySet() == [new TestEntry('a', document.get('a')),
+                                   new TestEntry('b', document.get('b')),
+                                   new TestEntry('c', document.get('c')),
+                                   new TestEntry('d', document.get('d'))] as Set
+    }
+
+    def 'all write methods should throw UnsupportedOperationException'() {
+        when:
+        rawDocument.clear()
+
+        then:
+        thrown(UnsupportedOperationException)
+
+        when:
+        rawDocument.put('x', BsonNull.VALUE)
+
+        then:
+        thrown(UnsupportedOperationException)
+
+        when:
+        rawDocument.append('x', BsonNull.VALUE)
+
+        then:
+        thrown(UnsupportedOperationException)
+
+        when:
+        rawDocument.putAll(new BsonDocument('x', BsonNull.VALUE))
+
+        then:
+        thrown(UnsupportedOperationException)
+
+        when:
+        rawDocument.remove(BsonNull.VALUE)
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def 'should get first key'() {
+        expect:
+        rawDocument.getFirstKey() == document.keySet().iterator().next()
+        emptyRawDocument.getFirstKey() == null
+    }
+
+    def 'hashCode should equal hash code of identical BsonDocument'() {
+        expect:
+        rawDocument.hashCode() == document.hashCode()
+    }
+
+    def 'equals should equal identical BsonDocument'() {
+        expect:
+        areEqual(rawDocument, document)
+        areEqual(document, rawDocument)
+        areEqual(rawDocument, rawDocument)
+        !areEqual(rawDocument, emptyRawDocument)
+    }
+
+    def 'clone should make a deep copy'() {
+        when:
+        BsonDocument cloned = rawDocument.clone()
+
+        then:
+        cloned == rawDocument
+    }
+
+    class TestEntry implements Map.Entry<String, BsonValue> {
+
+        private final String key;
+        private BsonValue value
+
+        TestEntry(String key, BsonValue value) {
+            this.key = key
+            this.value = value
+        }
+
+        @Override
+        String getKey() {
+            key
+        }
+
+        @Override
+        BsonValue getValue() {
+            value
+        }
+
+        @Override
+        BsonValue setValue(final BsonValue value) {
+            this.value = value
+        }
+    }
+
+}

--- a/driver-core/src/test/unit/com/mongodb/connection/CompositeByteBufSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/CompositeByteBufSpecification.groovy
@@ -1,0 +1,527 @@
+package com.mongodb.connection
+
+import org.bson.ByteBufNIO
+import spock.lang.Specification
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+class CompositeByteBufSpecification extends Specification {
+
+    def 'should throw if buffers is null'() {
+        when:
+        new CompositeByteBuf(null)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def 'should throw if buffers is empty'() {
+        when:
+        new CompositeByteBuf([])
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def 'reference count should be maintained'() {
+        when:
+        def buf = new CompositeByteBuf([new ByteBufNIO(ByteBuffer.wrap([1, 2, 3, 4] as byte[]))])
+
+        then:
+        buf.getReferenceCount() == 1
+
+        when:
+        buf.retain()
+
+        then:
+        buf.getReferenceCount() == 2
+
+        when:
+        buf.release()
+
+        then:
+        buf.getReferenceCount() == 1
+
+        when:
+        buf.release()
+
+        then:
+        buf.getReferenceCount() == 0
+
+        when:
+        buf.release()
+
+        then:
+        thrown(IllegalStateException)
+
+        when:
+        buf.retain()
+
+        then:
+        thrown(IllegalStateException)
+
+    }
+
+    def 'order should throw if not little endian'() {
+        when:
+        new CompositeByteBuf([new ByteBufNIO(ByteBuffer.wrap([1, 2, 3, 4] as byte[]))]).order(ByteOrder.BIG_ENDIAN)
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def 'order should return normally if little endian'() {
+        when:
+        new CompositeByteBuf([new ByteBufNIO(ByteBuffer.wrap([1, 2, 3, 4] as byte[]))]).order(ByteOrder.LITTLE_ENDIAN)
+
+        then:
+        true
+    }
+
+    def 'limit should be sum of limits of buffers'() {
+        expect:
+        new CompositeByteBuf([new ByteBufNIO(ByteBuffer.wrap([1, 2, 3, 4] as byte[]))]).limit() == 4
+        new CompositeByteBuf([new ByteBufNIO(ByteBuffer.wrap([1, 2, 3, 4] as byte[])),
+                              new ByteBufNIO(ByteBuffer.wrap([1, 2] as byte[]))]).limit() == 6
+    }
+
+    def 'capacity should be the initial limit'() {
+        expect:
+        new CompositeByteBuf([new ByteBufNIO(ByteBuffer.wrap([1, 2, 3, 4] as byte[]))]).capacity() == 4
+        new CompositeByteBuf([new ByteBufNIO(ByteBuffer.wrap([1, 2, 3, 4] as byte[])),
+                              new ByteBufNIO(ByteBuffer.wrap([1, 2] as byte[]))]).capacity() == 6
+    }
+
+    def 'position should be 0'() {
+        expect:
+        new CompositeByteBuf([new ByteBufNIO(ByteBuffer.wrap([1, 2, 3, 4] as byte[]))]).position() == 0
+    }
+
+    def 'position should be set if in range'() {
+        given:
+        def buf = new CompositeByteBuf([new ByteBufNIO(ByteBuffer.wrap([1, 2, 3] as byte[]))])
+
+        when:
+        buf.position(0)
+
+        then:
+        buf.position() == 0
+
+        when:
+        buf.position(1)
+
+        then:
+        buf.position() == 1
+
+        when:
+        buf.position(2)
+
+        then:
+        buf.position() == 2
+
+        when:
+        buf.position(3)
+
+        then:
+        buf.position() == 3
+    }
+
+    def 'position should throw if out of range'() {
+        given:
+        def buf = new CompositeByteBuf([new ByteBufNIO(ByteBuffer.wrap([1, 2, 3] as byte[]))])
+
+        when:
+        buf.position(-1)
+
+        then:
+        thrown(IndexOutOfBoundsException)
+
+        when:
+        buf.position(4)
+
+        then:
+        thrown(IndexOutOfBoundsException)
+
+        and:
+        buf.limit(2)
+
+        when:
+        buf.position(3)
+
+        then:
+        thrown(IndexOutOfBoundsException)
+    }
+
+    def 'limit should be set if in range'() {
+        given:
+        def buf = new CompositeByteBuf([new ByteBufNIO(ByteBuffer.wrap([1, 2, 3] as byte[]))])
+
+        when:
+        buf.limit(0)
+
+        then:
+        buf.limit() == 0
+
+        when:
+        buf.limit(1)
+
+        then:
+        buf.limit() == 1
+
+        when:
+        buf.limit(2)
+
+        then:
+        buf.limit() == 2
+
+        when:
+        buf.limit(3)
+
+        then:
+        buf.limit() == 3
+    }
+
+    def 'limit should throw if out of range'() {
+        given:
+        def buf = new CompositeByteBuf([new ByteBufNIO(ByteBuffer.wrap([1, 2, 3] as byte[]))])
+
+        when:
+        buf.limit(-1)
+
+        then:
+        thrown(IndexOutOfBoundsException)
+
+        when:
+        buf.limit(4)
+
+        then:
+        thrown(IndexOutOfBoundsException)
+    }
+
+    def 'clear should reset position and limit'() {
+        given:
+        def buf = new CompositeByteBuf([new ByteBufNIO(ByteBuffer.wrap([1, 2, 3] as byte[]))])
+        buf.limit(2)
+        buf.get()
+
+        when:
+        buf.clear()
+
+        then:
+        buf.position() == 0;
+        buf.limit() == 3
+    }
+
+
+    def 'duplicate should copy all properties'() {
+        given:
+        def buf = new CompositeByteBuf([new ByteBufNIO(ByteBuffer.wrap([1, 2, 1, 2, 3, 4, 1, 2] as byte[]))])
+        buf.limit(6)
+        buf.get()
+        buf.get()
+
+        when:
+        def duplicate = buf.duplicate()
+
+        then:
+        duplicate.position() == 2;
+        duplicate.limit() == 6
+        duplicate.getInt() == 67305985
+        !duplicate.hasRemaining()
+        buf.position() == 2
+    }
+
+
+    def 'position, remaining, and hasRemaining should update as bytes are read'() {
+        when:
+        def buf = new CompositeByteBuf([new ByteBufNIO(ByteBuffer.wrap([1, 2, 3, 4] as byte[]))])
+
+        then:
+        buf.position() == 0
+        buf.remaining() == 4
+        buf.hasRemaining()
+
+        when:
+        buf.get()
+
+        then:
+        buf.position() == 1
+        buf.remaining() == 3
+        buf.hasRemaining()
+
+        when:
+        buf.get()
+
+        then:
+        buf.position() == 2
+        buf.remaining() == 2
+        buf.hasRemaining()
+
+        when:
+        buf.get()
+
+        then:
+        buf.position() == 3
+        buf.remaining() == 1
+        buf.hasRemaining()
+
+        when:
+        buf.get()
+
+        then:
+        buf.position() == 4
+        buf.remaining() == 0
+        !buf.hasRemaining()
+    }
+
+    def 'absolute getInt should read little endian integer and preserve position'() {
+        given:
+        def byteBuffer = new ByteBufNIO(ByteBuffer.wrap([1, 2, 3, 4] as byte[]))
+        def buf = new CompositeByteBuf([byteBuffer])
+
+        when:
+        def i = buf.getInt(0)
+
+        then:
+        i == 67305985
+        buf.position() == 0
+        byteBuffer.position() == 0
+    }
+
+    def 'absolute getInt should read little endian integer when integer is split accross buffers'() {
+        given:
+        def byteBufferOne = new ByteBufNIO(ByteBuffer.wrap([1, 2] as byte[]))
+        def byteBufferTwo = new ByteBufNIO(ByteBuffer.wrap([3, 4] as byte[]))
+        def buf = new CompositeByteBuf([byteBufferOne, byteBufferTwo])
+
+        when:
+        def i = buf.getInt(0)
+
+        then:
+        i == 67305985
+        buf.position() == 0
+        byteBufferOne.position() == 0
+        byteBufferTwo.position() == 0
+    }
+
+    def 'relative getInt should read little endian integer and move position'() {
+        given:
+        def byteBuffer = new ByteBufNIO(ByteBuffer.wrap([1, 2, 3, 4] as byte[]))
+        def buf = new CompositeByteBuf([byteBuffer])
+
+        when:
+        def i = buf.getInt()
+
+        then:
+        i == 67305985
+        buf.position() == 4
+        byteBuffer.position() == 0
+    }
+
+    def 'absolute getLong should read little endian long and preserve position'() {
+        given:
+        def byteBuffer = new ByteBufNIO(ByteBuffer.wrap([1, 2, 3, 4, 5, 6, 7, 8] as byte[]))
+        def buf = new CompositeByteBuf([byteBuffer])
+
+        when:
+        def l = buf.getLong(0)
+
+        then:
+        l == 578437695752307201L
+        buf.position() == 0
+        byteBuffer.position() == 0
+    }
+
+    def 'absolute getLong should read little endian long when double is split accross buffers'() {
+        given:
+        def byteBufferOne = new ByteBufNIO(ByteBuffer.wrap([1, 2] as byte[]))
+        def byteBufferTwo = new ByteBufNIO(ByteBuffer.wrap([3, 4] as byte[]))
+        def byteBufferThree = new ByteBufNIO(ByteBuffer.wrap([5, 6] as byte[]))
+        def byteBufferFour = new ByteBufNIO(ByteBuffer.wrap([7, 8] as byte[]))
+        def buf = new CompositeByteBuf([byteBufferOne, byteBufferTwo, byteBufferThree, byteBufferFour])
+
+        when:
+        def l = buf.getLong(0)
+
+        then:
+        l == 578437695752307201L
+        buf.position() == 0
+        byteBufferOne.position() == 0
+        byteBufferTwo.position() == 0
+    }
+
+    def 'relative getLong should read little endian long and move position'() {
+        given:
+        def byteBuffer = new ByteBufNIO(ByteBuffer.wrap([1, 2, 3, 4, 5, 6, 7, 8] as byte[]))
+        def buf = new CompositeByteBuf([byteBuffer])
+
+        when:
+        def l = buf.getLong()
+
+        then:
+        l == 578437695752307201L
+        buf.position() == 8
+        byteBuffer.position() == 0
+    }
+
+    def 'absolute getDouble should read little endian double and preserve position'() {
+        given:
+        def byteBuffer = new ByteBufNIO(ByteBuffer.wrap([1, 2, 3, 4, 5, 6, 7, 8] as byte[]))
+        def buf = new CompositeByteBuf([byteBuffer])
+
+        when:
+        def d = buf.getDouble(0)
+
+        then:
+        d == 5.447603722011605E-270 as double
+        buf.position() == 0
+        byteBuffer.position() == 0
+    }
+
+    def 'relative getDouble should read little endian double and move position'() {
+        given:
+        def byteBuffer = new ByteBufNIO(ByteBuffer.wrap([1, 2, 3, 4, 5, 6, 7, 8] as byte[]))
+        def buf = new CompositeByteBuf([byteBuffer])
+
+        when:
+        def d = buf.getDouble()
+
+        then:
+        d == 5.447603722011605E-270 as double
+        buf.position() == 8
+        byteBuffer.position() == 0
+    }
+
+    def 'absolute bulk get should read bytes and preserve position'() {
+        given:
+        def byteBuffer = new ByteBufNIO(ByteBuffer.wrap([1, 2, 3, 4] as byte[]))
+        def buf = new CompositeByteBuf([byteBuffer])
+
+        when:
+        def bytes = new byte[4]
+        buf.get(0, bytes)
+
+        then:
+        bytes == [1, 2, 3, 4] as byte[]
+        buf.position() == 0
+        byteBuffer.position() == 0
+    }
+
+    def 'absolute bulk get should read bytes when split across buffers'() {
+        given:
+        def byteBufferOne = new ByteBufNIO(ByteBuffer.wrap([1] as byte[]))
+        def byteBufferTwo = new ByteBufNIO(ByteBuffer.wrap([2, 3] as byte[]))
+        def byteBufferThree = new ByteBufNIO(ByteBuffer.wrap([4, 5, 6] as byte[]))
+        def byteBufferFour = new ByteBufNIO(ByteBuffer.wrap([7, 8, 9, 10] as byte[]))
+        def byteBufferFive = new ByteBufNIO(ByteBuffer.wrap([11] as byte[]))
+        def byteBufferSix = new ByteBufNIO(ByteBuffer.wrap([12] as byte[]))
+        def buf = new CompositeByteBuf([byteBufferOne, byteBufferTwo, byteBufferThree, byteBufferFour,
+                                        byteBufferFive, byteBufferSix])
+
+        when:
+        def bytes = new byte[16]
+        buf.get(2, bytes, 4, 9)
+
+        then:
+        bytes == [0, 0, 0, 0, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0, 0, 0] as byte[]
+        buf.position() == 0
+    }
+
+    def 'relative bulk get should read bytes and move position'() {
+        given:
+        def byteBuffer = new ByteBufNIO(ByteBuffer.wrap([1, 2, 3, 4, 5, 6, 7, 8] as byte[]))
+        def buf = new CompositeByteBuf([byteBuffer])
+
+        when:
+        def bytes = new byte[4]
+        buf.get(bytes)
+
+        then:
+        bytes == [1, 2, 3, 4] as byte[]
+        buf.position() == 4
+        byteBuffer.position() == 0
+
+        when:
+        bytes = new byte[8]
+        buf.get(bytes, 4, 3)
+
+        then:
+        bytes == [0, 0, 0, 0, 5, 6, 7, 0] as byte[]
+        buf.position() == 7
+        byteBuffer.position() == 0
+    }
+
+    def 'should get as NIO ByteBuffer'() {
+        given:
+        def buf = new CompositeByteBuf([new ByteBufNIO(ByteBuffer.wrap([1, 2, 3, 4, 5, 6, 7, 8] as byte[]))])
+
+        when:
+        buf.position(1).limit(5)
+        def nio = buf.asNIO()
+
+        then:
+        nio.position() == 1
+        nio.limit(5)
+        def bytes = new byte[4]
+        nio.get(bytes)
+        bytes == [2, 3, 4, 5] as byte[]
+    }
+
+    def 'should get as NIO ByteBuffer with multiple buffers'() {
+        given:
+        def buf = new CompositeByteBuf([new ByteBufNIO(ByteBuffer.wrap([1, 2] as byte[])),
+                                        new ByteBufNIO(ByteBuffer.wrap([3, 4, 5] as byte[])),
+                                        new ByteBufNIO(ByteBuffer.wrap([6, 7, 8, 9] as byte[]))])
+
+        when:
+        buf.position(1).limit(6)
+        def nio = buf.asNIO()
+
+        then:
+        nio.position() == 0
+        nio.limit(5)
+        def bytes = new byte[5]
+        nio.get(bytes)
+        bytes == [2, 3, 4, 5, 6] as byte[]
+
+    }
+
+    def 'should throw IndexOutOfBoundsException if reading out of bounds'() {
+        given:
+        def buf = new CompositeByteBuf([new ByteBufNIO(ByteBuffer.wrap([1, 2, 3, 4] as byte[]))])
+        buf.position(4)
+
+        when:
+        buf.get()
+
+        then:
+        thrown(IndexOutOfBoundsException)
+
+        when:
+        buf.position(1)
+        buf.getInt()
+
+        then:
+        thrown(IndexOutOfBoundsException)
+
+        when:
+        buf.position(0)
+        buf.get(new byte[2], 1, 2)
+
+        then:
+        thrown(IndexOutOfBoundsException)
+    }
+
+    def 'should throw IllegalStateException if buffer is closed'() {
+        given:
+        def buf = new CompositeByteBuf([new ByteBufNIO(ByteBuffer.wrap([1, 2, 3, 4] as byte[]))])
+        buf.release()
+
+        when:
+        buf.get()
+
+        then:
+        thrown(IllegalStateException)
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/connection/DefaultServerConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/DefaultServerConnectionSpecification.groovy
@@ -224,7 +224,13 @@ class DefaultServerConnectionSpecification extends Specification {
         connection.killCursor([5])
 
         then:
-        1 * executor.execute({ compare(new KillCursorProtocol([5]), it) }, internalConnection)
+        1 * executor.execute({ compare(new KillCursorProtocol(null, [5]), it) }, internalConnection)
+
+        when:
+        connection.killCursor(namespace, [5])
+
+        then:
+        1 * executor.execute({ compare(new KillCursorProtocol(namespace, [5]), it) }, internalConnection)
     }
 
     def 'should execute insert protocol asynchronously'() {
@@ -405,6 +411,12 @@ class DefaultServerConnectionSpecification extends Specification {
         connection.killCursorAsync([5], callback)
 
         then:
-        1 * executor.executeAsync({ compare(new KillCursorProtocol([5]), it) }, internalConnection, callback)
+        1 * executor.executeAsync({ compare(new KillCursorProtocol(null, [5]), it) }, internalConnection, callback)
+
+        when:
+        connection.killCursorAsync(namespace, [5], callback)
+
+        then:
+        1 * executor.executeAsync({ compare(new KillCursorProtocol(namespace, [5]), it) }, internalConnection, callback)
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/connection/DefaultServerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/DefaultServerSpecification.groovy
@@ -28,6 +28,7 @@ import com.mongodb.WriteConcernResult
 import com.mongodb.async.FutureResultCallback
 import com.mongodb.async.SingleResultCallback
 import com.mongodb.bulk.InsertRequest
+import com.mongodb.event.CommandListener
 import org.bson.BsonDocument
 import spock.lang.Specification
 
@@ -53,7 +54,7 @@ class DefaultServerSpecification extends Specification {
 
         serverMonitorFactory.create(_) >> { serverMonitor }
         connectionPool.get() >> { internalConnection }
-        def server = new DefaultServer(new ServerAddress(), mode, connectionPool, connectionFactory, serverMonitorFactory)
+        def server = new DefaultServer(new ServerAddress(), mode, connectionPool, connectionFactory, serverMonitorFactory, null)
 
         when:
         def receivedConnection = server.getConnection()
@@ -80,7 +81,7 @@ class DefaultServerSpecification extends Specification {
         }
         serverMonitorFactory.create(_) >> { serverMonitor }
 
-        def server = new DefaultServer(new ServerAddress(), mode, connectionPool, connectionFactory, serverMonitorFactory)
+        def server = new DefaultServer(new ServerAddress(), mode, connectionPool, connectionFactory, serverMonitorFactory, null)
 
         when:
         def latch = new CountDownLatch(1)
@@ -102,7 +103,7 @@ class DefaultServerSpecification extends Specification {
         given:
         def connectionFactory = Mock(ConnectionFactory)
         def server = new DefaultServer(new ServerAddress(), SINGLE, new TestConnectionPool(),
-                                       connectionFactory, new TestServerMonitorFactory())
+                                       connectionFactory, new TestServerMonitorFactory(), null)
         def stateChanged = false;
 
         server.addChangeListener(new ChangeListener<ServerDescription>() {
@@ -131,7 +132,7 @@ class DefaultServerSpecification extends Specification {
         connectionPool.get() >> { throw new MongoSecurityException(createCredential('jeff', 'admin', '123'.toCharArray()), 'Auth failed') }
         serverMonitorFactory.create(_) >> { serverMonitor }
 
-        def server = new DefaultServer(new ServerAddress(), SINGLE, connectionPool, connectionFactory, serverMonitorFactory)
+        def server = new DefaultServer(new ServerAddress(), SINGLE, connectionPool, connectionFactory, serverMonitorFactory, null)
 
         when:
         server.getConnection()
@@ -153,7 +154,7 @@ class DefaultServerSpecification extends Specification {
                                                                            '123'.toCharArray()),
                                                           'Auth failed')
         def server = new DefaultServer(new ServerAddress(), SINGLE, new TestConnectionPool(exceptionToThrow), connectionFactory,
-                                       serverMonitorFactory)
+                                       serverMonitorFactory, null)
 
         when:
         def latch = new CountDownLatch(1)
@@ -179,7 +180,7 @@ class DefaultServerSpecification extends Specification {
 
         TestConnectionFactory connectionFactory = new TestConnectionFactory()
 
-        def server = new DefaultServer(new ServerAddress(), SINGLE, connectionPool, connectionFactory, serverMonitorFactory)
+        def server = new DefaultServer(new ServerAddress(), SINGLE, connectionPool, connectionFactory, serverMonitorFactory, null)
         def testConnection = (TestConnection) server.getConnection()
 
         when:
@@ -226,7 +227,8 @@ class DefaultServerSpecification extends Specification {
 
         TestConnectionFactory connectionFactory = new TestConnectionFactory()
 
-        def server = new DefaultServer(new ServerAddress(), SINGLE, connectionPool, connectionFactory, serverMonitorFactory)
+        def server = new DefaultServer(new ServerAddress(), SINGLE, connectionPool, connectionFactory, serverMonitorFactory,
+                                       null)
         def testConnection = (TestConnection) server.getConnection()
 
         when:
@@ -252,7 +254,8 @@ class DefaultServerSpecification extends Specification {
 
         TestConnectionFactory connectionFactory = new TestConnectionFactory()
 
-        def server = new DefaultServer(new ServerAddress(), SINGLE, connectionPool, connectionFactory, serverMonitorFactory)
+        def server = new DefaultServer(new ServerAddress(), SINGLE, connectionPool, connectionFactory, serverMonitorFactory,
+                                       null)
         def testConnection = (TestConnection) server.getConnection()
 
         when:
@@ -288,7 +291,8 @@ class DefaultServerSpecification extends Specification {
 
         TestConnectionFactory connectionFactory = new TestConnectionFactory()
 
-        def server = new DefaultServer(new ServerAddress(), SINGLE, connectionPool, connectionFactory, serverMonitorFactory)
+        def server = new DefaultServer(new ServerAddress(), SINGLE, connectionPool, connectionFactory, serverMonitorFactory,
+                                       null)
         def testConnection = (TestConnection) server.getConnection()
 
         when:
@@ -329,6 +333,10 @@ class DefaultServerSpecification extends Specification {
         @Override
         void executeAsync(final InternalConnection connection, final SingleResultCallback callback) {
             callback.onResult(null, mongoException);
+        }
+
+        @Override
+        void setCommandListener(final CommandListener operationListener) {
         }
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/connection/TestConnection.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/TestConnection.java
@@ -30,7 +30,7 @@ import org.bson.codecs.Decoder;
 
 import java.util.List;
 
-@SuppressWarnings({"rawtypes", "unchecked"})
+@SuppressWarnings({"rawtypes", "unchecked", "deprecation"})
 class TestConnection implements Connection, AsyncConnection {
     private final InternalConnection internalConnection;
     private final ProtocolExecutor executor;

--- a/driver-core/src/test/unit/com/mongodb/connection/TestConnection.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/TestConnection.java
@@ -210,7 +210,17 @@ class TestConnection implements Connection, AsyncConnection {
     }
 
     @Override
+    public void killCursor(final MongoNamespace namespace, final List<Long> cursors) {
+        executeEnqueuedProtocol();
+    }
+
+    @Override
     public void killCursorAsync(final List<Long> cursors, final SingleResultCallback<Void> callback) {
+        executeEnqueuedProtocolAsync(callback);
+    }
+
+    @Override
+    public void killCursorAsync(final MongoNamespace namespace, final List<Long> cursors, final SingleResultCallback<Void> callback) {
         executeEnqueuedProtocolAsync(callback);
     }
 

--- a/driver-core/src/test/unit/com/mongodb/connection/TestConnection.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/TestConnection.java
@@ -163,11 +163,30 @@ class TestConnection implements Connection, AsyncConnection {
     }
 
     @Override
+    public <T> QueryResult<T> query(final MongoNamespace namespace, final BsonDocument queryDocument, final BsonDocument fields,
+                                    final int skip, final int limit,
+                                    final int batchSize, final boolean slaveOk, final boolean tailableCursor, final boolean awaitData,
+                                    final boolean noCursorTimeout,
+                                    final boolean partial, final boolean oplogReplay, final Decoder<T> resultDecoder) {
+        return executeEnqueuedProtocol();
+    }
+
+    @Override
     public <T> void queryAsync(final MongoNamespace namespace, final BsonDocument queryDocument, final BsonDocument fields,
                                final int numberToReturn, final int skip,
                                final boolean slaveOk, final boolean tailableCursor, final boolean awaitData, final boolean noCursorTimeout,
                                final boolean partial,
                                final boolean oplogReplay, final Decoder<T> resultDecoder,
+                               final SingleResultCallback<QueryResult<T>> callback) {
+        executeEnqueuedProtocolAsync(callback);
+    }
+
+    @Override
+    public <T> void queryAsync(final MongoNamespace namespace, final BsonDocument queryDocument, final BsonDocument fields, final int skip,
+                               final int limit,
+                               final int batchSize, final boolean slaveOk, final boolean tailableCursor, final boolean awaitData,
+                               final boolean noCursorTimeout,
+                               final boolean partial, final boolean oplogReplay, final Decoder<T> resultDecoder,
                                final SingleResultCallback<QueryResult<T>> callback) {
         executeEnqueuedProtocolAsync(callback);
     }

--- a/driver-core/src/test/unit/com/mongodb/event/CommandListenerMulticasterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/event/CommandListenerMulticasterSpecification.groovy
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.event
+
+import com.mongodb.ServerAddress
+import com.mongodb.connection.ClusterId
+import com.mongodb.connection.ConnectionDescription
+import com.mongodb.connection.ServerId
+import org.bson.BsonDocument
+import org.bson.BsonInt32
+import spock.lang.Specification
+
+
+class CommandListenerMulticasterSpecification extends Specification {
+
+    def 'should get listeners'() {
+        given:
+        def first = Mock(CommandListener)
+        def second = Mock(CommandListener)
+        def multicaster = new CommandListenerMulticaster([first, second])
+
+        expect:
+        multicaster.commandListeners == [first, second]
+
+    }
+
+    def 'should multicast command started event'() {
+        given:
+        def first = Mock(CommandListener)
+        def second = Mock(CommandListener)
+        def multicaster = new CommandListenerMulticaster([first, second])
+        def event = new CommandStartedEvent(1, new ConnectionDescription(new ServerId(new ClusterId(), new ServerAddress())),
+                                            'admin', 'ping', new BsonDocument('ping', new BsonInt32(1)))
+
+        when:
+        multicaster.commandStarted(event)
+
+        then:
+        1 * first.commandStarted(event)
+        1 * second.commandStarted(event)
+    }
+
+    def 'should continue multicasting command started event when a listener throws an Exception'() {
+        given:
+        def first = Stub(CommandListener) {
+            commandStarted(_) >> {
+                throw new UnsupportedOperationException()
+            }
+        }
+        def second = Mock(CommandListener)
+        def multicaster = new CommandListenerMulticaster([first, second])
+        def event = new CommandStartedEvent(1, new ConnectionDescription(new ServerId(new ClusterId(), new ServerAddress())),
+                                            'admin', 'ping', new BsonDocument('ping', new BsonInt32(1)))
+
+        when:
+        multicaster.commandStarted(event)
+
+        then:
+        1 * second.commandStarted(event)
+    }
+
+    def 'should multicast command succeeded event'() {
+        given:
+        def first = Mock(CommandListener)
+        def second = Mock(CommandListener)
+        def multicaster = new CommandListenerMulticaster([first, second])
+        def event = new CommandSucceededEvent(1, new ConnectionDescription(new ServerId(new ClusterId(), new ServerAddress())),
+                                              'ping', new BsonDocument('ok', new BsonInt32(1)), 1000)
+
+        when:
+        multicaster.commandSucceeded(event)
+
+        then:
+        1 * first.commandSucceeded(event)
+        1 * second.commandSucceeded(event)
+    }
+
+    def 'should continue multicasting command succeeded event when a listener throws an Exception'() {
+        given:
+        def first = Stub(CommandListener) {
+            commandSucceeded(_) >> {
+                throw new UnsupportedOperationException()
+            }
+        }
+        def second = Mock(CommandListener)
+        def multicaster = new CommandListenerMulticaster([first, second])
+        def event = new CommandSucceededEvent(1, new ConnectionDescription(new ServerId(new ClusterId(), new ServerAddress())),
+                                              'ping', new BsonDocument('ok', new BsonInt32(1)), 1000)
+
+        when:
+        multicaster.commandSucceeded(event)
+
+        then:
+        1 * second.commandSucceeded(event)
+    }
+
+    def 'should multicast command failed event'() {
+        given:
+        def first = Mock(CommandListener)
+        def second = Mock(CommandListener)
+        def multicaster = new CommandListenerMulticaster([first, second])
+        def event = new CommandFailedEvent(1, new ConnectionDescription(new ServerId(new ClusterId(), new ServerAddress())),
+                                           'ping', 1000, new NullPointerException())
+
+        when:
+        multicaster.commandFailed(event)
+
+        then:
+        1 * first.commandFailed(event)
+        1 * second.commandFailed(event)
+    }
+
+    def 'should continue multicasting command failed event when a listener throws an Exception'() {
+        given:
+        def first = Stub(CommandListener) {
+            commandFailed(_) >> {
+                throw new UnsupportedOperationException()
+            }
+        }
+        def second = Mock(CommandListener)
+        def multicaster = new CommandListenerMulticaster([first, second])
+        def event = new CommandFailedEvent(1, new ConnectionDescription(new ServerId(new ClusterId(), new ServerAddress())),
+                                           'ping', 1000, new NullPointerException())
+
+        when:
+        multicaster.commandFailed(event)
+
+        then:
+        1 * second.commandFailed(event)
+    }
+}

--- a/driver/src/main/com/mongodb/Mongo.java
+++ b/driver/src/main/com/mongodb/Mongo.java
@@ -32,6 +32,7 @@ import com.mongodb.connection.Connection;
 import com.mongodb.connection.DefaultClusterFactory;
 import com.mongodb.connection.ServerDescription;
 import com.mongodb.connection.SocketStreamFactory;
+import com.mongodb.event.CommandListenerMulticaster;
 import com.mongodb.internal.connection.PowerOfTwoBufferPool;
 import com.mongodb.management.JMXConnectionPoolListener;
 import com.mongodb.operation.ListDatabasesOperation;
@@ -668,7 +669,8 @@ public class Mongo {
                                                                           options.getSslSettings(),
                                                                           options.getSocketFactory()),
                                                   credentialsList,
-                                                  null, new JMXConnectionPoolListener(), null, options.getCommandListener());
+                                                  null, new JMXConnectionPoolListener(), null,
+                                                  new CommandListenerMulticaster(options.getCommandListeners()));
     }
 
     private static List<ServerAddress> createNewSeedList(final List<ServerAddress> seedList) {

--- a/driver/src/main/com/mongodb/Mongo.java
+++ b/driver/src/main/com/mongodb/Mongo.java
@@ -667,7 +667,7 @@ public class Mongo {
                                                                           options.getSslSettings(),
                                                                           options.getSocketFactory()),
                                                   credentialsList,
-                                                  null, new JMXConnectionPoolListener(), null);
+                                                  null, new JMXConnectionPoolListener(), null, options.getCommandListener());
     }
 
     private static List<ServerAddress> createNewSeedList(final List<ServerAddress> seedList) {

--- a/driver/src/main/com/mongodb/MongoClientOptions.java
+++ b/driver/src/main/com/mongodb/MongoClientOptions.java
@@ -22,6 +22,7 @@ import com.mongodb.connection.ConnectionPoolSettings;
 import com.mongodb.connection.ServerSettings;
 import com.mongodb.connection.SocketSettings;
 import com.mongodb.connection.SslSettings;
+import com.mongodb.event.CommandListener;
 import org.bson.codecs.configuration.CodecRegistry;
 
 import javax.net.SocketFactory;
@@ -78,6 +79,7 @@ public class MongoClientOptions {
     private final ServerSettings serverSettings;
     private final SocketSettings heartbeatSocketSettings;
     private final SslSettings sslSettings;
+    private final CommandListener commandListener;
 
     private MongoClientOptions(final Builder builder) {
         description = builder.description;
@@ -107,6 +109,7 @@ public class MongoClientOptions {
         dbEncoderFactory = builder.dbEncoderFactory;
         socketFactory = builder.socketFactory;
         cursorFinalizerEnabled = builder.cursorFinalizerEnabled;
+        commandListener = builder.commandListener;
 
         connectionPoolSettings = ConnectionPoolSettings.builder()
                                                        .minSize(getMinConnectionsPerHost())
@@ -440,6 +443,15 @@ public class MongoClientOptions {
     }
 
     /**
+     * Gets the {@code CommandListener}. The default is null.
+     *
+     * @return the command listener
+     */
+    public CommandListener getCommandListener() {
+        return commandListener;
+    }
+
+    /**
      * Override the decoder factory. Default is for the standard Mongo Java driver configuration.
      *
      * @return the decoder factory
@@ -688,6 +700,7 @@ public class MongoClientOptions {
         private ReadPreference readPreference = ReadPreference.primary();
         private WriteConcern writeConcern = WriteConcern.ACKNOWLEDGED;
         private CodecRegistry codecRegistry = MongoClient.getDefaultCodecRegistry();
+        private CommandListener commandListener;
 
         private int minConnectionsPerHost;
         private int maxConnectionsPerHost = 100;
@@ -759,6 +772,7 @@ public class MongoClientOptions {
             dbEncoderFactory = options.getDbEncoderFactory();
             socketFactory = options.getSocketFactory();
             cursorFinalizerEnabled = options.isCursorFinalizerEnabled();
+            commandListener = options.getCommandListener();
         }
 
         /**
@@ -975,6 +989,17 @@ public class MongoClientOptions {
          */
         public Builder codecRegistry(final CodecRegistry codecRegistry) {
             this.codecRegistry = notNull("codecRegistry", codecRegistry);
+            return this;
+        }
+
+        /**
+         * Sets the command listener.
+         *
+         * @param commandListener the command listener
+         * @return this
+         */
+        public Builder commandListener(final CommandListener commandListener) {
+            this.commandListener = commandListener;
             return this;
         }
 

--- a/driver/src/test/functional/com/mongodb/MongoClientListenerRegistrationSpecification.groovy
+++ b/driver/src/test/functional/com/mongodb/MongoClientListenerRegistrationSpecification.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb
+
+import com.mongodb.event.CommandListener
+import org.bson.Document
+
+import static com.mongodb.Fixture.mongoClientURI
+
+class MongoClientListenerRegistrationSpecification extends FunctionalSpecification {
+
+    def 'should register command listeners'() {
+        given:
+        def first = Mock(CommandListener)
+        def second = Mock(CommandListener)
+        def client = new MongoClient(mongoClientURI.getHosts().collect { new ServerAddress(it) },
+                MongoClientOptions.builder(mongoClientURI.options)
+                                                       .addCommandListener(first)
+                                                       .addCommandListener(second).build());
+
+        when:
+        client.getDatabase('admin').runCommand(new Document('ping', 1))
+
+        then:
+        1 * first.commandStarted(_)
+        1 * second.commandStarted(_)
+        1 * first.commandSucceeded(_)
+        1 * second.commandSucceeded(_)
+    }
+}

--- a/driver/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
@@ -303,6 +303,7 @@ class MongoClientOptionsSpecification extends Specification {
         1 * options.isSslInvalidHostNameAllowed()
         1 * options.getThreadsAllowedToBlockForConnectionMultiplier()
         1 * options.getWriteConcern()
+        1 * options.getCommandListener()
 
         0 * options._ // Ensure no other interactions
     }
@@ -311,12 +312,12 @@ class MongoClientOptionsSpecification extends Specification {
         when:
         // A regression test so that if anymore methods are added then the builder(final MongoClientOptions options) should be updated
         def actual = MongoClientOptions.Builder.declaredFields.grep {  !it.synthetic } *.name.sort()
-        def expected = ['alwaysUseMBeans', 'codecRegistry', 'connectTimeout', 'cursorFinalizerEnabled', 'dbDecoderFactory',
-                        'dbEncoderFactory', 'description', 'heartbeatConnectTimeout', 'heartbeatFrequency', 'heartbeatSocketTimeout',
-                        'localThreshold', 'maxConnectionIdleTime', 'maxConnectionLifeTime', 'maxConnectionsPerHost', 'maxWaitTime',
-                        'minConnectionsPerHost', 'minHeartbeatFrequency', 'readPreference', 'requiredReplicaSetName',
-                        'serverSelectionTimeout', 'socketFactory', 'socketKeepAlive', 'socketTimeout', 'sslEnabled',
-                        'sslInvalidHostNameAllowed', 'threadsAllowedToBlockForConnectionMultiplier', 'writeConcern']
+        def expected = ['alwaysUseMBeans', 'codecRegistry', 'commandListener', 'connectTimeout', 'cursorFinalizerEnabled',
+                        'dbDecoderFactory', 'dbEncoderFactory', 'description', 'heartbeatConnectTimeout', 'heartbeatFrequency',
+                        'heartbeatSocketTimeout', 'localThreshold', 'maxConnectionIdleTime', 'maxConnectionLifeTime',
+                        'maxConnectionsPerHost', 'maxWaitTime', 'minConnectionsPerHost', 'minHeartbeatFrequency', 'readPreference',
+                        'requiredReplicaSetName', 'serverSelectionTimeout', 'socketFactory', 'socketKeepAlive', 'socketTimeout',
+                        'sslEnabled', 'sslInvalidHostNameAllowed', 'threadsAllowedToBlockForConnectionMultiplier', 'writeConcern']
 
         then:
         actual == expected

--- a/driver/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008 - 2014 MongoDB, Inc.
+ * Copyright (c) 2008 - 2015 MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the 'License');
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import com.mongodb.connection.ConnectionPoolSettings
 import com.mongodb.connection.ServerSettings
 import com.mongodb.connection.SocketSettings
 import com.mongodb.connection.SslSettings
+import com.mongodb.event.CommandListener
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 
@@ -246,6 +247,7 @@ class MongoClientOptionsSpecification extends Specification {
                 .requiredReplicaSetName('test')
                 .cursorFinalizerEnabled(false)
                 .dbEncoderFactory(new MyDBEncoderFactory())
+                .addCommandListener(Mock(CommandListener))
                 .build()
 
         then:
@@ -268,9 +270,53 @@ class MongoClientOptionsSpecification extends Specification {
         System.setProperty('java.version', javaVersion)
     }
 
+    def 'should add command listeners'() {
+        given:
+        CommandListener commandListenerOne = Mock(CommandListener)
+        CommandListener commandListenerTwo = Mock(CommandListener)
+        CommandListener commandListenerThree = Mock(CommandListener)
+
+        when:
+        def options = MongoClientOptions.builder()
+                                        .build()
+
+        then:
+        options.commandListeners.size() == 0
+
+        when:
+        options = MongoClientOptions.builder()
+                                    .addCommandListener(commandListenerOne)
+                                    .build()
+
+        then:
+        options.commandListeners.size() == 1
+        options.commandListeners[0].is commandListenerOne
+
+        when:
+        options = MongoClientOptions.builder()
+                                    .addCommandListener(commandListenerOne)
+                                    .addCommandListener(commandListenerTwo)
+                                    .build()
+
+        then:
+        options.commandListeners.size() == 2
+        options.commandListeners[0].is commandListenerOne
+        options.commandListeners[1].is commandListenerTwo
+
+        when:
+        options = MongoClientOptions.builder(options).addCommandListener(commandListenerThree).build()
+
+        then:
+        options.commandListeners.size() == 3
+        options.commandListeners[0].is commandListenerOne
+        options.commandListeners[1].is commandListenerTwo
+        options.commandListeners[2].is commandListenerThree
+    }
+
     def 'should copy all methods from the existing MongoClientOptions'() {
         given:
         def options = Mock(MongoClientOptions)
+
 
         when:
         MongoClientOptions.builder(options)
@@ -303,16 +349,15 @@ class MongoClientOptionsSpecification extends Specification {
         1 * options.isSslInvalidHostNameAllowed()
         1 * options.getThreadsAllowedToBlockForConnectionMultiplier()
         1 * options.getWriteConcern()
-        1 * options.getCommandListener()
 
         0 * options._ // Ensure no other interactions
     }
 
-    def 'should only have the following methods in the builder'() {
+    def 'should only have the following fields in the builder'() {
         when:
-        // A regression test so that if anymore methods are added then the builder(final MongoClientOptions options) should be updated
+        // A regression test so that if any more methods are added then the builder(final MongoClientOptions options) should be updated
         def actual = MongoClientOptions.Builder.declaredFields.grep {  !it.synthetic } *.name.sort()
-        def expected = ['alwaysUseMBeans', 'codecRegistry', 'commandListener', 'connectTimeout', 'cursorFinalizerEnabled',
+        def expected = ['alwaysUseMBeans', 'codecRegistry', 'commandListeners', 'connectTimeout', 'cursorFinalizerEnabled',
                         'dbDecoderFactory', 'dbEncoderFactory', 'description', 'heartbeatConnectTimeout', 'heartbeatFrequency',
                         'heartbeatSocketTimeout', 'localThreshold', 'maxConnectionIdleTime', 'maxConnectionLifeTime',
                         'maxConnectionsPerHost', 'maxWaitTime', 'minConnectionsPerHost', 'minHeartbeatFrequency', 'readPreference',


### PR DESCRIPTION
Generating command events in Protocol.execute for all implementations.

* Command : Straightforward
* Query : Up-converting to a find or an explain command and command response
* GetMore: Up-converting to a getMore command and command response
* KillCursors: Up-converting to a killCursors command and command response
* Write*: Up-converting to insert/update/delete command and command response
* WriteCommand*: Straightforward

To avoid double-encoding/decoding, passing command events instance of ByteBufBsonDocument, a package-private subclass of BsonDocument that sits on top of the raw BSON byte buffers that have been passed directly to the Stream implementations.
