### PR TITLE
JAVA-2583

### DIFF
--- a/bson/src/main/org/bson/BsonWriter.java
+++ b/bson/src/main/org/bson/BsonWriter.java
@@ -19,6 +19,8 @@ package org.bson;
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
 
+import java.util.List;
+
 /**
  * An interface for writing a logical BSON document using a push-oriented API.
  *
@@ -356,4 +358,13 @@ public interface BsonWriter {
      * @param reader The source.
      */
     void pipe(BsonReader reader);
+
+    /**
+     * Reads a single document from a BsonReader and writes it to this, appending the given extra elements to the end of
+     * the document.
+     *
+     * @param reader The source.
+     * @param extraElements The extra BSON elements to append
+     */
+    void pipe(BsonReader reader, List<BsonElement> extraElements);
 }

--- a/bson/src/main/org/bson/ElementExtendingBsonWriter.java
+++ b/bson/src/main/org/bson/ElementExtendingBsonWriter.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.bson;
+
+import org.bson.codecs.BsonTypeCodecMap;
+import org.bson.codecs.BsonValueCodecProvider;
+import org.bson.codecs.Codec;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
+
+import java.util.List;
+
+import static org.bson.assertions.Assertions.notNull;
+import static org.bson.codecs.BsonValueCodecProvider.getBsonTypeClassMap;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+
+/**
+ * A BsonWriter implementation that delegates to another BsonWriter, appending a list of extra Bson elements to the end of the document.
+ *
+ * @since 3.6
+ */
+public class ElementExtendingBsonWriter implements BsonWriter {
+    private static final CodecRegistry REGISTRY = fromProviders(new BsonValueCodecProvider());
+    private static final BsonTypeCodecMap CODEC_MAP = new BsonTypeCodecMap(getBsonTypeClassMap(), REGISTRY);
+    private static final EncoderContext ENCODER_CONTEXT = EncoderContext.builder().build();
+
+    private final BsonWriter bsonWriter;
+    private final List<BsonElement> extraElements;
+    private int level;
+
+    /**
+     * Construct an instance
+     *
+     * @param bsonWriter    the delegate
+     * @param extraElements the extra elements
+     */
+    public ElementExtendingBsonWriter(final BsonWriter bsonWriter, final List<BsonElement> extraElements) {
+        this.bsonWriter = notNull("bsonWriter", bsonWriter);
+        this.extraElements = notNull("extraElements", extraElements);
+    }
+
+    @Override
+    public void writeStartDocument(final String name) {
+        level++;
+        bsonWriter.writeStartDocument(name);
+    }
+
+    @Override
+    public void writeStartDocument() {
+        level++;
+        bsonWriter.writeStartDocument();
+    }
+
+    @Override
+    public void writeEndDocument() {
+        level--;
+        if (level == 0) {
+            writeExtraElements();
+        }
+        bsonWriter.writeEndDocument();
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void writeExtraElements() {
+        for (BsonElement cur : extraElements) {
+            bsonWriter.writeName(cur.getName());
+            Codec codec = CODEC_MAP.get(cur.getValue().getBsonType());
+            codec.encode(bsonWriter, cur.getValue(), ENCODER_CONTEXT);
+        }
+    }
+
+    @Override
+    public void writeStartArray(final String name) {
+        bsonWriter.writeStartArray(name);
+    }
+
+    @Override
+    public void writeStartArray() {
+        bsonWriter.writeStartArray();
+    }
+
+    @Override
+    public void writeEndArray() {
+        bsonWriter.writeEndArray();
+    }
+
+    @Override
+    public void writeBinaryData(final String name, final BsonBinary binary) {
+        bsonWriter.writeBinaryData(name, binary);
+    }
+
+    @Override
+    public void writeBinaryData(final BsonBinary binary) {
+        bsonWriter.writeBinaryData(binary);
+    }
+
+    @Override
+    public void writeBoolean(final String name, final boolean value) {
+        bsonWriter.writeBoolean(name, value);
+    }
+
+    @Override
+    public void writeBoolean(final boolean value) {
+        bsonWriter.writeBoolean(value);
+    }
+
+    @Override
+    public void writeDateTime(final String name, final long value) {
+        bsonWriter.writeDateTime(name, value);
+    }
+
+    @Override
+    public void writeDateTime(final long value) {
+        bsonWriter.writeDateTime(value);
+    }
+
+    @Override
+    public void writeDBPointer(final String name, final BsonDbPointer value) {
+        bsonWriter.writeDBPointer(name, value);
+    }
+
+    @Override
+    public void writeDBPointer(final BsonDbPointer value) {
+        bsonWriter.writeDBPointer(value);
+    }
+
+    @Override
+    public void writeDouble(final String name, final double value) {
+        bsonWriter.writeDouble(name, value);
+    }
+
+    @Override
+    public void writeDouble(final double value) {
+        bsonWriter.writeDouble(value);
+    }
+
+    @Override
+    public void writeInt32(final String name, final int value) {
+        bsonWriter.writeInt32(name, value);
+    }
+
+    @Override
+    public void writeInt32(final int value) {
+        bsonWriter.writeInt32(value);
+    }
+
+    @Override
+    public void writeInt64(final String name, final long value) {
+        bsonWriter.writeInt64(name, value);
+    }
+
+    @Override
+    public void writeInt64(final long value) {
+        bsonWriter.writeInt64(value);
+    }
+
+    @Override
+    public void writeDecimal128(final Decimal128 value) {
+        bsonWriter.writeDecimal128(value);
+    }
+
+    @Override
+    public void writeDecimal128(final String name, final Decimal128 value) {
+        bsonWriter.writeDecimal128(name, value);
+    }
+
+    @Override
+    public void writeJavaScript(final String name, final String code) {
+        bsonWriter.writeJavaScript(name, code);
+    }
+
+    @Override
+    public void writeJavaScript(final String code) {
+        bsonWriter.writeJavaScript(code);
+    }
+
+    @Override
+    public void writeJavaScriptWithScope(final String name, final String code) {
+        bsonWriter.writeJavaScriptWithScope(name, code);
+    }
+
+    @Override
+    public void writeJavaScriptWithScope(final String code) {
+        bsonWriter.writeJavaScriptWithScope(code);
+    }
+
+    @Override
+    public void writeMaxKey(final String name) {
+        bsonWriter.writeMaxKey(name);
+    }
+
+    @Override
+    public void writeMaxKey() {
+        bsonWriter.writeMaxKey();
+    }
+
+    @Override
+    public void writeMinKey(final String name) {
+        bsonWriter.writeMinKey(name);
+    }
+
+    @Override
+    public void writeMinKey() {
+        bsonWriter.writeMinKey();
+    }
+
+    @Override
+    public void writeName(final String name) {
+        bsonWriter.writeName(name);
+    }
+
+    @Override
+    public void writeNull(final String name) {
+        bsonWriter.writeNull(name);
+    }
+
+    @Override
+    public void writeNull() {
+        bsonWriter.writeNull();
+    }
+
+    @Override
+    public void writeObjectId(final String name, final ObjectId objectId) {
+        bsonWriter.writeObjectId(name, objectId);
+    }
+
+    @Override
+    public void writeObjectId(final ObjectId objectId) {
+        bsonWriter.writeObjectId(objectId);
+    }
+
+    @Override
+    public void writeRegularExpression(final String name, final BsonRegularExpression regularExpression) {
+        bsonWriter.writeRegularExpression(name, regularExpression);
+    }
+
+    @Override
+    public void writeRegularExpression(final BsonRegularExpression regularExpression) {
+        bsonWriter.writeRegularExpression(regularExpression);
+    }
+
+    @Override
+    public void writeString(final String name, final String value) {
+        bsonWriter.writeString(name, value);
+    }
+
+    @Override
+    public void writeString(final String value) {
+        bsonWriter.writeString(value);
+    }
+
+    @Override
+    public void writeSymbol(final String name, final String value) {
+        bsonWriter.writeSymbol(name, value);
+    }
+
+    @Override
+    public void writeSymbol(final String value) {
+        bsonWriter.writeSymbol(value);
+    }
+
+    @Override
+    public void writeTimestamp(final String name, final BsonTimestamp value) {
+        bsonWriter.writeTimestamp(name, value);
+    }
+
+    @Override
+    public void writeTimestamp(final BsonTimestamp value) {
+        bsonWriter.writeTimestamp(value);
+    }
+
+    @Override
+    public void writeUndefined(final String name) {
+        bsonWriter.writeUndefined(name);
+    }
+
+    @Override
+    public void writeUndefined() {
+        bsonWriter.writeUndefined();
+    }
+
+    @Override
+    public void pipe(final BsonReader reader) {
+        if (level == 0) {
+            bsonWriter.pipe(reader, extraElements);
+        } else {
+            bsonWriter.pipe(reader);
+        }
+    }
+
+    @Override
+    public void pipe(final BsonReader reader, final List<BsonElement> extraElements) {
+        bsonWriter.pipe(reader, extraElements);
+    }
+
+    @Override
+    public void flush() {
+        bsonWriter.flush();
+    }
+}

--- a/bson/src/test/unit/org/bson/BsonBinaryWriterTest.java
+++ b/bson/src/test/unit/org/bson/BsonBinaryWriterTest.java
@@ -26,7 +26,9 @@ import org.junit.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.List;
 
+import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -631,6 +633,98 @@ public class BsonBinaryWriterTest {
         assertEquals(0, reader2.readInt32("i"));
         reader2.readEndDocument();
         reader2.readEndDocument();
+    }
+
+    @Test
+    public void testPipeWithExtraElements() {
+        writer.writeStartDocument();
+        writer.writeBoolean("a", true);
+        writer.writeString("$db", "test");
+        writer.writeStartDocument("$readPreference");
+        writer.writeString("mode", "primary");
+        writer.writeEndDocument();
+        writer.writeEndDocument();
+
+        byte[] bytes = buffer.toByteArray();
+
+        BasicOutputBuffer pipedBuffer = new BasicOutputBuffer();
+        BsonBinaryWriter pipedWriter = new BsonBinaryWriter(new BsonWriterSettings(100),
+                                                                   new BsonBinaryWriterSettings(1024), pipedBuffer);
+
+        pipedWriter.writeStartDocument();
+        pipedWriter.writeBoolean("a", true);
+        pipedWriter.writeEndDocument();
+
+        List<BsonElement> extraElements = asList(
+                new BsonElement("$db", new BsonString("test")),
+                new BsonElement("$readPreference", new BsonDocument("mode", new BsonString("primary")))
+        );
+
+        BasicOutputBuffer newBuffer = new BasicOutputBuffer();
+        BsonBinaryWriter newWriter = new BsonBinaryWriter(newBuffer);
+        try {
+            BsonBinaryReader reader =
+                    new BsonBinaryReader(new ByteBufferBsonInput(new ByteBufNIO(ByteBuffer.wrap(pipedBuffer.toByteArray()))));
+            try {
+                newWriter.pipe(reader, extraElements);
+            } finally {
+                reader.close();
+            }
+        } finally {
+            newWriter.close();
+        }
+        assertArrayEquals(bytes, newBuffer.toByteArray());
+    }
+
+    @Test
+    public void testPipeOfNestedDocumentWithExtraElements() {
+        writer.writeStartDocument();
+        writer.writeStartDocument("nested");
+
+        writer.writeBoolean("a", true);
+        writer.writeString("$db", "test");
+        writer.writeStartDocument("$readPreference");
+        writer.writeString("mode", "primary");
+        writer.writeEndDocument();
+        writer.writeEndDocument();
+
+        writer.writeBoolean("b", true);
+        writer.writeEndDocument();
+
+        byte[] bytes = buffer.toByteArray();
+
+        BasicOutputBuffer pipedBuffer = new BasicOutputBuffer();
+        BsonBinaryWriter pipedWriter = new BsonBinaryWriter(new BsonWriterSettings(100),
+                                                                   new BsonBinaryWriterSettings(1024), pipedBuffer);
+
+        pipedWriter.writeStartDocument();
+        pipedWriter.writeBoolean("a", true);
+        pipedWriter.writeEndDocument();
+
+        List<BsonElement> extraElements = asList(
+                new BsonElement("$db", new BsonString("test")),
+                new BsonElement("$readPreference", new BsonDocument("mode", new BsonString("primary")))
+        );
+
+        BasicOutputBuffer newBuffer = new BasicOutputBuffer();
+        BsonBinaryWriter newWriter = new BsonBinaryWriter(newBuffer);
+        try {
+            BsonBinaryReader reader =
+                    new BsonBinaryReader(new ByteBufferBsonInput(new ByteBufNIO(ByteBuffer.wrap(pipedBuffer.toByteArray()))));
+            try {
+                newWriter.writeStartDocument();
+                newWriter.writeName("nested");
+                newWriter.pipe(reader, extraElements);
+                newWriter.writeBoolean("b", true);
+                newWriter.writeEndDocument();
+            } finally {
+                reader.close();
+            }
+        } finally {
+            newWriter.close();
+        }
+        byte[] actualBytes = newBuffer.toByteArray();
+        assertArrayEquals(bytes, actualBytes);
     }
 
     @Test

--- a/bson/src/test/unit/org/bson/BsonDocumentWriterSpecification.groovy
+++ b/bson/src/test/unit/org/bson/BsonDocumentWriterSpecification.groovy
@@ -46,4 +46,22 @@ class BsonDocumentWriterSpecification extends Specification {
         then:
         document == documentWithValuesOfEveryType()
     }
+
+    def 'should pipe all types with extra elements'() {
+        given:
+        def document = new BsonDocument()
+        def reader = new BsonDocumentReader(new BsonDocument())
+        def writer = new BsonDocumentWriter(document)
+
+        def extraElements = []
+        for (def entry : documentWithValuesOfEveryType()) {
+            extraElements.add(new BsonElement(entry.getKey(), entry.getValue()))
+        }
+
+        when:
+        writer.pipe(reader, extraElements)
+
+        then:
+        document == documentWithValuesOfEveryType()
+    }
 }

