### PR TITLE
A few updates to JAVA-2447

### DIFF
--- a/bson/src/main/org/bson/BsonDocument.java
+++ b/bson/src/main/org/bson/BsonDocument.java
@@ -791,8 +791,11 @@ public class BsonDocument extends BsonValue implements Map<String, BsonValue>, C
     }
 
     /**
-     * Gets a JSON representation of this document using the default settings of {@code JsonWriterSettings}.
+     * Gets a JSON representation of this document using the {@link org.bson.json.JsonMode#STRICT} output mode, and otherwise the default
+     * settings of {@link JsonWriterSettings.Builder}.
+     *
      * @return a JSON representation of this document
+     * @see #toJson(JsonWriterSettings)
      * @see JsonWriterSettings
      */
     @SuppressWarnings("deprecation")

--- a/bson/src/main/org/bson/BsonDocument.java
+++ b/bson/src/main/org/bson/BsonDocument.java
@@ -795,6 +795,7 @@ public class BsonDocument extends BsonValue implements Map<String, BsonValue>, C
      * @return a JSON representation of this document
      * @see JsonWriterSettings
      */
+    @SuppressWarnings("deprecation")
     public String toJson() {
         return toJson(new JsonWriterSettings());
     }

--- a/bson/src/main/org/bson/Document.java
+++ b/bson/src/main/org/bson/Document.java
@@ -261,12 +261,13 @@ public class Document implements Map<String, Object>, Serializable, Bson {
     }
 
     /**
-     * Gets a JSON representation of this document
-     *
-     * <p>With the default {@link JsonWriterSettings} and {@link DocumentCodec}.</p>
+     * Gets a JSON representation of this document using the {@link org.bson.json.JsonMode#STRICT} output mode, and otherwise the default
+     * settings of {@link JsonWriterSettings.Builder} and {@link DocumentCodec}.
      *
      * @return a JSON representation of this document
      * @throws org.bson.codecs.configuration.CodecConfigurationException if the document contains types not in the default registry
+     * @see #toJson(JsonWriterSettings)
+     * @see JsonWriterSettings
      */
     @SuppressWarnings("deprecation")
     public String toJson() {

--- a/bson/src/main/org/bson/Document.java
+++ b/bson/src/main/org/bson/Document.java
@@ -268,6 +268,7 @@ public class Document implements Map<String, Object>, Serializable, Bson {
      * @return a JSON representation of this document
      * @throws org.bson.codecs.configuration.CodecConfigurationException if the document contains types not in the default registry
      */
+    @SuppressWarnings("deprecation")
     public String toJson() {
         return toJson(new JsonWriterSettings());
     }
@@ -294,6 +295,7 @@ public class Document implements Map<String, Object>, Serializable, Bson {
      * @return a JSON representation of this document
      * @throws org.bson.codecs.configuration.CodecConfigurationException if the registry does not contain a codec for the document values.
      */
+    @SuppressWarnings("deprecation")
     public String toJson(final Encoder<Document> encoder) {
         return toJson(new JsonWriterSettings(), encoder);
     }

--- a/bson/src/main/org/bson/RawBsonDocument.java
+++ b/bson/src/main/org/bson/RawBsonDocument.java
@@ -294,6 +294,7 @@ public final class RawBsonDocument extends BsonDocument {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public String toJson() {
         return toJson(new JsonWriterSettings());
     }

--- a/bson/src/main/org/bson/json/JsonWriter.java
+++ b/bson/src/main/org/bson/json/JsonWriter.java
@@ -41,6 +41,7 @@ public class JsonWriter extends AbstractBsonWriter {
      *
      * @param writer the writer to write JSON to.
      */
+    @SuppressWarnings("deprecation")
     public JsonWriter(final Writer writer) {
         this(writer, new JsonWriterSettings());
     }

--- a/bson/src/main/org/bson/json/JsonWriterSettings.java
+++ b/bson/src/main/org/bson/json/JsonWriterSettings.java
@@ -101,6 +101,9 @@ public class JsonWriterSettings extends BsonWriterSettings {
 
     /**
      * Create a builder for JsonWriterSettings, which are immutable.
+     * <p>
+     *     Defaults to {@link JsonMode#RELAXED}
+     * </p>
      *
      * @return a Builder instance
      * @since 3.5
@@ -111,9 +114,15 @@ public class JsonWriterSettings extends BsonWriterSettings {
 
     /**
      * Creates a new instance with default values for all properties.
+     * <p>
+     *     Defaults to {@link JsonMode#STRICT}
+     * </p>
+     *
+     * @deprecated Prefer {@link #builder()}, but note that the default output mode is different for that method
      */
+    @Deprecated
     public JsonWriterSettings() {
-        this(builder());
+        this(builder().outputMode(JsonMode.STRICT));
     }
 
     /**
@@ -540,7 +549,7 @@ public class JsonWriterSettings extends BsonWriterSettings {
         private boolean indent;
         private String newLineCharacters = System.getProperty("line.separator");
         private String indentCharacters = "  ";
-        private JsonMode outputMode = JsonMode.STRICT;
+        private JsonMode outputMode = JsonMode.RELAXED;
         private Converter<BsonNull> nullConverter;
         private Converter<String> stringConverter;
         private Converter<Long> dateTimeConverter;
@@ -569,7 +578,7 @@ public class JsonWriterSettings extends BsonWriterSettings {
         }
 
         /**
-         * Sets whether indentation is enabled.
+         * Sets whether indentation is enabled, which defaults to false.
          *
          * @param indent whether indentation is enabled
          * @return this
@@ -580,7 +589,8 @@ public class JsonWriterSettings extends BsonWriterSettings {
         }
 
         /**
-         * Sets the new line character string to use when indentation is enabled.
+         * Sets the new line character string to use when indentation is enabled, which defaults to
+         * {@code System.getProperty("line.separator")}.
          *
          * @param newLineCharacters the non-null new line character string
          * @return this
@@ -592,7 +602,7 @@ public class JsonWriterSettings extends BsonWriterSettings {
         }
 
         /**
-         * Sets the indent character string to use when indentation is enabled.
+         * Sets the indent character string to use when indentation is enabled, which defaults to two spaces.
          *
          * @param indentCharacters the non-null indent character string
          * @return this
@@ -604,7 +614,7 @@ public class JsonWriterSettings extends BsonWriterSettings {
         }
 
         /**
-         * Sets the output mode.
+         * Sets the output mode, which defaults to {@link JsonMode#RELAXED}.
          *
          * @param outputMode the non-null output mode
          * @return this

--- a/bson/src/test/unit/org/bson/json/JsonWriterSettingsSpecification.groovy
+++ b/bson/src/test/unit/org/bson/json/JsonWriterSettingsSpecification.groovy
@@ -28,6 +28,13 @@ class JsonWriterSettingsSpecification extends Specification {
         then:
         !settings.isIndent()
         settings.getOutputMode() == JsonMode.STRICT
+
+        when:
+        settings = JsonWriterSettings.builder().build();
+
+        then:
+        !settings.isIndent()
+        settings.getOutputMode() == JsonMode.RELAXED
     }
 
 

--- a/bson/src/test/unit/org/bson/json/JsonWriterTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonWriterTest.java
@@ -41,7 +41,7 @@ public class JsonWriterTest {
     @Before
     public void before() {
         stringWriter = new StringWriter();
-        writer = new JsonWriter(stringWriter, new JsonWriterSettings());
+        writer = new JsonWriter(stringWriter, JsonWriterSettings.builder().build());
     }
 
     private static class TestData<T> {
@@ -261,11 +261,11 @@ public class JsonWriterTest {
                 new TestData<Double>(Double.POSITIVE_INFINITY, "Infinity"));
         for (final TestData<Double> cur : tests) {
             stringWriter = new StringWriter();
-            writer = new JsonWriter(stringWriter, new JsonWriterSettings());
+            writer = new JsonWriter(stringWriter, JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build());
             writer.writeStartDocument();
             writer.writeDouble("d", cur.value);
             writer.writeEndDocument();
-            String expected = "{ \"d\" : " + cur.expected + " }";
+            String expected = "{ \"d\" : { \"$numberDouble\" : \"" + cur.expected + "\" } }";
             assertEquals(expected, stringWriter.toString());
         }
     }

--- a/driver-core/src/main/com/mongodb/client/model/geojson/Geometry.java
+++ b/driver-core/src/main/com/mongodb/client/model/geojson/Geometry.java
@@ -66,7 +66,7 @@ public abstract class Geometry {
      *
      * @return the GeoJSON representation
      */
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({"unchecked", "rawtypes", "deprecation"})
     public String toJson() {
         StringWriter stringWriter = new StringWriter();
         JsonWriter writer = new JsonWriter(stringWriter, new JsonWriterSettings());

--- a/driver-core/src/main/com/mongodb/connection/ByteBufBsonDocument.java
+++ b/driver-core/src/main/com/mongodb/connection/ByteBufBsonDocument.java
@@ -236,6 +236,7 @@ class ByteBufBsonDocument extends BsonDocument implements Cloneable {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public String toJson() {
         return toJson(new JsonWriterSettings());
     }

--- a/driver/src/main/com/mongodb/BasicDBObject.java
+++ b/driver/src/main/com/mongodb/BasicDBObject.java
@@ -133,12 +133,13 @@ public class BasicDBObject extends BasicBSONObject implements DBObject, Bson {
     }
 
     /**
-     * Gets a JSON representation of this document
-     *
-     * <p>With the default {@link JsonWriterSettings} and {@link DBObjectCodec}.</p>
+     * Gets a JSON representation of this document using the {@link org.bson.json.JsonMode#STRICT} output mode, and otherwise the default
+     * settings of {@link JsonWriterSettings.Builder} and {@link DBObjectCodec}.
      *
      * @return a JSON representation of this document
      * @throws org.bson.codecs.configuration.CodecConfigurationException if the document contains types not in the default registry
+     * @see #toJson(JsonWriterSettings)
+     * @see JsonWriterSettings
      */
     @SuppressWarnings("deprecation")
     public String toJson() {

--- a/driver/src/main/com/mongodb/BasicDBObject.java
+++ b/driver/src/main/com/mongodb/BasicDBObject.java
@@ -140,6 +140,7 @@ public class BasicDBObject extends BasicBSONObject implements DBObject, Bson {
      * @return a JSON representation of this document
      * @throws org.bson.codecs.configuration.CodecConfigurationException if the document contains types not in the default registry
      */
+    @SuppressWarnings("deprecation")
     public String toJson() {
         return toJson(new JsonWriterSettings());
     }
@@ -166,6 +167,7 @@ public class BasicDBObject extends BasicBSONObject implements DBObject, Bson {
      * @return a JSON representation of this document
      * @throws org.bson.codecs.configuration.CodecConfigurationException if the registry does not contain a codec for the document values.
      */
+    @SuppressWarnings("deprecation")
     public String toJson(final Encoder<BasicDBObject> encoder) {
         return toJson(new JsonWriterSettings(), encoder);
     }


### PR DESCRIPTION
1. Change default JsonMode for JsonWriterSettings.builder() to JsonMode#RELAXED and deprecate JsonWriterSettings constructor
2. Document that toJson() method in BsonDocument, Document, and BasicDBObject defaults to deprecated JsonMode#STRICT

To track spec compliance opened https://jira.mongodb.org/browse/JAVA-2556, which is a breaking change.