### PR TITLE
Updates for the 3.5 release

### DIFF
--- a/bson/build.gradle
+++ b/bson/build.gradle
@@ -23,7 +23,7 @@ archivesBaseName = 'bson'
 
 clirr {
     excludeFilter = new File("$configDir/clirr-exclude.yml")
-    baseline 'org.mongodb:bson:3.2.0'
+    baseline 'org.mongodb:bson:3.4.0'
     failOnErrors = true
 }
 

--- a/docs/landing/data/releases.toml
+++ b/docs/landing/data/releases.toml
@@ -1,14 +1,13 @@
-current = "3.4.2"
+current = "3.5.0"
 
 [[versions]]
-  version = "3.5.0-SNAPSHOT"
-  status = "snapshot"
+  version = "3.5.0"
+  status = "current"
   docs = "./3.5"
   api = "./3.5/javadoc"
 
 [[versions]]
   version = "3.4.2"
-  status = "current"
   docs = "./3.4"
   api = "./3.4/javadoc"
 
@@ -45,19 +44,19 @@ current = "3.4.2"
 [[drivers]]
   name = "mongodb-driver"
   description = "The synchronous driver, new in 3.0.<br/>For older versions of the driver or for OSGi-based applications please use the `mongo-java-driver`."
-  versions = "3.5.0-SNAPSHOT,3.4.2,3.3.0,3.2.2,3.1.1,3.0.4"
+  versions = "3.5.0,3.4.2,3.3.0,3.2.2,3.1.1,3.0.4"
 
 [[drivers]]
   name = "mongo-java-driver"
   description = "An uber jar containing the bson library, the core library and the mongodb-driver.<br/>This artifact is a valid OSGi bundle."
-  versions = "3.5.0-SNAPSHOT,3.4.2,3.3.0,3.2.2,3.1.1,3.0.4,2.14.2,2.13.3"
+  versions = "3.5.0,3.4.2,3.3.0,3.2.2,3.1.1,3.0.4,2.14.2,2.13.3"
 
 [[drivers]]
   name = "mongodb-driver-async"
   description = "The new asynchronous driver, new in 3.0"
-  versions = "3.5.0-SNAPSHOT,3.4.2,3.3.0,3.2.2,3.1.1,3.0.4"
+  versions = "3.5.0,3.4.2,3.3.0,3.2.2,3.1.1,3.0.4"
 
 [[drivers]]
   name = "mongodb-driver-core"
   description = "The core library, new in 3.0"
-  versions = "3.5.0-SNAPSHOT,3.4.2,3.3.0,3.2.2,3.1.1,3.0.4"
+  versions = "3.5.0,3.4.2,3.3.0,3.2.2,3.1.1,3.0.4"

--- a/docs/landing/static/versions.json
+++ b/docs/landing/static/versions.json
@@ -1,1 +1,1 @@
-[{"version": "3.4"}, {"version": "3.3"}, {"version": "3.2"}, {"version": "3.1"}, {"version": "3.0"}, {"version": "2.13"}, {"version": "2.14"}]
+[{"version": "3.5"}, {"version": "3.4"}, {"version": "3.3"}, {"version": "3.2"}, {"version": "3.1"}, {"version": "3.0"}, {"version": "2.13"}, {"version": "2.14"}]