--- a/bson/src/test/unit/org/bson/ElementExtendingBsonWriterSpecification.groovy
+++ b/bson/src/test/unit/org/bson/ElementExtendingBsonWriterSpecification.groovy
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson
+
+import org.bson.codecs.BsonDocumentCodec
+import org.bson.codecs.EncoderContext
+import spock.lang.Specification
+
+import static org.bson.BsonHelper.documentWithValuesOfEveryType
+
+class ElementExtendingBsonWriterSpecification extends Specification {
+
+    def 'should write all types'() {
+        given:
+        def encodedDoc = new BsonDocument();
+
+        when:
+        new BsonDocumentCodec().encode(new ElementExtendingBsonWriter(new BsonDocumentWriter(encodedDoc), []),
+                documentWithValuesOfEveryType(), EncoderContext.builder().build())
+
+        then:
+        encodedDoc == documentWithValuesOfEveryType()
+    }
+
+    def 'should extend with extra elements'() {
+        given:
+        def encodedDoc = new BsonDocument();
+        def extraElements = [
+                new BsonElement('$db', new BsonString('test')),
+                new BsonElement('$readPreference', new BsonDocument('mode', new BsonString('primary')))
+        ]
+        def expectedDocument = documentWithValuesOfEveryType()
+        for (def cur : extraElements) {
+            expectedDocument.put(cur.name, cur.value)
+        }
+        def writer = new ElementExtendingBsonWriter(new BsonDocumentWriter(encodedDoc), extraElements)
+
+        when:
+        new BsonDocumentCodec().encode(writer, documentWithValuesOfEveryType(), EncoderContext.builder().build())
+
+        then:
+        encodedDoc == expectedDocument
+    }
+
+    def 'should extend with extra elements when piping a reader at the top level'() {
+        given:
+        def encodedDoc = new BsonDocument();
+        def extraElements = [
+                new BsonElement('$db', new BsonString('test')),
+                new BsonElement('$readPreference', new BsonDocument('mode', new BsonString('primary')))
+        ]
+        def expectedDocument = documentWithValuesOfEveryType()
+        for (def cur : extraElements) {
+            expectedDocument.put(cur.name, cur.value)
+        }
+        def writer = new ElementExtendingBsonWriter(new BsonDocumentWriter(encodedDoc), extraElements)
+
+        when:
+        writer.pipe(new BsonDocumentReader(documentWithValuesOfEveryType()))
+
+        then:
+        encodedDoc == expectedDocument
+    }
+
+    def 'should not extend with extra elements when piping a reader at nested level'() {
+        given:
+        def encodedDoc = new BsonDocument();
+        def extraElements = [
+                new BsonElement('$db', new BsonString('test')),
+                new BsonElement('$readPreference', new BsonDocument('mode', new BsonString('primary')))
+        ]
+        def expectedDocument = new BsonDocument('pipedDocument', new BsonDocument())
+        for (def cur : extraElements) {
+            expectedDocument.put(cur.name, cur.value)
+        }
+        def writer = new ElementExtendingBsonWriter(new BsonDocumentWriter(encodedDoc), extraElements)
+
+        when:
+        writer.writeStartDocument()
+        writer.writeName('pipedDocument')
+        writer.pipe(new BsonDocumentReader(new BsonDocument()))
+        writer.writeEndDocument()
+
+        then:
+        encodedDoc == expectedDocument
+    }
+}

--- a/config/clirr-exclude.yml
+++ b/config/clirr-exclude.yml
@@ -21,5 +21,6 @@ members:
   org.bson.BsonWriter:
   - writeDecimal128(org.bson.types.Decimal128)
   - writeDecimal128(java.lang.String,org.bson.types.Decimal128)
+  - pipe(org.bson.BsonReader,java.util.List)
   org.bson.diagnostics.Loggers:
   - getLogger(java.lang.String)


### PR DESCRIPTION
Add ElementExtendingBsonWriter to enable efficient appending of extra BSON element to the end of a document as it's being encoded.   This avoids having to potentially hydrate a RawBsonDocument or BsonDocumentWrapper into a full BsonDocument when using the OP_MSG wire protocol.

Proposed usage in OP_MSG:

* https://github.com/jyemin/mongo-java-driver/blob/j2563/driver-core/src/main/com/mongodb/connection/SimpleCommandMessage.java#L64-L69
* https://github.com/jyemin/mongo-java-driver/blob/j2563/driver-core/src/main/com/mongodb/connection/RequestMessage.java#L244-L249