### PR TITLE
JAVA-2507

### DIFF
--- a/bson/src/main/org/bson/internal/Base64.java
+++ b/bson/src/main/org/bson/internal/Base64.java
@@ -16,7 +16,7 @@
  *
  */
 
-package org.bson.json;
+package org.bson.internal;
 
 /**
  * <p>Provides Base64 encoding and decoding.</p>

--- a/bson/src/main/org/bson/json/Base64.java
+++ b/bson/src/main/org/bson/json/Base64.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2014 MongoDB, Inc.
+ * Copyright 2014-2017 MongoDB, Inc.
  * Copyright 1999,2005 The Apache Software Foundation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -8,18 +8,15 @@
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
  */
 
-package com.mongodb.connection;
-
-import com.mongodb.MongoException;
-
-import java.io.UnsupportedEncodingException;
+package org.bson.json;
 
 /**
  * <p>Provides Base64 encoding and decoding.</p>
@@ -27,8 +24,10 @@ import java.io.UnsupportedEncodingException;
  * <p>Thanks to Apache Commons project. This class refactored from org.apache.commons.codec.binary</p>
  * <p>Original Thanks to <a href="http://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/">commons</a> project in
  * ws.apache.org for this code. </p>
+ *
+ * @since 3.5
  */
-class Base64Codec {
+public final class Base64 {
     private static final int BYTES_PER_UNENCODED_BLOCK = 3;
     private static final int BYTES_PER_ENCODED_BLOCK = 4;
 
@@ -61,7 +60,13 @@ class Base64Codec {
         }
     }
 
-    public byte[] decode(final String s) {
+    /**
+     * Decodes the given Base64-encoded string.
+     *
+     * @param s the Base64-encoded string
+     * @return the decoded byte array
+     */
+    public static byte[] decode(final String s) {
         int delta = s.endsWith("==") ? 2 : s.endsWith("=") ? 1 : 0;
         byte[] buffer = new byte[s.length() * BYTES_PER_UNENCODED_BLOCK / BYTES_PER_ENCODED_BLOCK - delta];
         int mask = 0xFF;
@@ -84,7 +89,14 @@ class Base64Codec {
         return buffer;
     }
 
-    public String encode(final byte[] in) {
+    /**
+     * Encodes the given byte array into a Base64-encoded string.
+     *
+     *
+     * @param in the byte array
+     * @return the Base64-encoded string
+     */
+    public static String encode(final byte[] in) {
 
         int modulus = 0;
         int bitWorkArea = 0;
@@ -128,10 +140,14 @@ class Base64Codec {
                 break;
         }
 
-        try {
-            return new String(buffer, "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new MongoException("UTF-8 Charset is not available");
-        }
+        return byteArrayToString(buffer);
+    }
+
+    @SuppressWarnings("deprecation")
+    private static String byteArrayToString(final byte[] buffer) {
+        return new String(buffer, 0, 0, buffer.length);
+    }
+
+    private Base64() {
     }
 }

--- a/bson/src/main/org/bson/json/DateTimeFormatter.java
+++ b/bson/src/main/org/bson/json/DateTimeFormatter.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package org.bson.json;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalQuery;
+import java.util.Calendar;
+
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+final class DateTimeFormatter {
+    private static final FormatterImpl FORMATTER_IMPL;
+
+    static {
+        FormatterImpl dateTimeHelper;
+        try {
+            dateTimeHelper = loadDateTimeFormatter("org.bson.json.DateTimeFormatter$Java8DateTimeFormatter");
+        } catch (LinkageError e) {
+            // this is expected if running on a release prior to Java 8: fallback to JAXB.
+            dateTimeHelper = loadDateTimeFormatter("org.bson.json.DateTimeFormatter$JaxbDateTimeFormatter");
+        }
+
+        FORMATTER_IMPL = dateTimeHelper;
+    }
+
+    private static FormatterImpl loadDateTimeFormatter(final String className) {
+        try {
+            return (FormatterImpl) Class.forName(className).newInstance();
+        } catch (ClassNotFoundException e) {
+            // this is unexpected as it means the class itself is not found
+            throw new ExceptionInInitializerError(e);
+        } catch (InstantiationException e) {
+            // this is unexpected as it means the class can't be instantiated
+            throw new ExceptionInInitializerError(e);
+        } catch (IllegalAccessException e) {
+            // this is unexpected as it means the no-args constructor isn't accessible
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    static long parse(final String dateTimeString) {
+        return FORMATTER_IMPL.parse(dateTimeString);
+    }
+
+    private interface FormatterImpl {
+        long parse(String dateTimeString);
+    }
+
+    // Reflective use of DatatypeConverter avoids a compile-time dependency on the java.xml.bind module in Java 9
+    static class JaxbDateTimeFormatter implements FormatterImpl {
+
+        private static final Method DATATYPE_CONVERTER_PARSE_DATE_TIME_METHOD;
+
+        static {
+            try {
+                DATATYPE_CONVERTER_PARSE_DATE_TIME_METHOD = Class.forName("javax.xml.bind.DatatypeConverter")
+                                                                    .getDeclaredMethod("parseDateTime", String.class);
+            } catch (NoSuchMethodException e) {
+                throw new ExceptionInInitializerError(e);
+            } catch (ClassNotFoundException e) {
+                throw new ExceptionInInitializerError(e);
+            }
+        }
+
+        @Override
+        public long parse(final String dateTimeString) {
+            try {
+                return ((Calendar) DATATYPE_CONVERTER_PARSE_DATE_TIME_METHOD.invoke(null, dateTimeString)).getTimeInMillis();
+            } catch (IllegalAccessException e) {
+                throw new IllegalStateException(e);
+            } catch (InvocationTargetException e) {
+                throw (RuntimeException) e.getCause();
+            }
+        }
+    }
+
+    static class Java8DateTimeFormatter implements FormatterImpl {
+
+        // if running on Java 8 or above then java.time.format.DateTimeFormatter will be available and initialization will succeed.
+        // Otherwise it will fail.
+        static {
+            try {
+                Class.forName("java.time.format.DateTimeFormatter");
+            } catch (ClassNotFoundException e) {
+                throw new ExceptionInInitializerError(e);
+            }
+        }
+
+        @Override
+        public long parse(final String dateTimeString) {
+            try {
+                return ISO_OFFSET_DATE_TIME.parse(dateTimeString, new TemporalQuery<Instant>() {
+                    @Override
+                    public Instant queryFrom(final TemporalAccessor temporal) {
+                        return Instant.from(temporal);
+                    }
+                }).toEpochMilli();
+            } catch (DateTimeParseException e) {
+                throw new IllegalArgumentException(e.getMessage());
+            }
+        }
+    }
+
+    private DateTimeFormatter() {
+    }
+}

--- a/bson/src/main/org/bson/json/ExtendedJsonBinaryConverter.java
+++ b/bson/src/main/org/bson/json/ExtendedJsonBinaryConverter.java
@@ -19,14 +19,12 @@ package org.bson.json;
 
 import org.bson.BsonBinary;
 
-import static javax.xml.bind.DatatypeConverter.printBase64Binary;
-
 class ExtendedJsonBinaryConverter implements Converter<BsonBinary> {
 
     @Override
     public void convert(final BsonBinary value, final StrictJsonWriter writer) {
         writer.writeStartObject();
-        writer.writeString("$binary", printBase64Binary(value.getData()));
+        writer.writeString("$binary", Base64.encode(value.getData()));
         writer.writeString("$type", String.format("%02X", value.getType()));
         writer.writeEndObject();
     }

--- a/bson/src/main/org/bson/json/ExtendedJsonBinaryConverter.java
+++ b/bson/src/main/org/bson/json/ExtendedJsonBinaryConverter.java
@@ -18,6 +18,7 @@
 package org.bson.json;
 
 import org.bson.BsonBinary;
+import org.bson.internal.Base64;
 
 class ExtendedJsonBinaryConverter implements Converter<BsonBinary> {
 

--- a/bson/src/main/org/bson/json/JsonReader.java
+++ b/bson/src/main/org/bson/json/JsonReader.java
@@ -29,6 +29,7 @@ import org.bson.BsonRegularExpression;
 import org.bson.BsonTimestamp;
 import org.bson.BsonType;
 import org.bson.BsonUndefined;
+import org.bson.internal.Base64;
 import org.bson.internal.UnsignedLongs;
 import org.bson.types.Decimal128;
 import org.bson.types.MaxKey;

--- a/bson/src/main/org/bson/json/JsonReader.java
+++ b/bson/src/main/org/bson/json/JsonReader.java
@@ -24,11 +24,11 @@ import org.bson.BsonBinarySubType;
 import org.bson.BsonContextType;
 import org.bson.BsonDbPointer;
 import org.bson.BsonInvalidOperationException;
+import org.bson.BsonReaderMark;
 import org.bson.BsonRegularExpression;
 import org.bson.BsonTimestamp;
 import org.bson.BsonType;
 import org.bson.BsonUndefined;
-import org.bson.BsonReaderMark;
 import org.bson.internal.UnsignedLongs;
 import org.bson.types.Decimal128;
 import org.bson.types.MaxKey;
@@ -679,7 +679,7 @@ public class JsonReader extends AbstractBsonReader {
         }
         verifyToken(JsonTokenType.RIGHT_PAREN);
         String hexString = bytesToken.getValue(String.class).replaceAll("\\{", "").replaceAll("\\}", "").replaceAll("-", "");
-        byte[] bytes = DatatypeConverter.parseHexBinary(hexString);
+        byte[] bytes = decodeHex(hexString);
         BsonBinarySubType subType = BsonBinarySubType.UUID_STANDARD;
         if (!"UUID".equals(uuidConstructorName) || !"GUID".equals(uuidConstructorName)) {
             subType = BsonBinarySubType.UUID_LEGACY;
@@ -856,10 +856,10 @@ public class JsonReader extends AbstractBsonReader {
 
         for (final BsonBinarySubType subType : BsonBinarySubType.values()) {
             if (subType.getValue() == subTypeToken.getValue(Integer.class)) {
-                return new BsonBinary(subType, DatatypeConverter.parseHexBinary(hex));
+                return new BsonBinary(subType, decodeHex(hex));
             }
         }
-        return new BsonBinary(DatatypeConverter.parseHexBinary(hex));
+        return new BsonBinary(decodeHex(hex));
     }
 
     private long visitDateTimeConstructor() {
@@ -1248,6 +1248,26 @@ public class JsonReader extends AbstractBsonReader {
         protected BsonContextType getContextType() {
             return super.getContextType();
         }
+    }
+
+    private static byte[] decodeHex(final String hex) {
+        if (hex.length() % 2 != 0) {
+            throw new IllegalArgumentException("A hex string must contain an even number of characters: " + hex);
+        }
+
+        byte[] out = new byte[hex.length() / 2];
+
+        for (int i = 0; i < hex.length(); i += 2) {
+            int high = Character.digit(hex.charAt(i), 16);
+            int low = Character.digit(hex.charAt(i + 1), 16);
+            if (high == -1 || low == -1) {
+                throw new IllegalArgumentException("A hex string can only contain the characters 0-9, A-F, a-f: " + hex);
+            }
+
+            out[i / 2] = (byte) (high * 16 + low);
+        }
+
+        return out;
     }
 }
 

--- a/bson/src/main/org/bson/json/JsonReader.java
+++ b/bson/src/main/org/bson/json/JsonReader.java
@@ -666,7 +666,7 @@ public class JsonReader extends AbstractBsonReader {
         }
         verifyToken(JsonTokenType.RIGHT_PAREN);
 
-        byte[] bytes = DatatypeConverter.parseBase64Binary(bytesToken.getValue(String.class));
+        byte[] bytes = Base64.decode(bytesToken.getValue(String.class));
         return new BsonBinary(subTypeToken.getValue(Integer.class).byteValue(), bytes);
     }
 
@@ -963,11 +963,11 @@ public class JsonReader extends AbstractBsonReader {
 
         for (final BsonBinarySubType st : BsonBinarySubType.values()) {
             if (st.getValue() == subType) {
-                return new BsonBinary(st, DatatypeConverter.parseBase64Binary(bytesToken.getValue(String.class)));
+                return new BsonBinary(st, Base64.decode(bytesToken.getValue(String.class)));
             }
         }
 
-        return new BsonBinary(DatatypeConverter.parseBase64Binary(bytesToken.getValue(String.class)));
+        return new BsonBinary(Base64.decode(bytesToken.getValue(String.class)));
     }
 
     private long visitDateTimeExtendedJson() {

--- a/bson/src/main/org/bson/json/JsonReader.java
+++ b/bson/src/main/org/bson/json/JsonReader.java
@@ -35,7 +35,6 @@ import org.bson.types.MaxKey;
 import org.bson.types.MinKey;
 import org.bson.types.ObjectId;
 
-import javax.xml.bind.DatatypeConverter;
 import java.text.DateFormat;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
@@ -988,7 +987,7 @@ public class JsonReader extends AbstractBsonReader {
             } else if (valueToken.getType() == JsonTokenType.STRING) {
                 String dateTimeString = valueToken.getValue(String.class);
                 try {
-                    value = DatatypeConverter.parseDateTime(dateTimeString).getTimeInMillis();
+                    value = DateTimeFormatter.parse(dateTimeString);
                 } catch (IllegalArgumentException e) {
                     throw new JsonParseException("Failed to parse string as a date", e);
                 }

--- a/bson/src/main/org/bson/json/ShellBinaryConverter.java
+++ b/bson/src/main/org/bson/json/ShellBinaryConverter.java
@@ -20,12 +20,11 @@ package org.bson.json;
 import org.bson.BsonBinary;
 
 import static java.lang.String.format;
-import static javax.xml.bind.DatatypeConverter.printBase64Binary;
 
 class ShellBinaryConverter implements Converter<BsonBinary> {
     @Override
     public void convert(final BsonBinary value, final StrictJsonWriter writer) {
         writer.writeRaw(format("new BinData(%s, \"%s\")", Integer.toString(value.getType() & 0xFF),
-                printBase64Binary(value.getData())));
+                Base64.encode(value.getData())));
     }
 }

--- a/bson/src/main/org/bson/json/ShellBinaryConverter.java
+++ b/bson/src/main/org/bson/json/ShellBinaryConverter.java
@@ -18,6 +18,7 @@
 package org.bson.json;
 
 import org.bson.BsonBinary;
+import org.bson.internal.Base64;
 
 import static java.lang.String.format;
 

--- a/bson/src/test/unit/org/bson/GenericBsonDecimal128Test.java
+++ b/bson/src/test/unit/org/bson/GenericBsonDecimal128Test.java
@@ -25,9 +25,9 @@ import org.bson.types.Decimal128;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import util.Hex;
 import util.JsonPoweredTestHelper;
 
-import javax.xml.bind.DatatypeConverter;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -121,7 +121,7 @@ public class GenericBsonDecimal128Test {
     }
 
     private BsonDocument decodeToDocument(final String subjectHex, final String description) {
-        ByteBuffer byteBuffer = ByteBuffer.wrap(DatatypeConverter.parseHexBinary(subjectHex));
+        ByteBuffer byteBuffer = ByteBuffer.wrap(Hex.decode(subjectHex));
         BsonDocument actualDecodedDocument = new BsonDocumentCodec().decode(new BsonBinaryReader(byteBuffer),
                 DecoderContext.builder().build());
 
@@ -135,7 +135,7 @@ public class GenericBsonDecimal128Test {
     private String encodeToHex(final BsonDocument decodedDocument) {
         BasicOutputBuffer outputBuffer = new BasicOutputBuffer();
         new BsonDocumentCodec().encode(new BsonBinaryWriter(outputBuffer), decodedDocument, EncoderContext.builder().build());
-        return DatatypeConverter.printHexBinary(outputBuffer.toByteArray());
+        return Hex.encode(outputBuffer.toByteArray());
     }
 
     private void runParseError() {

--- a/bson/src/test/unit/org/bson/GenericBsonTest.java
+++ b/bson/src/test/unit/org/bson/GenericBsonTest.java
@@ -27,9 +27,9 @@ import org.bson.json.JsonWriterSettings;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import util.Hex;
 import util.JsonPoweredTestHelper;
 
-import javax.xml.bind.DatatypeConverter;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
@@ -216,7 +216,7 @@ public class GenericBsonTest {
     }
 
     private BsonDocument decodeToDocument(final String subjectHex, final String description) {
-        ByteBuffer byteBuffer = ByteBuffer.wrap(DatatypeConverter.parseHexBinary(subjectHex));
+        ByteBuffer byteBuffer = ByteBuffer.wrap(Hex.decode(subjectHex));
         BsonDocument actualDecodedDocument = new BsonDocumentCodec().decode(new BsonBinaryReader(byteBuffer),
                 DecoderContext.builder().build());
 
@@ -231,7 +231,7 @@ public class GenericBsonTest {
     private String encodeToHex(final BsonDocument decodedDocument) {
         BasicOutputBuffer outputBuffer = new BasicOutputBuffer();
         new BsonDocumentCodec().encode(new BsonBinaryWriter(outputBuffer), decodedDocument, EncoderContext.builder().build());
-        return DatatypeConverter.printHexBinary(outputBuffer.toByteArray());
+        return Hex.encode(outputBuffer.toByteArray());
     }
 
     private void runDecodeError() {

--- a/bson/src/test/unit/org/bson/json/Base64Specification.groovy
+++ b/bson/src/test/unit/org/bson/json/Base64Specification.groovy
@@ -16,6 +16,7 @@
 
 package org.bson.json
 
+import org.bson.internal.Base64
 import spock.lang.Specification
 import spock.lang.Unroll
 

--- a/bson/src/test/unit/org/bson/json/Base64Specification.groovy
+++ b/bson/src/test/unit/org/bson/json/Base64Specification.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2014 MongoDB, Inc.
+ * Copyright 2014-2017 MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,21 +14,18 @@
  * limitations under the License.
  */
 
-package com.mongodb.connection
+package org.bson.json
 
 import spock.lang.Specification
 import spock.lang.Unroll
 
-class Base64CodecSpecification extends Specification {
+class Base64Specification extends Specification {
 
     @Unroll
     def 'encodes #encoded into #decoded'() {
-        given:
-        def subject = new Base64Codec();
-
         expect:
-        subject.encode(encoded.getBytes()) == decoded
-        subject.decode(decoded) == encoded.getBytes()
+        Base64.encode(encoded.getBytes()) == decoded
+        Base64.decode(decoded) == encoded.getBytes()
 
         where:
         encoded  | decoded

--- a/bson/src/test/unit/util/Hex.java
+++ b/bson/src/test/unit/util/Hex.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package util;
+
+public final class Hex {
+    public static byte[] decode(final String hex) {
+        if (hex.length() % 2 != 0) {
+            throw new IllegalArgumentException("A hex string must contain an even number of characters: " + hex);
+        }
+
+        byte[] out = new byte[hex.length() / 2];
+
+        for (int i = 0; i < hex.length(); i += 2) {
+            int high = Character.digit(hex.charAt(i), 16);
+            int low = Character.digit(hex.charAt(i + 1), 16);
+            if (high == -1 || low == -1) {
+                throw new IllegalArgumentException("A hex string can only contain the characters 0-9, A-F, a-f: " + hex);
+            }
+
+            out[i / 2] = (byte) (high * 16 + low);
+        }
+
+        return out;
+    }
+
+    private static final char[] UPPER_HEX_DIGITS = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', };
+
+    public static String encode(final byte[] bytes) {
+        StringBuilder stringBuilder = new StringBuilder(bytes.length * 2);
+        for (byte cur : bytes) {
+            stringBuilder.append(UPPER_HEX_DIGITS[(cur >> 4) & 0xF]);
+            stringBuilder.append(UPPER_HEX_DIGITS[(cur & 0xF)]);
+        }
+        return stringBuilder.toString();
+    }
+
+    private Hex() {
+    }
+}

--- a/driver-async/src/test/functional/com/mongodb/async/client/gridfs/GridFSTest.java
+++ b/driver-async/src/test/functional/com/mongodb/async/client/gridfs/GridFSTest.java
@@ -38,9 +38,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import util.Hex;
 import util.JsonPoweredTestHelper;
 
-import javax.xml.bind.DatatypeConverter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -54,7 +54,6 @@ import java.util.List;
 import static com.mongodb.ClusterFixture.getDefaultDatabaseName;
 import static com.mongodb.async.client.gridfs.helpers.AsyncStreamHelper.toAsyncInputStream;
 import static com.mongodb.async.client.gridfs.helpers.AsyncStreamHelper.toAsyncOutputStream;
-import static javax.xml.bind.DatatypeConverter.printHexBinary;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -279,7 +278,7 @@ public class GridFSTest extends DatabaseTestCase {
 
         if (assertion.containsKey("result")) {
             assertNull("Should not have thrown an exception", error);
-            assertEquals(printHexBinary(outputStream.toByteArray()).toLowerCase(),
+            assertEquals(Hex.encode(outputStream.toByteArray()).toLowerCase(),
                     assertion.getDocument("result").getString("$hex").getValue());
         } else if (assertion.containsKey("error")) {
             assertNotNull("Should have thrown an exception", error);
@@ -311,7 +310,7 @@ public class GridFSTest extends DatabaseTestCase {
         }
         if (assertion.containsKey("result")) {
             assertNull("Should not have thrown an exception", error);
-            assertEquals(printHexBinary(outputStream.toByteArray()).toLowerCase(),
+            assertEquals(Hex.encode(outputStream.toByteArray()).toLowerCase(),
                     assertion.getDocument("result").getString("$hex").getValue());
         } else if (assertion.containsKey("error")) {
             assertNotNull("Should have thrown an exception", error);
@@ -455,7 +454,7 @@ public class GridFSTest extends DatabaseTestCase {
 
     private BsonDocument parseHexDocument(final BsonDocument document, final String hexDocument) {
         if (document.containsKey(hexDocument) && document.get(hexDocument).isDocument()) {
-            byte[] bytes = DatatypeConverter.parseHexBinary(document.getDocument(hexDocument).getString("$hex").getValue());
+            byte[] bytes = Hex.decode(document.getDocument(hexDocument).getString("$hex").getValue());
             document.put(hexDocument, new BsonBinary(bytes));
         }
         return document;

--- a/driver-core/src/main/com/mongodb/connection/ScramSha1Authenticator.java
+++ b/driver-core/src/main/com/mongodb/connection/ScramSha1Authenticator.java
@@ -19,6 +19,7 @@ package com.mongodb.connection;
 import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
 import com.mongodb.internal.authentication.NativeAuthenticationHelper;
+import org.bson.json.Base64;
 
 import javax.crypto.Mac;
 import javax.crypto.SecretKeyFactory;
@@ -66,7 +67,6 @@ class ScramSha1Authenticator extends SaslAuthenticator {
         private static final String GS2_HEADER = "n,,";
         private static final int RANDOM_LENGTH = 24;
 
-        private final Base64Codec base64Codec;
         private final MongoCredential credential;
         private String clientFirstMessageBare;
         private final RandomStringGenerator randomStringGenerator;
@@ -76,7 +76,6 @@ class ScramSha1Authenticator extends SaslAuthenticator {
 
         ScramSha1SaslClient(final MongoCredential credential, final RandomStringGenerator randomStringGenerator) {
             this.credential = credential;
-            this.base64Codec = new Base64Codec();
             this.randomStringGenerator = randomStringGenerator;
         }
 
@@ -185,7 +184,7 @@ class ScramSha1Authenticator extends SaslAuthenticator {
         }
 
         private byte[] decodeBase64(final String str) {
-            return this.base64Codec.decode(str);
+            return Base64.decode(str);
         }
 
         private byte[] decodeUTF8(final String str) throws SaslException {
@@ -198,7 +197,7 @@ class ScramSha1Authenticator extends SaslAuthenticator {
         }
 
         private String encodeBase64(final byte[] bytes) {
-            return this.base64Codec.encode(bytes);
+            return Base64.encode(bytes);
         }
 
         private String encodeUTF8(final byte[] bytes) throws SaslException {

--- a/driver-core/src/main/com/mongodb/connection/ScramSha1Authenticator.java
+++ b/driver-core/src/main/com/mongodb/connection/ScramSha1Authenticator.java
@@ -19,7 +19,7 @@ package com.mongodb.connection;
 import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
 import com.mongodb.internal.authentication.NativeAuthenticationHelper;
-import org.bson.json.Base64;
+import org.bson.internal.Base64;
 
 import javax.crypto.Mac;
 import javax.crypto.SecretKeyFactory;

--- a/driver/src/main/com/mongodb/util/JSONCallback.java
+++ b/driver/src/main/com/mongodb/util/JSONCallback.java
@@ -26,6 +26,7 @@ import org.bson.BSON;
 import org.bson.BSONObject;
 import org.bson.BasicBSONCallback;
 import org.bson.BsonUndefined;
+import org.bson.json.Base64;
 import org.bson.types.BSONTimestamp;
 import org.bson.types.Binary;
 import org.bson.types.Code;
@@ -35,7 +36,6 @@ import org.bson.types.MaxKey;
 import org.bson.types.MinKey;
 import org.bson.types.ObjectId;
 
-import javax.xml.bind.DatatypeConverter;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -129,7 +129,7 @@ public class JSONCallback extends BasicBSONCallback {
             o = UUID.fromString((String) b.get("$uuid"));
         } else if (b.containsField("$binary")) {
             int type = (b.get("$type") instanceof String) ? Integer.valueOf((String) b.get("$type"), 16) : (Integer) b.get("$type");
-            byte[] bytes = DatatypeConverter.parseBase64Binary((String) b.get("$binary"));
+            byte[] bytes = Base64.decode((String) b.get("$binary"));
             o = new Binary((byte) type, bytes);
         } else if (b.containsField("$undefined") && b.get("$undefined").equals(true)) {
             o = new BsonUndefined();

--- a/driver/src/main/com/mongodb/util/JSONCallback.java
+++ b/driver/src/main/com/mongodb/util/JSONCallback.java
@@ -26,7 +26,7 @@ import org.bson.BSON;
 import org.bson.BSONObject;
 import org.bson.BasicBSONCallback;
 import org.bson.BsonUndefined;
-import org.bson.json.Base64;
+import org.bson.internal.Base64;
 import org.bson.types.BSONTimestamp;
 import org.bson.types.Binary;
 import org.bson.types.Code;

--- a/driver/src/main/com/mongodb/util/JSONSerializers.java
+++ b/driver/src/main/com/mongodb/util/JSONSerializers.java
@@ -21,6 +21,7 @@ import com.mongodb.Bytes;
 import com.mongodb.DBObject;
 import com.mongodb.DBRef;
 import org.bson.BsonUndefined;
+import org.bson.json.Base64;
 import org.bson.types.BSONTimestamp;
 import org.bson.types.Binary;
 import org.bson.types.Code;
@@ -31,7 +32,6 @@ import org.bson.types.MinKey;
 import org.bson.types.ObjectId;
 import org.bson.types.Symbol;
 
-import javax.xml.bind.DatatypeConverter;
 import java.lang.reflect.Array;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -474,7 +474,7 @@ public class JSONSerializers {
 
         protected void serialize(final byte[] bytes, final byte type, final StringBuilder buf) {
             DBObject temp = new BasicDBObject();
-            temp.put("$binary", DatatypeConverter.printBase64Binary(bytes));
+            temp.put("$binary", Base64.encode(bytes));
             temp.put("$type", type);
             serializer.serialize(temp, buf);
         }

--- a/driver/src/main/com/mongodb/util/JSONSerializers.java
+++ b/driver/src/main/com/mongodb/util/JSONSerializers.java
@@ -21,7 +21,7 @@ import com.mongodb.Bytes;
 import com.mongodb.DBObject;
 import com.mongodb.DBRef;
 import org.bson.BsonUndefined;
-import org.bson.json.Base64;
+import org.bson.internal.Base64;
 import org.bson.types.BSONTimestamp;
 import org.bson.types.Binary;
 import org.bson.types.Code;

--- a/driver/src/test/functional/com/mongodb/client/gridfs/GridFSTest.java
+++ b/driver/src/test/functional/com/mongodb/client/gridfs/GridFSTest.java
@@ -34,9 +34,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import util.Hex;
 import util.JsonPoweredTestHelper;
 
-import javax.xml.bind.DatatypeConverter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -47,7 +47,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static javax.xml.bind.DatatypeConverter.printHexBinary;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -225,7 +224,7 @@ public class GridFSTest extends DatabaseTestCase {
 
         if (assertion.containsKey("result")) {
             assertNull("Should not have thrown an exception", error);
-            assertEquals(printHexBinary(outputStream.toByteArray()).toLowerCase(),
+            assertEquals(Hex.encode(outputStream.toByteArray()).toLowerCase(),
                     assertion.getDocument("result").getString("$hex").getValue());
         } else if (assertion.containsKey("error")) {
             assertNotNull("Should have thrown an exception", error);
@@ -250,7 +249,7 @@ public class GridFSTest extends DatabaseTestCase {
         }
         if (assertion.containsKey("result")) {
             assertNull("Should not have thrown an exception", error);
-            assertEquals(printHexBinary(outputStream.toByteArray()).toLowerCase(),
+            assertEquals(Hex.encode(outputStream.toByteArray()).toLowerCase(),
                     assertion.getDocument("result").getString("$hex").getValue());
         } else if (assertion.containsKey("error")) {
             assertNotNull("Should have thrown an exception", error);
@@ -360,7 +359,7 @@ public class GridFSTest extends DatabaseTestCase {
 
     private BsonDocument parseHexDocument(final BsonDocument document, final String hexDocument) {
         if (document.containsKey(hexDocument) && document.get(hexDocument).isDocument()) {
-            byte[] bytes = DatatypeConverter.parseHexBinary(document.getDocument(hexDocument).getString("$hex").getValue());
+            byte[] bytes = Hex.decode(document.getDocument(hexDocument).getString("$hex").getValue());
             document.put(hexDocument, new BsonBinary(bytes));
         }
         return document;

--- a/driver/src/test/unit/com/mongodb/util/JSONSerializersTest.java
+++ b/driver/src/test/unit/com/mongodb/util/JSONSerializersTest.java
@@ -19,7 +19,7 @@ package com.mongodb.util;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBRef;
 import org.bson.BsonUndefined;
-import org.bson.json.Base64;
+import org.bson.internal.Base64;
 import org.bson.types.BSONTimestamp;
 import org.bson.types.BasicBSONList;
 import org.bson.types.Binary;

--- a/driver/src/test/unit/com/mongodb/util/JSONSerializersTest.java
+++ b/driver/src/test/unit/com/mongodb/util/JSONSerializersTest.java
@@ -19,6 +19,7 @@ package com.mongodb.util;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBRef;
 import org.bson.BsonUndefined;
+import org.bson.json.Base64;
 import org.bson.types.BSONTimestamp;
 import org.bson.types.BasicBSONList;
 import org.bson.types.Binary;
@@ -31,7 +32,6 @@ import org.bson.types.ObjectId;
 import org.bson.types.Symbol;
 import org.junit.Test;
 
-import javax.xml.bind.DatatypeConverter;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -203,7 +203,7 @@ public class JSONSerializersTest {
 
         // test  BINARY
         byte[] b = {1, 2, 3, 4};
-        String base64 = DatatypeConverter.printBase64Binary(b);
+        String base64 = Base64.encode(b);
         StringBuilder buf = new StringBuilder();
         serializer.serialize(new Binary(b), buf);
         assertEquals("{ \"$binary\" : \"" + base64 + "\" , \"$type\" : 0}", buf.toString());


### PR DESCRIPTION
Remove dependency on javax.xml.bind.DatatypeConverter

Well, almost.  There is still a runtime dependency on DatatypeConverter for Java 7 and earlier, as that was the only reliable way to get ISO8601 DateTime parsing for JsonReader.