--- a/docs/reference/content/bson/installation-guide.md
+++ b/docs/reference/content/bson/installation-guide.md
@@ -22,4 +22,4 @@ This library comprehensively supports [BSON](http://www.bsonspec.org),
 the data storage and network transfer format that MongoDB uses for "documents".
 BSON is short for Binary [JSON](http://json.org/), is a binary-encoded serialization of JSON-like documents.
 
-{{< install artifactId="bson" version="3.4.2" >}}
+{{< install artifactId="bson" version="3.5.0" >}}

--- a/docs/reference/content/driver-async/getting-started/installation.md
+++ b/docs/reference/content/driver-async/getting-started/installation.md
@@ -23,4 +23,4 @@ The MongoDB Async Driver requires either [Netty](http://netty.io/) or Java 7.
 
 The MongoDB Async Driver provides asynchronous API that can leverage either Netty or Java 7's AsynchronousSocketChannel for fast and non-blocking I/O.
 
-{{< install artifactId="mongodb-driver-async" version="3.5.0-SNAPSHOT" dependencies="true">}}
+{{< install artifactId="mongodb-driver-async" version="3.5.0" dependencies="true">}}

--- a/docs/reference/content/driver-async/index.md
+++ b/docs/reference/content/driver-async/index.md
@@ -9,7 +9,7 @@ title = "MongoDB Async Driver"
 
 ## MongoDB Async Java Driver Documentation
 
-The following guide provides information on using the callback-based MongoDB Async Java Driver 3.4.
+The following guide provides information on using the callback-based MongoDB Async Java Driver 3.5.
 
 {{% note %}}
 There are two higher level MongoDB Asynchronous Java Drivers available, that users may find easier to work with due to their friendlier APIs:

--- a/docs/reference/content/driver-async/tutorials/ssl.md
+++ b/docs/reference/content/driver-async/tutorials/ssl.md
@@ -19,7 +19,7 @@ To use TLS/SSL, you must configure the asynchronous driver to use [Netty](http:/
 
 {{% note %}}
 If your application requires Netty, it must explicitly add a dependency to
-Netty artifacts.  The driver is currently tested against Netty 4.0.
+Netty artifacts.  The driver is currently tested against Netty 4.1.
 {{% /note %}}
 
 ### Via Connection String
@@ -36,7 +36,9 @@ You can also specify the connection string via the [`ConnectionString`]({{< apir
 
 ### Via `MongoClientSettings`
 
-To specify TLS/SSL with  [`MongoClientSettings`]({{< apiref "com/mongodb/async/client/MongoClientSettings.Builder.html#streamFactoryFactory-com.mongodb.connection.StreamFactoryFactory-">}}) , set the ``sslEnabled`` property to ``true``, and the stream factory to [`NettyStreamFactoryFactory`]({{< apiref "com/mongodb/connection/netty/NettyStreamFactoryFactory" >}}), as in
+To specify TLS/SSL with  [`MongoClientSettings`]({{< apiref "com/mongodb/async/client/MongoClientSettings.Builder.html#streamFactoryFactory-com.mongodb.connection.StreamFactoryFactory-">}}) , 
+set the ``sslEnabled`` property to ``true``, and the stream factory to 
+[`NettyStreamFactoryFactory`]({{< apiref "com/mongodb/connection/netty/NettyStreamFactoryFactory" >}}), as in
 
 ```java
 
@@ -64,6 +66,18 @@ configurable via the [`NettyStreamFactoryFactory`]({{< apiref "com/mongodb/conne
 Netty may also be configured by setting the `org.mongodb.async.type` system property to `netty`, but this should be considered as
 deprecated as of the 3.1 driver release.
 {{% /note %}}
+
+To override the default [`javax.net.ssl.SSLContext`](https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLContext.html) used for SSL
+connections, set the `sslContext` property on the `SslSettings`, as in:
+
+```java
+ SSLContext sslContext = ...
+ SslSettings sslSettings = SslSettings.builder()
+                                      .enabled(true)
+                                      .sslContext(sslContext)
+                                      .build();
+ // Pass sslSettings to the MongoClientSettings.Builder
+```
 
 
 ## Disable Hostname Verification

--- a/docs/reference/content/driver/getting-started/installation.md
+++ b/docs/reference/content/driver/getting-started/installation.md
@@ -13,7 +13,7 @@ title = "Installation"
 The recommended way to get started using one of the drivers in your
 project is with a dependency management system.
 
-There are two Maven artifacts available in the 3.4 release. The preferred artifact for new applications is `mongodb-driver`
+There are two Maven artifacts available in the 3.5 release. The preferred artifact for new applications is `mongodb-driver`
 however, we still publish the legacy `mongo-java-driver` uber-jar.
 
 {{< distroPicker >}}
@@ -29,7 +29,7 @@ For OSGi-based applications, use the [mongo-java-driver](#uber-jar-legacy) uber 
 
 {{% /note %}}
 
-{{< install artifactId="mongodb-driver" version="3.5.0-SNAPSHOT" dependencies="true">}}
+{{< install artifactId="mongodb-driver" version="3.5.0" dependencies="true">}}
 
 
 ## Uber Jar (Legacy)
@@ -41,4 +41,4 @@ For new applications, the preferred artifact is [mongodb-driver](#mongodb-driver
 The `mongo-java-driver` artifact is a valid OSGi bundle.
 {{% /note %}}
 
-{{< install artifactId="mongo-java-driver" version="3.5.0-SNAPSHOT">}}
+{{< install artifactId="mongo-java-driver" version="3.5.0">}}

--- a/docs/reference/content/driver/tutorials/jndi.md
+++ b/docs/reference/content/driver/tutorials/jndi.md
@@ -28,7 +28,7 @@ The configuration of the `MongoClientFactory` differs depending on the applicati
 
         <module xmlns="urn:jboss:module:1.3" name="org.mongodb">
            <resources>
-               <resource-root path="mongo-java-driver-3.4.2.jar"/>
+               <resource-root path="mongo-java-driver-3.5.0.jar"/>
            </resources>
            <dependencies>
                <module name="javax.api"/>

--- a/docs/reference/content/driver/tutorials/ssl.md
+++ b/docs/reference/content/driver/tutorials/ssl.md
@@ -35,10 +35,30 @@ MongoClient mongoClient = new MongoClient(uri);
 import com.mongodb.MongoClientOptions;
 ```
 
-To specify TLS/SSL with with [`MongoClientOptions`]({{<apiref "com/mongodb/MongoClientOptions">}}), set the ``sslEnabled`` property to ``true``, as in:
+To specify TLS/SSL with with [`MongoClientOptions`]({{<apiref "com/mongodb/MongoClientOptions">}}), set the `sslEnabled` property to `true`, as in:
 
 ```java
  MongoClientOptions options = MongoClientOptions.builder().sslEnabled(true).build();
+ MongoClient client = new MongoClient("localhost", options);
+```
+
+## Specify `SSLContext` via `MongoClientOptions`
+
+```java
+import javax.net.ssl.SSLContext;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoClient;
+```
+
+To specify the [`javax.net.ssl.SSLContext`](https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLContext.html) with 
+[`MongoClientOptions`]({{<apiref "com/mongodb/MongoClientOptions">}}), set the `sslContext` property, as in:
+
+```java
+ SSLContext sslContext = ...
+ MongoClientOptions options = MongoClientOptions.builder()
+                                                .sslEnabled(true)
+                                                .sslContext(sslContext)
+                                                .build();
  MongoClient client = new MongoClient("localhost", options);
 ```
 

--- a/docs/reference/content/index.md
+++ b/docs/reference/content/index.md
@@ -6,12 +6,12 @@ type = "index"
 
 ## MongoDB Java Driver Documentation
 
-Welcome to the MongoDB Java driver documentation hub for the 3.4 driver release.
+Welcome to the MongoDB Java driver documentation hub for the 3.5 driver release.
 
 
-### What's New in 3.4
+### What's New in 3.5
 
-For key new features of 3.4, see [What's New]({{< relref "whats-new.md" >}}).
+For key new features of 3.5, see [What's New]({{< relref "whats-new.md" >}}).
 
 ### Upgrade
 

--- a/docs/reference/content/upgrading.md
+++ b/docs/reference/content/upgrading.md
@@ -2,19 +2,15 @@
 date = "2015-03-19T12:53:39-04:00"
 title = "Upgrade Considerations"
 [menu.main]
-  identifier = "Upgrading to 3.4"
+  identifier = "Upgrading to 3.5"
   weight = 80
   pre = "<i class='fa fa-level-up'></i>"
 +++
 
-## Upgrading from 3.3.x
+## Upgrading from 3.4.x
 
-There is one breaking API change in the 3.4 release: due to the addition of a new BSON type for 128-bit decimal values, a new method
-had to be added to the BSONCallback({{< apiref "org/bson/BSONCallback.html">}}) interface.  Any clients that directly implement that
-interface must add an implementation of the new method in order to be compatible with the 3.4 driver.
-
-Otherwise, the 3.4 release is binary and source compatible with the 3.3 release, except for methods that have been added to interfaces that
-have been marked as unstable.
+The 3.5 release is binary and source compatible with the 3.4 release, except for methods that have been added to interfaces that
+have been marked as unstable, and changes to classes or interfaces that have been marked as internal or annotated as Beta.
 
 ## Upgrading from 2.x
 
@@ -36,6 +32,7 @@ The following table specifies the compatibility of the MongoDB Java driver for u
 
 |Java Driver Version|MongoDB 2.6|MongoDB 3.0 |MongoDB 3.2|MongoDB 3.4|
 |-------------------|-----------|------------|-----------|-----------|
+|Version 3.5        |  ✓  |  ✓  |  ✓  |  ✓  |
 |Version 3.4        |  ✓  |  ✓  |  ✓  |  ✓  |
 |Version 3.3        |  ✓  |  ✓  |  ✓  |     |
 |Version 3.2        |  ✓  |  ✓  |  ✓  |     |
@@ -46,6 +43,7 @@ The following table specifies the compatibility of the MongoDB Java driver for u
 
 |Java Driver Version|Java 5 | Java 6 | Java 7 | Java 8 |
 |-------------------|-------|--------|--------|--------|
+|Version 3.5        |     | ✓ | ✓ | ✓ |
 |Version 3.4        |     | ✓ | ✓ | ✓ |
 |Version 3.3        |     | ✓ | ✓ | ✓ |
 |Version 3.2        |     | ✓ | ✓ | ✓ |

--- a/docs/reference/content/whats-new.md
+++ b/docs/reference/content/whats-new.md
@@ -7,8 +7,41 @@ title = "What's New"
   pre = "<i class='fa fa-level-up'></i>"
 +++
 
-# What's New 3.5
+## What's New in 3.5
 
+Key new features of the 3.5 Java driver release:
+
+### Native POJO support
+
+The 3.5 release adds support for [POJO](https://en.wikipedia.org/wiki/Plain_old_Java_object) serialization at the BSON layer, and can be
+used by the synchronous and asynchronous drivers.  See the POJO Quick start pages for details.
+
+* [POJO Quick Start]({{<ref "driver/getting-started/quick-start-pojo.md">}}) 
+* [POJO Quick Start (Async)]({{<ref "driver-async/getting-started/quick-start-pojo.md">}})
+* [POJO Reference]({{<ref "bson/pojos.md">}}) 
+
+### Improved JSON support
+
+The 3.5 release improves support for JSON parsing and generation.
+
+* Implements the new [Extended JSON specification](https://github.com/mongodb/specifications/blob/master/source/extended-json.rst)
+* Implements custom JSON converters to give applications full control over JSON generation for each BSON type
+
+See the [JSON reference]({{<ref "bson/extended-json.md">}}) for details. 
+
+### Connection pool monitoring
+
+The 3.5 release adds support for monitoring connection pool-related events.
+
+* [Connection pool monitoring in the driver]({{<ref "driver/reference/monitoring.md">}})
+* [Connection pool monitoring in the async driver]({{<ref "driver-async/reference/monitoring.md">}})
+
+### SSLContext configuration
+
+The 3.5 release supports overriding the default `javax.net.ssl.SSLContext` used for SSL connections to MongoDB.
+
+* [SSL configuration in the driver]({{<ref "driver/tutorials/ssl.md">}})
+* [SSL configuration in the async driver]({{<ref "driver-async/tutorials/ssl.md">}})
 
 ### KeepAlive configuration deprecated
 
@@ -22,7 +55,7 @@ documentation for more information.
 
 ## What's New in 3.4
 
-The 3.4 release included full support for the upcoming MongoDB 3.4 server release.  Key new features include:
+The 3.4 release includes full support for the MongoDB 3.4 server release.  Key new features include:
 
 ### Support for Decimal128 Format
 
@@ -182,4 +215,4 @@ The synchronous driver now includes a [JNDI]({{<ref "driver/tutorials/jndi.md">}
 
 ## Upgrading
 
-See the [upgrading guide]({{<ref "upgrading.md">}}) on how to upgrade to 3.4.
+See the [upgrading guide]({{<ref "upgrading.md">}}) on how to upgrade to 3.5.

--- a/driver-async/build.gradle
+++ b/driver-async/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 
 clirr {
     excludeFilter = new File("$configDir/clirr-exclude.yml")
-    baseline 'org.mongodb:mongodb-driver-async:3.2.0'
+    baseline 'org.mongodb:mongodb-driver-async:3.4.0'
     failOnErrors = false
 }
 

--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -22,7 +22,7 @@ archivesBaseName = 'mongodb-driver-core'
 
 clirr {
     excludeFilter = new File("$configDir/clirr-exclude.yml")
-    baseline 'org.mongodb:mongodb-driver-core:3.2.0'
+    baseline 'org.mongodb:mongodb-driver-core:3.4.0'
     failOnErrors = false
 }
 

--- a/driver/build.gradle
+++ b/driver/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 
 clirr {
     excludeFilter = new File("$configDir/clirr-exclude.yml")
-    baseline 'org.mongodb:mongodb-driver:3.2.0'
+    baseline 'org.mongodb:mongodb-driver:3.4.0'
     failOnErrors = false
 }
 


### PR DESCRIPTION
Includes reference documentation and a CLIRR baseline update to check for compatibility issues with 3.4.

Published to [my fork's github pages](http://jyemin.github.io/mongo-java-driver/)