### PR TITLE
JAVA-2563: Support OP_MSG

### DIFF
--- a/bson/src/main/org/bson/ByteBufNIO.java
+++ b/bson/src/main/org/bson/ByteBufNIO.java
@@ -35,7 +35,7 @@ public class ByteBufNIO implements ByteBuf {
      * @param buf the {@code ByteBuffer} to wrap.
      */
     public ByteBufNIO(final ByteBuffer buf) {
-        this.buf = buf;
+        this.buf = buf.order(ByteOrder.LITTLE_ENDIAN);
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/connection/AsyncConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/AsyncConnection.java
@@ -17,6 +17,7 @@
 package com.mongodb.connection;
 
 import com.mongodb.MongoNamespace;
+import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
 import com.mongodb.WriteConcernResult;
 import com.mongodb.annotations.ThreadSafe;
@@ -172,8 +173,25 @@ public interface AsyncConnection extends ReferenceCounted {
      * @param commandResultDecoder the decoder for the result
      * @param callback             the callback to be passed the command result
      * @param <T>                  the type of the result
+     * @deprecated Prefer {@link #commandAsync(String, BsonDocument, ReadPreference, FieldNameValidator, Decoder, SingleResultCallback)}
      */
+    @Deprecated
     <T> void commandAsync(String database, BsonDocument command, boolean slaveOk, FieldNameValidator fieldNameValidator,
+                          Decoder<T> commandResultDecoder, SingleResultCallback<T> callback);
+
+    /**
+     * Execute the command asynchronously.
+     *
+     * @param database             the database to execute the command in
+     * @param command              the command document
+     * @param readPreference       the read preference that was applied to get this connection
+     * @param fieldNameValidator   the field name validator for the command document
+     * @param commandResultDecoder the decoder for the result
+     * @param callback             the callback to be passed the command result
+     * @param <T>                  the type of the result
+     * @since 3.6
+     */
+    <T> void commandAsync(String database, BsonDocument command, ReadPreference readPreference, FieldNameValidator fieldNameValidator,
                           Decoder<T> commandResultDecoder, SingleResultCallback<T> callback);
 
     /**

--- a/driver-core/src/main/com/mongodb/connection/BaseWriteCommandMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/BaseWriteCommandMessage.java
@@ -108,7 +108,7 @@ abstract class BaseWriteCommandMessage extends CommandMessage {
             writer.writeStartDocument();
             writeCommandPrologue(writer);
             nextMessage = writeTheWrites(outputStream, commandStartPosition, writer);
-            if (useNewOpCode()) {
+            if (useOpMsg()) {
                 writer.writeString("$db", getWriteNamespace().getDatabaseName());
             }
             writer.writeEndDocument();
@@ -126,7 +126,7 @@ abstract class BaseWriteCommandMessage extends CommandMessage {
     protected abstract FieldNameValidator getFieldNameValidator();
 
     private void writeCommandHeader(final BsonOutput outputStream) {
-        if (useNewOpCode()) {
+        if (useOpMsg()) {
             outputStream.writeInt32(0);  // flag bits
             outputStream.writeByte(0);   // payload type
         } else {

--- a/driver-core/src/main/com/mongodb/connection/BaseWriteCommandMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/BaseWriteCommandMessage.java
@@ -42,7 +42,7 @@ abstract class BaseWriteCommandMessage extends CommandMessage {
 
     BaseWriteCommandMessage(final MongoNamespace writeNamespace, final boolean ordered, final WriteConcern writeConcern,
                             final Boolean bypassDocumentValidation, final MessageSettings settings) {
-        super(new MongoNamespace(writeNamespace.getDatabaseName(), COMMAND_COLLECTION_NAME).getFullName(), OpCode.OP_QUERY, settings);
+        super(new MongoNamespace(writeNamespace.getDatabaseName(), COMMAND_COLLECTION_NAME).getFullName(), getOpCode(settings), settings);
 
         this.writeNamespace = writeNamespace;
         this.ordered = ordered;
@@ -108,6 +108,9 @@ abstract class BaseWriteCommandMessage extends CommandMessage {
             writer.writeStartDocument();
             writeCommandPrologue(writer);
             nextMessage = writeTheWrites(outputStream, commandStartPosition, writer);
+            if (useNewOpCode()) {
+                writer.writeString("$db", getWriteNamespace().getDatabaseName());
+            }
             writer.writeEndDocument();
         } finally {
             writer.close();
@@ -123,11 +126,16 @@ abstract class BaseWriteCommandMessage extends CommandMessage {
     protected abstract FieldNameValidator getFieldNameValidator();
 
     private void writeCommandHeader(final BsonOutput outputStream) {
-        outputStream.writeInt32(0);
-        outputStream.writeCString(getCollectionName());
+        if (useNewOpCode()) {
+            outputStream.writeInt32(0);  // flag bits
+            outputStream.writeByte(0);   // payload type
+        } else {
+            outputStream.writeInt32(0);
+            outputStream.writeCString(getCollectionName());
 
-        outputStream.writeInt32(0);
-        outputStream.writeInt32(-1);
+            outputStream.writeInt32(0);
+            outputStream.writeInt32(-1);
+        }
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/connection/CommandHelper.java
+++ b/driver-core/src/main/com/mongodb/connection/CommandHelper.java
@@ -43,7 +43,9 @@ final class CommandHelper {
                                     final SingleResultCallback<BsonDocument> callback) {
         final SimpleCommandMessage message =
                 new SimpleCommandMessage(new MongoNamespace(database, COMMAND_COLLECTION_NAME).getFullName(), command, false,
-                                                MessageSettings.builder().build());
+                                                MessageSettings.builder()
+                                                        .serverVersion(internalConnection.getDescription().getServerVersion())
+                                                        .build());
 
         internalConnection.sendAndReceiveAsync(message, new BsonDocumentCodec(), new SingleResultCallback<BsonDocument>() {
             @Override

--- a/driver-core/src/main/com/mongodb/connection/CommandHelper.java
+++ b/driver-core/src/main/com/mongodb/connection/CommandHelper.java
@@ -24,6 +24,7 @@ import org.bson.BsonValue;
 import org.bson.codecs.BsonDocumentCodec;
 
 import static com.mongodb.MongoNamespace.COMMAND_COLLECTION_NAME;
+import static com.mongodb.ReadPreference.primary;
 
 final class CommandHelper {
     static BsonDocument executeCommand(final String database, final BsonDocument command, final InternalConnection internalConnection) {
@@ -42,7 +43,7 @@ final class CommandHelper {
     static void executeCommandAsync(final String database, final BsonDocument command, final InternalConnection internalConnection,
                                     final SingleResultCallback<BsonDocument> callback) {
         final SimpleCommandMessage message =
-                new SimpleCommandMessage(new MongoNamespace(database, COMMAND_COLLECTION_NAME).getFullName(), command, false,
+                new SimpleCommandMessage(new MongoNamespace(database, COMMAND_COLLECTION_NAME).getFullName(), command, primary(),
                                                 MessageSettings.builder()
                                                         .serverVersion(internalConnection.getDescription().getServerVersion())
                                                         .build());
@@ -76,7 +77,7 @@ final class CommandHelper {
     private static BsonDocument sendAndReceive(final String database, final BsonDocument command,
                                                final InternalConnection internalConnection) {
         SimpleCommandMessage message = new SimpleCommandMessage(new MongoNamespace(database, COMMAND_COLLECTION_NAME).getFullName(),
-                                                                       command, false,
+                                                                       command, primary(),
                                                                        MessageSettings
                                                                                .builder()
                                                                                // Note: server version will be 0.0 at this point when called

--- a/driver-core/src/main/com/mongodb/connection/CommandHelper.java
+++ b/driver-core/src/main/com/mongodb/connection/CommandHelper.java
@@ -45,16 +45,13 @@ final class CommandHelper {
                 new SimpleCommandMessage(new MongoNamespace(database, COMMAND_COLLECTION_NAME).getFullName(), command, false,
                                                 MessageSettings.builder().build());
 
-        internalConnection.sendAndReceiveAsync(message, new SingleResultCallback<ResponseBuffers>() {
+        internalConnection.sendAndReceiveAsync(message, new BsonDocumentCodec(), new SingleResultCallback<BsonDocument>() {
             @Override
-            public void onResult(final ResponseBuffers result, final Throwable t) {
+            public void onResult(final BsonDocument result, final Throwable t) {
                 if (t != null) {
                     callback.onResult(null, t);
                 } else {
-                    ReplyMessage<BsonDocument> replyMessage = new ReplyMessage<BsonDocument>(result, new BsonDocumentCodec(),
-                                                                                                    message.getId());
-                    BsonDocument reply = replyMessage.getDocuments().get(0);
-                    callback.onResult(reply, null);
+                    callback.onResult(result, null);
                 }
             }
         });
@@ -78,12 +75,7 @@ final class CommandHelper {
                                                final InternalConnection internalConnection) {
         SimpleCommandMessage message = new SimpleCommandMessage(new MongoNamespace(database, COMMAND_COLLECTION_NAME).getFullName(),
                                                                        command, false, MessageSettings.builder().build());
-        ResponseBuffers responseBuffers = internalConnection.sendAndReceive(message);
-        try {
-            return new ReplyMessage<BsonDocument>(responseBuffers, new BsonDocumentCodec(), message.getId()).getDocuments().get(0);
-        } finally {
-            responseBuffers.close();
-        }
+        return internalConnection.sendAndReceive(message, new BsonDocumentCodec());
     }
 
     private CommandHelper() {

--- a/driver-core/src/main/com/mongodb/connection/CommandHelper.java
+++ b/driver-core/src/main/com/mongodb/connection/CommandHelper.java
@@ -74,7 +74,15 @@ final class CommandHelper {
     private static BsonDocument sendAndReceive(final String database, final BsonDocument command,
                                                final InternalConnection internalConnection) {
         SimpleCommandMessage message = new SimpleCommandMessage(new MongoNamespace(database, COMMAND_COLLECTION_NAME).getFullName(),
-                                                                       command, false, MessageSettings.builder().build());
+                                                                       command, false,
+                                                                       MessageSettings
+                                                                               .builder()
+                                                                               // Note: server version will be 0.0 at this point when called
+                                                                               // from InternalConnectionInitializer, which means OP_MSG
+                                                                               // will not be used
+                                                                               .serverVersion(internalConnection.getDescription()
+                                                                                                      .getServerVersion())
+                                                                               .build());
         return internalConnection.sendAndReceive(message, new BsonDocumentCodec());
     }
 

--- a/driver-core/src/main/com/mongodb/connection/CommandMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/CommandMessage.java
@@ -23,14 +23,14 @@ abstract class CommandMessage extends RequestMessage {
     }
 
     protected static OpCode getOpCode(final MessageSettings settings) {
-        return useNewOpCode(settings) ? OpCode.OP_MSG : OpCode.OP_QUERY;
+        return useOpMsg(settings) ? OpCode.OP_MSG : OpCode.OP_QUERY;
     }
 
-    protected static boolean useNewOpCode(final MessageSettings settings) {
+    protected static boolean useOpMsg(final MessageSettings settings) {
         return settings.getServerVersion().compareTo(new ServerVersion(3, 5)) >= 0;
     }
 
-    protected boolean useNewOpCode() {
-        return useNewOpCode(getSettings());
+    protected boolean useOpMsg() {
+        return useOpMsg(getSettings());
     }
 }

--- a/driver-core/src/main/com/mongodb/connection/CommandMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/CommandMessage.java
@@ -21,4 +21,16 @@ abstract class CommandMessage extends RequestMessage {
     CommandMessage(final String collectionName, final OpCode opCode, final MessageSettings settings) {
         super(collectionName, opCode, settings);
     }
+
+    protected static OpCode getOpCode(final MessageSettings settings) {
+        return useNewOpCode(settings) ? OpCode.OP_MSG : OpCode.OP_QUERY;
+    }
+
+    protected static boolean useNewOpCode(final MessageSettings settings) {
+        return settings.getServerVersion().compareTo(new ServerVersion(3, 5)) >= 0;
+    }
+
+    protected boolean useNewOpCode() {
+        return useNewOpCode(getSettings());
+    }
 }

--- a/driver-core/src/main/com/mongodb/connection/CommandProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/CommandProtocol.java
@@ -26,6 +26,7 @@ import org.bson.FieldNameValidator;
 import org.bson.codecs.Decoder;
 
 import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.connection.ProtocolHelper.getMessageSettings;
 import static java.lang.String.format;
 
 /**
@@ -70,25 +71,17 @@ class CommandProtocol<T> implements Protocol<T> {
                                 namespace.getDatabaseName(), connection.getDescription().getConnectionId(),
                                 connection.getDescription().getServerAddress()));
         }
-        ResponseBuffers responseBuffers = null;
-        try {
-            SimpleCommandMessage commandMessage = new SimpleCommandMessage(namespace.getFullName(), command, slaveOk, fieldNameValidator,
-                                                                      ProtocolHelper.getMessageSettings(connection.getDescription()));
-            responseBuffers = connection.sendAndReceive(commandMessage);
-            T retval = getResponseDocument(responseBuffers, commandMessage, commandResultDecoder);
-            LOGGER.debug("Command execution completed");
-            return retval;
-        } finally {
-            if (responseBuffers != null) {
-                responseBuffers.close();
-            }
-        }
+        SimpleCommandMessage commandMessage = new SimpleCommandMessage(namespace.getFullName(), command, slaveOk, fieldNameValidator,
+                                                                              getMessageSettings(connection.getDescription()));
+        T retval = connection.sendAndReceive(commandMessage, commandResultDecoder);
+        LOGGER.debug("Command execution completed");
+        return retval;
     }
 
     @Override
     public void executeAsync(final InternalConnection connection, final SingleResultCallback<T> callback) {
         final SimpleCommandMessage message = new SimpleCommandMessage(namespace.getFullName(), command, slaveOk, fieldNameValidator,
-                ProtocolHelper.getMessageSettings(connection.getDescription()));
+                getMessageSettings(connection.getDescription()));
         try {
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug(format("Asynchronously sending command {%s : %s} to database %s on connection [%s] to server %s",
@@ -96,18 +89,13 @@ class CommandProtocol<T> implements Protocol<T> {
                                     namespace.getDatabaseName(), connection.getDescription().getConnectionId(),
                                     connection.getDescription().getServerAddress()));
             }
-            connection.sendAndReceiveAsync(message, new SingleResultCallback<ResponseBuffers>() {
+            connection.sendAndReceiveAsync(message, commandResultDecoder, new SingleResultCallback<T>() {
                 @Override
-                public void onResult(final ResponseBuffers responseBuffers, final Throwable t) {
+                public void onResult(final T result, final Throwable t) {
                     if (t != null) {
                         callback.onResult(null, t);
                     } else {
-                        try {
-                            T responseDocument = getResponseDocument(responseBuffers, message, commandResultDecoder);
-                            callback.onResult(responseDocument, null);
-                        } catch (Exception e) {
-                            callback.onResult(null, e);
-                        }
+                        callback.onResult(result, null);
                     }
                 }
             });
@@ -122,13 +110,5 @@ class CommandProtocol<T> implements Protocol<T> {
 
     private String getCommandName() {
         return command.keySet().iterator().next();
-    }
-
-    private static <D> D getResponseDocument(final ResponseBuffers responseBuffers, final SimpleCommandMessage commandMessage,
-                                             final Decoder<D> decoder) {
-        responseBuffers.reset();
-        ReplyMessage<D> replyMessage = new ReplyMessage<D>(responseBuffers, decoder, commandMessage.getId());
-
-        return replyMessage.getDocuments().get(0);
     }
 }

--- a/driver-core/src/main/com/mongodb/connection/CompressedHeader.java
+++ b/driver-core/src/main/com/mongodb/connection/CompressedHeader.java
@@ -17,7 +17,7 @@
 package com.mongodb.connection;
 
 import com.mongodb.MongoInternalException;
-import org.bson.io.BsonInput;
+import org.bson.ByteBuf;
 
 import static com.mongodb.connection.MessageHeader.MESSAGE_HEADER_LENGTH;
 import static com.mongodb.connection.OpCode.OP_COMPRESSED;
@@ -40,7 +40,7 @@ class CompressedHeader {
     private final byte compressorId;
     private final MessageHeader messageHeader;
 
-    CompressedHeader(final BsonInput header, final MessageHeader messageHeader) {
+    CompressedHeader(final ByteBuf header, final MessageHeader messageHeader) {
         this.messageHeader = messageHeader;
 
         if (messageHeader.getOpCode() != OP_COMPRESSED.getValue()) {
@@ -53,9 +53,9 @@ class CompressedHeader {
                     messageHeader.getMessageLength(), COMPRESSED_HEADER_LENGTH));
         }
 
-        originalOpcode = header.readInt32();
-        uncompressedSize = header.readInt32();
-        compressorId = header.readByte();
+        originalOpcode = header.getInt();
+        uncompressedSize = header.getInt();
+        compressorId = header.get();
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/connection/CompressedHeader.java
+++ b/driver-core/src/main/com/mongodb/connection/CompressedHeader.java
@@ -20,7 +20,7 @@ import com.mongodb.MongoInternalException;
 import org.bson.io.BsonInput;
 
 import static com.mongodb.connection.MessageHeader.MESSAGE_HEADER_LENGTH;
-import static com.mongodb.connection.RequestMessage.OpCode.OP_COMPRESSED;
+import static com.mongodb.connection.OpCode.OP_COMPRESSED;
 import static java.lang.String.format;
 
 // Contains the details of an OP_COMPRESSED reply from a MongoDB server.

--- a/driver-core/src/main/com/mongodb/connection/Connection.java
+++ b/driver-core/src/main/com/mongodb/connection/Connection.java
@@ -17,6 +17,7 @@
 package com.mongodb.connection;
 
 import com.mongodb.MongoNamespace;
+import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
 import com.mongodb.WriteConcernResult;
 import com.mongodb.annotations.ThreadSafe;
@@ -166,8 +167,25 @@ public interface Connection extends ReferenceCounted {
      * @param commandResultDecoder the decoder for the result
      * @param <T>                  the type of the result
      * @return the command result
+     * @deprecated Prefer {@link #command(String, BsonDocument, ReadPreference, FieldNameValidator, Decoder)}
      */
+    @Deprecated
     <T> T command(String database, BsonDocument command, boolean slaveOk, FieldNameValidator fieldNameValidator,
+                  Decoder<T> commandResultDecoder);
+
+    /**
+     * Execute the command.
+     *
+     * @param database             the database to execute the command in
+     * @param command              the command document
+     * @param readPreference       the read preference that was applied to get this connection
+     * @param fieldNameValidator   the field name validator for the command document
+     * @param commandResultDecoder the decoder for the result
+     * @param <T>                  the type of the result
+     * @return the command result
+     * @since 3.6
+     */
+    <T> T command(String database, BsonDocument command, ReadPreference readPreference, FieldNameValidator fieldNameValidator,
                   Decoder<T> commandResultDecoder);
 
     /**

--- a/driver-core/src/main/com/mongodb/connection/GetMoreProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/GetMoreProtocol.java
@@ -177,7 +177,7 @@ class GetMoreProtocol<T> implements Protocol<QueryResult<T>> {
     private BsonDocument asGetMoreCommandResponseDocument(final QueryResult<T> queryResult, final ResponseBuffers responseBuffers) {
         List<ByteBufBsonDocument> rawResultDocuments = Collections.emptyList();
         if (responseBuffers.getReplyHeader().getNumberReturned() != 0) {
-            responseBuffers.getBodyByteBuffer().position(0);
+            responseBuffers.reset();
             rawResultDocuments = ByteBufBsonDocument.create(responseBuffers);
         }
 

--- a/driver-core/src/main/com/mongodb/connection/InternalConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/InternalConnection.java
@@ -18,6 +18,7 @@ package com.mongodb.connection;
 
 import com.mongodb.async.SingleResultCallback;
 import org.bson.ByteBuf;
+import org.bson.codecs.Decoder;
 
 import java.util.List;
 
@@ -66,14 +67,14 @@ interface InternalConnection extends BufferProvider {
      *
      * @param message   the command message to send
      */
-    ResponseBuffers sendAndReceive(CommandMessage message);
+    <T> T sendAndReceive(CommandMessage message, Decoder<T> decoder);
 
     /**
      * Send a command message to the server.
      *
      * @param message   the command message to send
      */
-    void sendAndReceiveAsync(CommandMessage message, SingleResultCallback<ResponseBuffers> callback);
+    <T> void sendAndReceiveAsync(CommandMessage message, Decoder<T> decoder, SingleResultCallback<T> callback);
 
     /**
      * Send a message to the server. The connection may not make any attempt to validate the integrity of the message.

--- a/driver-core/src/main/com/mongodb/connection/InternalStreamConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/InternalStreamConnection.java
@@ -64,7 +64,7 @@ import static com.mongodb.connection.ProtocolHelper.sendCommandStartedEvent;
 import static com.mongodb.connection.ProtocolHelper.sendCommandSucceededEvent;
 import static com.mongodb.connection.ReplyHeader.REPLY_HEADER_LENGTH;
 import static com.mongodb.connection.ReplyHeader.TOTAL_REPLY_HEADER_LENGTH;
-import static com.mongodb.connection.RequestMessage.OpCode.OP_COMPRESSED;
+import static com.mongodb.connection.OpCode.OP_COMPRESSED;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -263,7 +263,7 @@ class InternalStreamConnection implements InternalConnection {
             if (sendCompressor == null || SECURITY_SENSITIVE_COMMANDS.contains(commandName)) {
                 sendMessage(bsonOutput.getByteBuffers(), message.getId());
             } else {
-                CompressedMessage compressedMessage = new CompressedMessage(RequestMessage.OpCode.OP_QUERY, bsonOutput.getByteBuffers(),
+                CompressedMessage compressedMessage = new CompressedMessage(OpCode.OP_QUERY, bsonOutput.getByteBuffers(),
                                                                                    sendCompressor, getMessageSettings(description));
                 ByteBufferBsonOutput compressedBsonOutput = new ByteBufferBsonOutput(this);
                 compressedMessage.encode(compressedBsonOutput);
@@ -314,7 +314,7 @@ class InternalStreamConnection implements InternalConnection {
             if (sendCompressor == null || SECURITY_SENSITIVE_COMMANDS.contains(commandName)) {
                 sendCommandMessageAsync(message, callback, bsonOutput, commandName, startTimeNanos);
             } else {
-                CompressedMessage compressedMessage = new CompressedMessage(RequestMessage.OpCode.OP_QUERY, bsonOutput.getByteBuffers(),
+                CompressedMessage compressedMessage = new CompressedMessage(OpCode.OP_QUERY, bsonOutput.getByteBuffers(),
                                                                                    sendCompressor, getMessageSettings(description));
                 compressedMessage.encode(compressedBsonOutput);
                 bsonOutput.close();

--- a/driver-core/src/main/com/mongodb/connection/InternalStreamConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/InternalStreamConnection.java
@@ -55,7 +55,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static com.mongodb.assertions.Assertions.isTrue;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.connection.ByteBufBsonDocument.createOne;
-import static com.mongodb.connection.CompressedHeader.COMPRESSED_HEADER_LENGTH;
+import static com.mongodb.connection.MessageHeader.MESSAGE_HEADER_LENGTH;
 import static com.mongodb.connection.OpCode.OP_COMPRESSED;
 import static com.mongodb.connection.ProtocolHelper.getCommandFailureException;
 import static com.mongodb.connection.ProtocolHelper.getMessageSettings;
@@ -63,8 +63,6 @@ import static com.mongodb.connection.ProtocolHelper.isCommandOk;
 import static com.mongodb.connection.ProtocolHelper.sendCommandFailedEvent;
 import static com.mongodb.connection.ProtocolHelper.sendCommandStartedEvent;
 import static com.mongodb.connection.ProtocolHelper.sendCommandSucceededEvent;
-import static com.mongodb.connection.ReplyHeader.REPLY_HEADER_LENGTH;
-import static com.mongodb.connection.ReplyHeader.TOTAL_REPLY_HEADER_LENGTH;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -236,34 +234,34 @@ class InternalStreamConnection implements InternalConnection {
 
     @Override
     public <T> T sendAndReceive(final CommandMessage message, final Decoder<T> decoder) {
-        String commandName;
+        CommandEventSender commandEventSender = new CommandEventSender(message);
+
         ByteBufferBsonOutput bsonOutput = new ByteBufferBsonOutput(this);
         try {
             message.encode(bsonOutput);
-            commandName = sendStartedEvent(bsonOutput, message);
+            commandEventSender.sendStartedEvent(bsonOutput);
         } catch (RuntimeException e) {
             bsonOutput.close();
             throw e;
         }
 
-        long startTimeNanos = System.nanoTime();
-
         try {
-            sendCommandMessage(message, commandName, bsonOutput);
-            return receiveCommandMessageResponse(message, startTimeNanos, commandName, decoder);
+            sendCommandMessage(message, commandEventSender, bsonOutput);
+            return receiveCommandMessageResponse(message, decoder, commandEventSender);
         } catch (RuntimeException e) {
             close();
-            sendFailedEvent(startTimeNanos, message, commandName, e);
+            commandEventSender.sendFailedEvent(e);
             throw e;
         }
     }
 
-    private void sendCommandMessage(final CommandMessage message, final String commandName, final ByteBufferBsonOutput bsonOutput) {
+    private void sendCommandMessage(final CommandMessage message, final CommandEventSender commandEventSender,
+                                    final ByteBufferBsonOutput bsonOutput) {
         try {
-            if (sendCompressor == null || SECURITY_SENSITIVE_COMMANDS.contains(commandName)) {
+            if (sendCompressor == null || SECURITY_SENSITIVE_COMMANDS.contains(commandEventSender.getCommandName())) {
                 sendMessage(bsonOutput.getByteBuffers(), message.getId());
             } else {
-                CompressedMessage compressedMessage = new CompressedMessage(OpCode.OP_QUERY, bsonOutput.getByteBuffers(),
+                CompressedMessage compressedMessage = new CompressedMessage(message.getOpCode(), bsonOutput.getByteBuffers(),
                                                                                    sendCompressor, getMessageSettings(description));
                 ByteBufferBsonOutput compressedBsonOutput = new ByteBufferBsonOutput(this);
                 compressedMessage.encode(compressedBsonOutput);
@@ -278,19 +276,18 @@ class InternalStreamConnection implements InternalConnection {
         }
     }
 
-    private <T> T receiveCommandMessageResponse(final CommandMessage message, final long startTimeNanos,
-                                                final String commandName, final Decoder<T> decoder) {
+    private <T> T receiveCommandMessageResponse(final CommandMessage message, final Decoder<T> decoder,
+                                                final CommandEventSender commandEventSender) {
         ResponseBuffers responseBuffers = receiveMessage(message.getId());
         try {
             boolean commandOk = isCommandOk(new BsonBinaryReader(new ByteBufferBsonInput(responseBuffers.getBodyByteBuffer())));
             responseBuffers.reset();
             if (!commandOk) {
-                throw getCommandFailureException(getResponseDocument(responseBuffers, message, new BsonDocumentCodec()),
+                throw getCommandFailureException(getResponseDocument(responseBuffers, message.getId(), new BsonDocumentCodec()),
                         description.getServerAddress());
             }
 
-            sendSucceededEvent(startTimeNanos, message, commandName, getResponseDocument(responseBuffers, message,
-                    new RawBsonDocumentCodec()));
+            commandEventSender.sendSucceededEvent(responseBuffers);
 
             return new ReplyMessage<T>(responseBuffers, decoder, message.getId()).getDocuments().get(0);
         } finally {
@@ -312,145 +309,66 @@ class InternalStreamConnection implements InternalConnection {
 
         try {
             message.encode(bsonOutput);
-            String commandName = sendStartedEvent(bsonOutput, message);
+            CommandEventSender commandEventSender = new CommandEventSender(message);
+            commandEventSender.sendStartedEvent(bsonOutput);
 
-            long startTimeNanos = System.nanoTime();
-            if (sendCompressor == null || SECURITY_SENSITIVE_COMMANDS.contains(commandName)) {
-                sendCommandMessageAsync(message, decoder, callback, bsonOutput, commandName, startTimeNanos);
+            if (sendCompressor == null || SECURITY_SENSITIVE_COMMANDS.contains(commandEventSender.getCommandName())) {
+                sendCommandMessageAsync(message.getId(), decoder, callback, bsonOutput, commandEventSender);
             } else {
-                CompressedMessage compressedMessage = new CompressedMessage(OpCode.OP_QUERY, bsonOutput.getByteBuffers(),
+                CompressedMessage compressedMessage = new CompressedMessage(message.getOpCode(), bsonOutput.getByteBuffers(),
                                                                                    sendCompressor, getMessageSettings(description));
                 compressedMessage.encode(compressedBsonOutput);
                 bsonOutput.close();
-                sendCommandMessageAsync(message, decoder, callback, compressedBsonOutput, commandName, startTimeNanos);
+                sendCommandMessageAsync(message.getId(), decoder, callback, compressedBsonOutput, commandEventSender);
             }
         } catch (RuntimeException e) {
-            close();
             bsonOutput.close();
             compressedBsonOutput.close();
             callback.onResult(null, e);
         }
     }
 
-    private <T> void sendCommandMessageAsync(final CommandMessage message, final Decoder<T> decoder, final SingleResultCallback<T> callback,
-                                         final ByteBufferBsonOutput bsonOutput, final String commandName, final long startTimeNanos) {
-        sendMessageAsync(bsonOutput.getByteBuffers(), message.getId(), new SingleResultCallback<Void>() {
+    private <T> void sendCommandMessageAsync(final int messageId, final Decoder<T> decoder, final SingleResultCallback<T> callback,
+                                             final ByteBufferBsonOutput bsonOutput,
+                                             final CommandEventSender commandEventSender) {
+        sendMessageAsync(bsonOutput.getByteBuffers(), messageId, new SingleResultCallback<Void>() {
             @Override
             public void onResult(final Void result, final Throwable t) {
                 bsonOutput.close();
                 if (t != null) {
-                    sendFailedEvent(startTimeNanos, message, commandName, t);
+                    commandEventSender.sendFailedEvent(t);
                     callback.onResult(null, t);
                 } else {
-                    readAsync(MessageHeader.MESSAGE_HEADER_LENGTH, new SingleResultCallback<ByteBuf>() {
+                    readAsync(MESSAGE_HEADER_LENGTH, new MessageHeaderCallback(new SingleResultCallback<ResponseBuffers>() {
                         @Override
-                        public void onResult(final ByteBuf result, final Throwable t) {
+                        public void onResult(final ResponseBuffers responseBuffers, final Throwable t) {
                             if (t != null) {
-                                sendFailedEvent(startTimeNanos, message, commandName, t);
+                                commandEventSender.sendFailedEvent(t);
+                                close();
                                 callback.onResult(null, t);
                                 return;
                             }
-                            ByteBufferBsonInput headerInputBuffer = new ByteBufferBsonInput(result);
-                            final MessageHeader messageHeader;
                             try {
-                                messageHeader = new MessageHeader(headerInputBuffer, description.getMaxMessageSize());
+                                boolean commandOk =
+                                        isCommandOk(new BsonBinaryReader(new ByteBufferBsonInput(responseBuffers.getBodyByteBuffer())));
+                                responseBuffers.reset();
+                                if (!commandOk) {
+                                    MongoException commandFailureException = getCommandFailureException(getResponseDocument(responseBuffers,
+                                            messageId, new BsonDocumentCodec()), description.getServerAddress());
+                                    commandEventSender.sendFailedEvent(commandFailureException);
+                                    throw commandFailureException;
+                                }
+                                commandEventSender.sendSucceededEvent(responseBuffers);
+                                T result = new ReplyMessage<T>(responseBuffers, decoder, messageId).getDocuments().get(0);
+
+                                callback.onResult(result, null);
+                            } catch (Throwable localThrowable) {
+                                callback.onResult(null, localThrowable);
                             } finally {
-                                headerInputBuffer.close();
-                            }
-                            if (messageHeader.getOpCode() == OP_COMPRESSED.getValue()) {
-                                readAsync(CompressedHeader.COMPRESSED_HEADER_LENGTH, new SingleResultCallback<ByteBuf>() {
-                                    @Override
-                                    public void onResult(final ByteBuf result, final Throwable t) {
-                                        if (t != null) {
-                                            sendFailedEvent(startTimeNanos, message, commandName, t);
-                                            callback.onResult(null, t);
-                                            return;
-                                        }
-                                        ByteBufferBsonInput headerInputBuffer = new ByteBufferBsonInput(result);
-                                        final CompressedHeader compressedHeader;
-                                        try {
-                                            compressedHeader = new CompressedHeader(headerInputBuffer, messageHeader);
-                                        } finally {
-                                            headerInputBuffer.close();
-                                        }
-                                        readAsync(compressedHeader.getCompressedSize(), new SingleResultCallback<ByteBuf>() {
-                                            @Override
-                                            public void onResult(final ByteBuf result, final Throwable t) {
-                                                if (t != null) {
-                                                    sendFailedEvent(startTimeNanos, message, commandName, t);
-                                                    callback.onResult(null, t);
-                                                    return;
-                                                }
-                                                Compressor compressor = getCompressor(compressedHeader);
-                                                ByteBuf buffer = getBuffer(compressedHeader.getUncompressedSize());
-                                                compressor.uncompress(result, buffer);
-
-                                                buffer.flip();
-                                                // Don't close the buffer, as it doesn't own the buffer
-                                                ReplyHeader replyHeader = new ReplyHeader(compressedHeader,
-                                                                                                 new ByteBufferBsonInput(buffer));
-
-                                                handleReplyAsync(buffer, replyHeader);
-                                            }
-                                        });
-                                    }
-                                });
-                            } else {
-                                readAsync(REPLY_HEADER_LENGTH, new SingleResultCallback<ByteBuf>() {
-                                    @Override
-                                    public void onResult(final ByteBuf result, final Throwable t) {
-                                        if (t != null) {
-                                            sendFailedEvent(startTimeNanos, message, commandName, t);
-                                            callback.onResult(null, t);
-                                            return;
-                                        }
-                                        ByteBufferBsonInput input = new ByteBufferBsonInput(result);
-                                        final ReplyHeader replyHeader;
-                                        try {
-                                            replyHeader = new ReplyHeader(input, messageHeader);
-                                        } finally {
-                                            input.close();
-                                        }
-                                        readAsync(replyHeader.getMessageLength() - TOTAL_REPLY_HEADER_LENGTH,
-                                                new SingleResultCallback<ByteBuf>() {
-                                                    @Override
-                                                    public void onResult(final ByteBuf result, final Throwable t) {
-                                                        if (t != null) {
-                                                            sendFailedEvent(startTimeNanos, message, commandName, t);
-                                                            callback.onResult(null, t);
-                                                            return;
-                                                        }
-                                                        handleReplyAsync(result, replyHeader);
-                                                    }
-                                                });
-                                    }
-                                });
+                                responseBuffers.close();
                             }
                         }
-                    });
-                }
-            }
-
-            private void handleReplyAsync(final ByteBuf buffer, final ReplyHeader replyHeader) {
-                ResponseBuffers responseBuffers = new ResponseBuffers(replyHeader, buffer);
-                try {
-                    boolean commandOk = isCommandOk(new BsonBinaryReader(new ByteBufferBsonInput(responseBuffers.getBodyByteBuffer())));
-                    responseBuffers.reset();
-                    if (!commandOk) {
-                        MongoException commandFailureException = getCommandFailureException(getResponseDocument(responseBuffers, message,
-                                new BsonDocumentCodec()), description.getServerAddress());
-                        sendFailedEvent(startTimeNanos, message, commandName, commandFailureException);
-                        throw commandFailureException;
-                    }
-                    sendSucceededEvent(startTimeNanos, message, commandName,
-                            getResponseDocument(responseBuffers, message, new RawBsonDocumentCodec()));
-                    T result = new ReplyMessage<T>(responseBuffers, decoder, message.getId()).getDocuments().get(0);
-
-                    callback.onResult(result, null);
-                } catch (Throwable t) {
-                    callback.onResult(null, t);
-                } finally {
-                    responseBuffers.close();
+                    }));
                 }
             }
         });
@@ -508,8 +426,8 @@ class InternalStreamConnection implements InternalConnection {
 
             @Override
             public void failed(final Throwable t) {
-                callback.onResult(null, translateWriteException(t));
                 close();
+                callback.onResult(null, translateWriteException(t));
             }
         });
     }
@@ -526,11 +444,17 @@ class InternalStreamConnection implements InternalConnection {
         if (LOGGER.isTraceEnabled()) {
             LOGGER.trace(String.format("Start receiving response on %s", getId()));
         }
-        receiveResponseAsync(callback);
-    }
-
-    private void receiveResponseAsync(final SingleResultCallback<ResponseBuffers> callback) {
-        readAsync(TOTAL_REPLY_HEADER_LENGTH, errorHandlingCallback(new ResponseHeaderCallback(callback), LOGGER));
+        readAsync(MESSAGE_HEADER_LENGTH, new MessageHeaderCallback(new SingleResultCallback<ResponseBuffers>() {
+            @Override
+            public void onResult(final ResponseBuffers result, final Throwable t) {
+                if (t != null) {
+                    close();
+                    callback.onResult(null, t);
+                    return;
+                }
+                callback.onResult(result, null);
+            }
+        }));
     }
 
     private void readAsync(final int numBytes, final SingleResultCallback<ByteBuf> callback) {
@@ -598,53 +522,28 @@ class InternalStreamConnection implements InternalConnection {
     }
 
     private ResponseBuffers receiveResponseBuffers() throws IOException {
-        ByteBuf messageHeaderBytBuf = stream.read(MessageHeader.MESSAGE_HEADER_LENGTH);
-        ByteBufferBsonInput headerInputBuffer = new ByteBufferBsonInput(messageHeaderBytBuf);
+        ByteBuf messageHeaderBuffer = stream.read(MESSAGE_HEADER_LENGTH);
         MessageHeader messageHeader;
         try {
-            messageHeader = new MessageHeader(headerInputBuffer, description.getMaxMessageSize());
+            messageHeader = new MessageHeader(messageHeaderBuffer, description.getMaxMessageSize());
         } finally {
-            headerInputBuffer.close();
+            messageHeaderBuffer.release();
         }
 
-        if (messageHeader.getOpCode() == OP_COMPRESSED.getValue()) {
-            ByteBuf headerByteBuffer = stream.read(COMPRESSED_HEADER_LENGTH);
-            CompressedHeader compressedHeader;
-            ByteBufferBsonInput compressedHeaderInputBuffer = new ByteBufferBsonInput(headerByteBuffer);
-            try {
-                compressedHeader = new CompressedHeader(compressedHeaderInputBuffer, messageHeader);
-            } finally {
-                compressedHeaderInputBuffer.close();
-            }
+        ByteBuf messageBuffer = stream.read(messageHeader.getMessageLength() - MESSAGE_HEADER_LENGTH);
 
-            ByteBuf compressedByteBuffer = stream.read(compressedHeader.getCompressedSize());
+        if (messageHeader.getOpCode() == OP_COMPRESSED.getValue()) {
+            CompressedHeader compressedHeader = new CompressedHeader(messageBuffer, messageHeader);
+
             Compressor compressor = getCompressor(compressedHeader);
 
             ByteBuf buffer = getBuffer(compressedHeader.getUncompressedSize());
-            compressor.uncompress(compressedByteBuffer, buffer);
+            compressor.uncompress(messageBuffer, buffer);
 
             buffer.flip();
-            // Don't close the input, as it doesn't own the buffer
-            ReplyHeader replyHeader = new ReplyHeader(compressedHeader, new ByteBufferBsonInput(buffer));
-
-            return new ResponseBuffers(replyHeader, buffer);
-
+            return new ResponseBuffers(new ReplyHeader(buffer, compressedHeader), buffer);
         } else {
-            ByteBuf headerByteBuffer = stream.read(REPLY_HEADER_LENGTH);
-            ReplyHeader replyHeader;
-            ByteBufferBsonInput replyHeaderInputBuffer = new ByteBufferBsonInput(headerByteBuffer);
-            try {
-                replyHeader = new ReplyHeader(replyHeaderInputBuffer, messageHeader);
-            } finally {
-                replyHeaderInputBuffer.close();
-            }
-
-            ByteBuf bodyByteBuffer = null;
-
-            if (replyHeader.getNumberReturned() > 0) {
-                bodyByteBuffer = stream.read(replyHeader.getMessageLength() - TOTAL_REPLY_HEADER_LENGTH);
-            }
-            return new ResponseBuffers(replyHeader, bodyByteBuffer);
+            return new ResponseBuffers(new ReplyHeader(messageBuffer, messageHeader), messageBuffer);
         }
     }
 
@@ -662,129 +561,135 @@ class InternalStreamConnection implements InternalConnection {
         return stream.getBuffer(size);
     }
 
-    private class ResponseHeaderCallback implements SingleResultCallback<ByteBuf> {
+    private static <T extends BsonDocument> T getResponseDocument(final ResponseBuffers responseBuffers,
+                                                                  final int messageId, final Decoder<T> decoder) {
+        ReplyMessage<T> replyMessage = new ReplyMessage<T>(responseBuffers, decoder, messageId);
+        responseBuffers.reset();
+        return replyMessage.getDocuments().get(0);
+    }
+
+    private class MessageHeaderCallback implements SingleResultCallback<ByteBuf> {
         private final SingleResultCallback<ResponseBuffers> callback;
 
-        ResponseHeaderCallback(final SingleResultCallback<ResponseBuffers> callback) {
+        MessageHeaderCallback(final SingleResultCallback<ResponseBuffers> callback) {
             this.callback = callback;
         }
 
         @Override
-        public void onResult(final ByteBuf result, final Throwable throwableFromCallback) {
-            if (throwableFromCallback != null) {
-                callback.onResult(null, throwableFromCallback);
-            } else {
-                try {
-                    ReplyHeader replyHeader;
-                    ByteBufferBsonInput headerInputBuffer = new ByteBufferBsonInput(result);
-                    try {
-                        MessageHeader messageHeader = new MessageHeader(headerInputBuffer, description.getMaxMessageSize());
-                        replyHeader = new ReplyHeader(headerInputBuffer, messageHeader);
-                    } finally {
-                        headerInputBuffer.close();
-                    }
-
-                    if (replyHeader.getMessageLength() == TOTAL_REPLY_HEADER_LENGTH) {
-                        onSuccess(new ResponseBuffers(replyHeader, null));
-                    } else {
-                        readAsync(replyHeader.getMessageLength() - TOTAL_REPLY_HEADER_LENGTH,
-                                  new ResponseBodyCallback(replyHeader));
-                    }
-                } catch (Throwable t) {
-                    close();
-                    callback.onResult(null, t);
+        public void onResult(final ByteBuf result, final Throwable t) {
+            try {
+                if (t != null) {
+                    throw t;
+                }
+                MessageHeader messageHeader = new MessageHeader(result, description.getMaxMessageSize());
+                readAsync(messageHeader.getMessageLength() - MESSAGE_HEADER_LENGTH, new MessageCallback(messageHeader));
+            } catch (Throwable localThrowable) {
+                callback.onResult(null, localThrowable);
+            } finally {
+                if (result != null) {
+                    result.release();
                 }
             }
         }
 
-        private void onSuccess(final ResponseBuffers responseBuffers) {
+        private class MessageCallback implements SingleResultCallback<ByteBuf> {
+            private final MessageHeader messageHeader;
 
-            if (responseBuffers == null) {
-                callback.onResult(null, new MongoException("Unexpected empty response buffers"));
-                return;
-            }
-
-            try {
-                callback.onResult(responseBuffers, null);
-            } catch (Throwable t) {
-                LOGGER.warn("Exception calling callback", t);
-            }
-        }
-
-        private class ResponseBodyCallback implements SingleResultCallback<ByteBuf> {
-            private final ReplyHeader replyHeader;
-
-            ResponseBodyCallback(final ReplyHeader replyHeader) {
-                this.replyHeader = replyHeader;
+            MessageCallback(final MessageHeader messageHeader) {
+                this.messageHeader = messageHeader;
             }
 
             @Override
             public void onResult(final ByteBuf result, final Throwable t) {
-                if (t != null) {
-                    try {
-                        callback.onResult(new ResponseBuffers(replyHeader, result), t);
-                    } catch (Throwable tr) {
-                        LOGGER.warn("Exception calling callback", tr);
+                try {
+                    if (t != null) {
+                        throw t;
                     }
-                } else {
-                    onSuccess(new ResponseBuffers(replyHeader, result));
+                    ReplyHeader replyHeader;
+                    ByteBuf responseBuffer;
+                    if (messageHeader.getOpCode() == OP_COMPRESSED.getValue()) {
+                        try {
+                            CompressedHeader compressedHeader = new CompressedHeader(result, messageHeader);
+                            Compressor compressor = getCompressor(compressedHeader);
+                            ByteBuf buffer = getBuffer(compressedHeader.getUncompressedSize());
+                            compressor.uncompress(result, buffer);
+
+                            buffer.flip();
+                            replyHeader = new ReplyHeader(buffer, compressedHeader);
+                            responseBuffer = buffer;
+                        } finally {
+                            result.release();
+                        }
+                    } else {
+                        replyHeader = new ReplyHeader(result, messageHeader);
+                        responseBuffer = result;
+                    }
+                    callback.onResult(new ResponseBuffers(replyHeader, responseBuffer), null);
+                } catch (Throwable localThrowable) {
+                    callback.onResult(null, localThrowable);
                 }
             }
         }
     }
 
-    // This is a bit of a hack, but is designed to save work for the normal path where there is no command listener or send compressor
-    // The command name is returned but is a bit expensive to compute, so we only want to do it if necessary and if so do it only once.
-    // So this method returns the command name only if necessary, otherwise it returns null and the caller has to not care.  And the caller
-    // does not care because the command name is only needed to determine if the command is security-sensitive and therefore should not
-    // be compressed.
-    private String sendStartedEvent(final ByteBufferBsonOutput bsonOutput, final CommandMessage message) {
-        if (commandListener != null || sendCompressor != null) {
-            String commandName;
-            ByteBufBsonDocument byteBufBsonDocument = createOne(bsonOutput, message.getEncodingMetadata().getFirstDocumentPosition());
-            BsonDocument commandDocument;
-            if (byteBufBsonDocument.containsKey("$query")) {
-                commandDocument = byteBufBsonDocument.getDocument("$query");
-                commandName = commandDocument.keySet().iterator().next();
-            } else {
-                commandDocument = byteBufBsonDocument;
-                commandName = byteBufBsonDocument.getFirstKey();
-            }
-            if (commandListener != null && opened()) {
-                BsonDocument commandDocumentForEvent = (SECURITY_SENSITIVE_COMMANDS.contains(commandName))
-                                                               ? new BsonDocument() : commandDocument;
-                sendCommandStartedEvent(message, new MongoNamespace(message.getCollectionName()).getDatabaseName(), commandName,
-                        commandDocumentForEvent, getDescription(), commandListener);
+    private class CommandEventSender {
+        private final long startTimeNanos;
+        private final CommandMessage message;
+        private String commandName;
+
+        CommandEventSender(final CommandMessage message) {
+            this.startTimeNanos = System.nanoTime();
+            this.message = message;
+        }
+
+        // Call after sendStartedEvent. Returns null unless there's either a command listener or a sendCompress configured.  Otherwise,
+        // there's no need to compute the command name
+        public String getCommandName() {
+            if (commandName == null) {
+                throw new MongoInternalException("Attempting to use the command name when it has not been determined");
             }
             return commandName;
         }
-        return null;
-    }
 
-    private void sendSucceededEvent(final long startTimeNanos, final CommandMessage commandMessage, final String commandName,
-                                    final BsonDocument response) {
-        if (commandListener != null && opened()) {
-            BsonDocument responseDocumentForEvent = (SECURITY_SENSITIVE_COMMANDS.contains(commandName)) ? new BsonDocument() : response;
-            sendCommandSucceededEvent(commandMessage, commandName, responseDocumentForEvent, description, startTimeNanos,
-                    commandListener);
-        }
-    }
-
-    private void sendFailedEvent(final long startTimeNanos, final CommandMessage commandMessage, final String commandName,
-                                 final Throwable t) {
-        if (commandListener != null && opened()) {
-            Throwable commandEventException = t;
-            if (t instanceof MongoCommandException && (SECURITY_SENSITIVE_COMMANDS.contains(commandName))) {
-                commandEventException = new MongoCommandException(new BsonDocument(), description.getServerAddress());
+        public void sendStartedEvent(final ByteBufferBsonOutput bsonOutput) {
+            if (commandListener != null || sendCompressor != null) {
+                ByteBufBsonDocument byteBufBsonDocument = createOne(bsonOutput, message.getEncodingMetadata().getFirstDocumentPosition());
+                BsonDocument commandDocument;
+                if (byteBufBsonDocument.containsKey("$query")) {
+                    commandDocument = byteBufBsonDocument.getDocument("$query");
+                    commandName = commandDocument.keySet().iterator().next();
+                } else {
+                    commandDocument = byteBufBsonDocument;
+                    commandName = byteBufBsonDocument.getFirstKey();
+                }
+                if (commandListener != null && opened()) {
+                    BsonDocument commandDocumentForEvent = (SECURITY_SENSITIVE_COMMANDS.contains(commandName))
+                                                                   ? new BsonDocument() : commandDocument;
+                    sendCommandStartedEvent(message, new MongoNamespace(message.getCollectionName()).getDatabaseName(), commandName,
+                            commandDocumentForEvent, getDescription(), commandListener);
+                }
             }
-            sendCommandFailedEvent(commandMessage, commandName, description, startTimeNanos, commandEventException, commandListener);
         }
-    }
 
-    private static <T extends BsonDocument> T getResponseDocument(final ResponseBuffers responseBuffers,
-                                                                  final CommandMessage commandMessage, final Decoder<T> decoder) {
-        ReplyMessage<T> replyMessage = new ReplyMessage<T>(responseBuffers, decoder, commandMessage.getId());
-        responseBuffers.reset();
-        return replyMessage.getDocuments().get(0);
+        public void sendFailedEvent(final Throwable t) {
+            if (commandListener != null && opened()) {
+                Throwable commandEventException = t;
+                if (t instanceof MongoCommandException && (SECURITY_SENSITIVE_COMMANDS.contains(commandName))) {
+                    commandEventException = new MongoCommandException(new BsonDocument(), description.getServerAddress());
+                }
+                sendCommandFailedEvent(message, commandName, description, startTimeNanos, commandEventException, commandListener);
+            }
+        }
+
+        public void sendSucceededEvent(final ResponseBuffers responseBuffers) {
+            if (commandListener != null && opened()) {
+                BsonDocument responseDocumentForEvent = (SECURITY_SENSITIVE_COMMANDS.contains(commandName))
+                                                                ? new BsonDocument()
+                                                                : getResponseDocument(responseBuffers, message.getId(),
+                        new RawBsonDocumentCodec());
+                sendCommandSucceededEvent(message, commandName, responseDocumentForEvent, description, startTimeNanos,
+                        commandListener);
+            }
+        }
     }
 }

--- a/driver-core/src/main/com/mongodb/connection/MessageHeader.java
+++ b/driver-core/src/main/com/mongodb/connection/MessageHeader.java
@@ -17,7 +17,7 @@
 package com.mongodb.connection;
 
 import com.mongodb.MongoInternalException;
-import org.bson.io.BsonInput;
+import org.bson.ByteBuf;
 
 // Contains the details of an OP_COMPRESSED reply from a MongoDB server.
 class MessageHeader {
@@ -31,11 +31,11 @@ class MessageHeader {
     private final int responseTo;
     private final int opCode;
 
-    MessageHeader(final BsonInput header, final int maxMessageLength) {
-        messageLength = header.readInt32();
-        requestId = header.readInt32();
-        responseTo = header.readInt32();
-        opCode = header.readInt32();
+    MessageHeader(final ByteBuf header, final int maxMessageLength) {
+        messageLength = header.getInt();
+        requestId = header.getInt();
+        responseTo = header.getInt();
+        opCode = header.getInt();
 
         if (messageLength > maxMessageLength) {
             throw new MongoInternalException(String.format("The reply message length %d is less than the maximum message length %d",

--- a/driver-core/src/main/com/mongodb/connection/MessageSettings.java
+++ b/driver-core/src/main/com/mongodb/connection/MessageSettings.java
@@ -33,6 +33,7 @@ final class MessageSettings {
     private final int maxDocumentSize;
     private final int maxMessageSize;
     private final int maxBatchCount;
+    private final ServerVersion serverVersion;
 
     /**
      * Gets the builder
@@ -51,6 +52,7 @@ final class MessageSettings {
         private int maxDocumentSize = DEFAULT_MAX_DOCUMENT_SIZE;
         private int maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
         private int maxBatchCount = DEFAULT_MAX_BATCH_COUNT;
+        private ServerVersion serverVersion;
 
         /**
          * Build it.
@@ -93,6 +95,11 @@ final class MessageSettings {
             this.maxBatchCount = maxBatchCount;
             return this;
         }
+
+        public Builder serverVersion(final ServerVersion serverVersion) {
+            this.serverVersion = serverVersion;
+            return this;
+        }
     }
 
     /**
@@ -122,9 +129,14 @@ final class MessageSettings {
         return maxBatchCount;
     }
 
+    public ServerVersion getServerVersion() {
+        return serverVersion;
+    }
+
     private MessageSettings(final Builder builder) {
         this.maxDocumentSize = builder.maxDocumentSize;
         this.maxMessageSize = builder.maxMessageSize;
         this.maxBatchCount = builder.maxBatchCount;
+        this.serverVersion = builder.serverVersion;
     }
 }

--- a/driver-core/src/main/com/mongodb/connection/OpCode.java
+++ b/driver-core/src/main/com/mongodb/connection/OpCode.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.connection;
+
+enum OpCode {
+    OP_REPLY(1),
+    OP_UPDATE(2001),
+    OP_INSERT(2002),
+    OP_QUERY(2004),
+    OP_GETMORE(2005),
+    OP_DELETE(2006),
+    OP_KILL_CURSORS(2007),
+    OP_COMPRESSED(2012),
+    OP_MSG(2013);
+
+    OpCode(final int value) {
+        this.value = value;
+    }
+
+    private final int value;
+
+    public int getValue() {
+        return value;
+    }
+}

--- a/driver-core/src/main/com/mongodb/connection/ProtocolHelper.java
+++ b/driver-core/src/main/com/mongodb/connection/ProtocolHelper.java
@@ -136,6 +136,7 @@ final class ProtocolHelper {
                               .maxDocumentSize(connectionDescription.getMaxDocumentSize())
                               .maxMessageSize(connectionDescription.getMaxMessageSize())
                               .maxBatchCount(connectionDescription.getMaxBatchCount())
+                              .serverVersion(connectionDescription.getServerVersion())
                               .build();
     }
 

--- a/driver-core/src/main/com/mongodb/connection/QueryProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/QueryProtocol.java
@@ -472,7 +472,7 @@ class QueryProtocol<T> implements Protocol<QueryResult<T>> {
                                                        final boolean isExplain) {
         List<ByteBufBsonDocument> rawResultDocuments = Collections.emptyList();
         if (responseBuffers.getReplyHeader().getNumberReturned() > 0) {
-            responseBuffers.getBodyByteBuffer().position(0);
+            responseBuffers.reset();
             rawResultDocuments = ByteBufBsonDocument.create(responseBuffers);
         }
 

--- a/driver-core/src/main/com/mongodb/connection/RequestMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/RequestMessage.java
@@ -240,26 +240,4 @@ abstract class RequestMessage {
         }
     }
 
-    // TODO: Move to top-level
-    enum OpCode {
-        OP_REPLY(1),
-        OP_MSG(1000),
-        OP_UPDATE(2001),
-        OP_INSERT(2002),
-        OP_QUERY(2004),
-        OP_GETMORE(2005),
-        OP_DELETE(2006),
-        OP_KILL_CURSORS(2007),
-        OP_COMPRESSED(2012);
-
-        OpCode(final int value) {
-            this.value = value;
-        }
-
-        private final int value;
-
-        public int getValue() {
-            return value;
-        }
-    }
 }

--- a/driver-core/src/main/com/mongodb/connection/RequestMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/RequestMessage.java
@@ -239,5 +239,4 @@ abstract class RequestMessage {
             writer.close();
         }
     }
-
 }

--- a/driver-core/src/main/com/mongodb/connection/SimpleCommandMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/SimpleCommandMessage.java
@@ -20,9 +20,13 @@ import com.mongodb.MongoNamespace;
 import com.mongodb.ReadPreference;
 import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import org.bson.BsonDocument;
+import org.bson.BsonElement;
 import org.bson.BsonString;
 import org.bson.FieldNameValidator;
 import org.bson.io.BsonOutput;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.mongodb.ReadPreference.primary;
 
@@ -52,12 +56,15 @@ class SimpleCommandMessage extends CommandMessage {
     @Override
     protected EncodingMetadata encodeMessageBodyWithMetadata(final BsonOutput bsonOutput, final int messageStartPosition) {
         BsonDocument commandToEncode;
+        List<BsonElement> extraElements = null;
         if (useNewOpCode()) {
             bsonOutput.writeInt32(0);  // flag bits
             bsonOutput.writeByte(0);   // payload type
-            command.put("$db", new BsonString(new MongoNamespace(getCollectionName()).getDatabaseName()));
+
+            extraElements = new ArrayList<BsonElement>();
+            extraElements.add(new BsonElement("$db", new BsonString(new MongoNamespace(getCollectionName()).getDatabaseName())));
             if (!isDefaultReadPreference()) {
-                command.put("$readPreference", readPreference.toDocument());
+                extraElements.add(new BsonElement("$readPreference", readPreference.toDocument()));
             }
             commandToEncode = command;
         } else {
@@ -74,7 +81,7 @@ class SimpleCommandMessage extends CommandMessage {
         }
 
         int firstDocumentPosition = bsonOutput.getPosition();
-        addDocument(commandToEncode, bsonOutput, validator);
+        addDocument(commandToEncode, bsonOutput, validator, extraElements);
         return new EncodingMetadata(null, firstDocumentPosition);
     }
 

--- a/driver-core/src/main/com/mongodb/connection/SimpleCommandMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/SimpleCommandMessage.java
@@ -57,7 +57,7 @@ class SimpleCommandMessage extends CommandMessage {
     protected EncodingMetadata encodeMessageBodyWithMetadata(final BsonOutput bsonOutput, final int messageStartPosition) {
         BsonDocument commandToEncode;
         List<BsonElement> extraElements = null;
-        if (useNewOpCode()) {
+        if (useOpMsg()) {
             bsonOutput.writeInt32(0);  // flag bits
             bsonOutput.writeByte(0);   // payload type
 

--- a/driver-core/src/main/com/mongodb/connection/SimpleCommandMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/SimpleCommandMessage.java
@@ -17,11 +17,14 @@
 package com.mongodb.connection;
 
 import com.mongodb.MongoNamespace;
+import com.mongodb.ReadPreference;
 import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
 import org.bson.FieldNameValidator;
 import org.bson.io.BsonOutput;
+
+import static com.mongodb.ReadPreference.primary;
 
 /**
  * A command message that uses OP_QUERY to send the command.
@@ -29,39 +32,54 @@ import org.bson.io.BsonOutput;
  * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-query OP_QUERY
  */
 class SimpleCommandMessage extends CommandMessage {
-    private final boolean slaveOk;
+    private final ReadPreference readPreference;
     private final BsonDocument command;
     private final FieldNameValidator validator;
 
-    SimpleCommandMessage(final String collectionName, final BsonDocument command, final boolean slaveOk, final MessageSettings settings) {
-        this(collectionName, command, slaveOk, new NoOpFieldNameValidator(), settings);
+    SimpleCommandMessage(final String collectionName, final BsonDocument command, final ReadPreference readPreference,
+                         final MessageSettings settings) {
+        this(collectionName, command, readPreference, new NoOpFieldNameValidator(), settings);
     }
 
-    SimpleCommandMessage(final String collectionName, final BsonDocument command, final boolean slaveOk,
+    SimpleCommandMessage(final String collectionName, final BsonDocument command, final ReadPreference readPreference,
                          final FieldNameValidator validator, final MessageSettings settings) {
         super(collectionName, useNewOpCode(settings) ? OpCode.OP_MSG : OpCode.OP_QUERY, settings);
-        this.slaveOk = slaveOk;
+        this.readPreference = readPreference;
         this.command = command;
         this.validator = validator;
     }
 
     @Override
     protected EncodingMetadata encodeMessageBodyWithMetadata(final BsonOutput bsonOutput, final int messageStartPosition) {
+        BsonDocument commandToEncode;
         if (useNewOpCode()) {
             bsonOutput.writeInt32(0);  // flag bits
             bsonOutput.writeByte(0);   // payload type
-            // TODO: this is ugly
             command.put("$db", new BsonString(new MongoNamespace(getCollectionName()).getDatabaseName()));
+            if (!isDefaultReadPreference()) {
+                command.put("$readPreference", readPreference.toDocument());
+            }
+            commandToEncode = command;
         } else {
-            bsonOutput.writeInt32(slaveOk ? 1 << 2 : 0);
+            bsonOutput.writeInt32(readPreference.isSlaveOk() ? 1 << 2 : 0);
             bsonOutput.writeCString(getCollectionName());
             bsonOutput.writeInt32(0);
             bsonOutput.writeInt32(-1);
+            // TODO: only do this when sending to mongos?
+            if (!isDefaultReadPreference()) {
+                commandToEncode = new BsonDocument("$query", command).append("$readPreference", readPreference.toDocument());
+            } else {
+                commandToEncode = command;
+            }
         }
 
         int firstDocumentPosition = bsonOutput.getPosition();
-        addDocument(command, bsonOutput, validator);
+        addDocument(commandToEncode, bsonOutput, validator);
         return new EncodingMetadata(null, firstDocumentPosition);
+    }
+
+    private boolean isDefaultReadPreference() {
+        return readPreference.equals(primary());
     }
 
     private boolean useNewOpCode() {

--- a/driver-core/src/main/com/mongodb/connection/SimpleCommandMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/SimpleCommandMessage.java
@@ -47,7 +47,7 @@ class SimpleCommandMessage extends CommandMessage {
 
     SimpleCommandMessage(final String collectionName, final BsonDocument command, final ReadPreference readPreference,
                          final FieldNameValidator validator, final MessageSettings settings) {
-        super(collectionName, useNewOpCode(settings) ? OpCode.OP_MSG : OpCode.OP_QUERY, settings);
+        super(collectionName, getOpCode(settings), settings);
         this.readPreference = readPreference;
         this.command = command;
         this.validator = validator;
@@ -87,13 +87,5 @@ class SimpleCommandMessage extends CommandMessage {
 
     private boolean isDefaultReadPreference() {
         return readPreference.equals(primary());
-    }
-
-    private boolean useNewOpCode() {
-        return useNewOpCode(getSettings());
-    }
-
-    private static boolean useNewOpCode(final MessageSettings settings) {
-        return settings.getServerVersion().compareTo(new ServerVersion(3, 5)) >= 0;
     }
 }

--- a/driver-core/src/main/com/mongodb/connection/SimpleCommandMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/SimpleCommandMessage.java
@@ -72,7 +72,6 @@ class SimpleCommandMessage extends CommandMessage {
             bsonOutput.writeCString(getCollectionName());
             bsonOutput.writeInt32(0);
             bsonOutput.writeInt32(-1);
-            // TODO: only do this when sending to mongos?
             if (!isDefaultReadPreference()) {
                 commandToEncode = new BsonDocument("$query", command).append("$readPreference", readPreference.toDocument());
             } else {

--- a/driver-core/src/main/com/mongodb/connection/WriteProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/WriteProtocol.java
@@ -18,6 +18,7 @@ package com.mongodb.connection;
 
 import com.mongodb.MongoInternalException;
 import com.mongodb.MongoNamespace;
+import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
 import com.mongodb.WriteConcernException;
 import com.mongodb.WriteConcernResult;
@@ -88,7 +89,7 @@ abstract class WriteProtocol implements Protocol<WriteConcernResult> {
                 if (shouldAcknowledge(requestMessage.getEncodingMetadata().getNextMessage())) {
                     SimpleCommandMessage getLastErrorMessage = new SimpleCommandMessage(new MongoNamespace(getNamespace().getDatabaseName(),
                             COMMAND_COLLECTION_NAME).getFullName(),
-                            createGetLastErrorCommandDocument(), false,
+                            createGetLastErrorCommandDocument(), ReadPreference.primary(),
                             getMessageSettings(connection.getDescription()));
                     getLastErrorMessage.encode(bsonOutput);
                     messageId = getLastErrorMessage.getId();
@@ -157,7 +158,7 @@ abstract class WriteProtocol implements Protocol<WriteConcernResult> {
             if (shouldAcknowledge(encodingMetadata.getNextMessage())) {
                 SimpleCommandMessage getLastErrorMessage = new SimpleCommandMessage(new MongoNamespace(getNamespace().getDatabaseName(),
                         COMMAND_COLLECTION_NAME).getFullName(),
-                        createGetLastErrorCommandDocument(), false,
+                        createGetLastErrorCommandDocument(), ReadPreference.primary(),
                         getMessageSettings(connection.getDescription()));
                 encodeMessage(getLastErrorMessage, bsonOutput);
                 SingleResultCallback<ResponseBuffers> receiveCallback = new WriteResultCallback(callback,

--- a/driver-core/src/main/com/mongodb/connection/netty/NettyByteBuf.java
+++ b/driver-core/src/main/com/mongodb/connection/netty/NettyByteBuf.java
@@ -26,8 +26,9 @@ final class NettyByteBuf implements ByteBuf {
     private io.netty.buffer.ByteBuf proxied;
     private boolean isWriting = true;
 
+    @SuppressWarnings("deprecation")
     NettyByteBuf(final io.netty.buffer.ByteBuf proxied) {
-        this.proxied = proxied;
+        this.proxied = proxied.order(ByteOrder.LITTLE_ENDIAN);
     }
 
     NettyByteBuf(final io.netty.buffer.ByteBuf proxied, final boolean isWriting) {

--- a/driver-core/src/main/com/mongodb/operation/AsyncQueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/AsyncQueryBatchCursor.java
@@ -19,6 +19,7 @@ package com.mongodb.operation;
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoException;
 import com.mongodb.MongoNamespace;
+import com.mongodb.ReadPreference;
 import com.mongodb.ServerCursor;
 import com.mongodb.async.AsyncBatchCursor;
 import com.mongodb.async.SingleResultCallback;
@@ -146,7 +147,7 @@ class AsyncQueryBatchCursor<T> implements AsyncBatchCursor<T> {
 
     private void getMore(final AsyncConnection connection, final ServerCursor cursor, final SingleResultCallback<List<T>> callback) {
         if (serverIsAtLeastVersionThreeDotTwo(connection.getDescription())) {
-            connection.commandAsync(namespace.getDatabaseName(), asGetMoreCommandDocument(cursor.getId()), false,
+            connection.commandAsync(namespace.getDatabaseName(), asGetMoreCommandDocument(cursor.getId()), ReadPreference.primary(),
                                     new NoOpFieldNameValidator(), CommandResultDocumentCodec.create(decoder, "nextBatch"),
                                     new CommandResultSingleResultCallback(connection, cursor, callback));
 
@@ -199,7 +200,7 @@ class AsyncQueryBatchCursor<T> implements AsyncBatchCursor<T> {
 
     private void killCursorAsynchronouslyAndReleaseConnectionAndSource(final AsyncConnection connection, final ServerCursor localCursor) {
         if (serverIsAtLeastVersionThreeDotTwo(connection.getDescription())) {
-            connection.commandAsync(namespace.getDatabaseName(), asKillCursorsCommandDocument(localCursor), false,
+            connection.commandAsync(namespace.getDatabaseName(), asKillCursorsCommandDocument(localCursor), ReadPreference.primary(),
                     new NoOpFieldNameValidator(), new BsonDocumentCodec(), new SingleResultCallback<BsonDocument>() {
                         @Override
                         public void onResult(final BsonDocument result, final Throwable t) {

--- a/driver-core/src/main/com/mongodb/operation/QueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/QueryBatchCursor.java
@@ -18,6 +18,7 @@ package com.mongodb.operation;
 
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoNamespace;
+import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
 import com.mongodb.ServerCursor;
 import com.mongodb.binding.ConnectionSource;
@@ -208,7 +209,7 @@ class QueryBatchCursor<T> implements BatchCursor<T> {
                 try {
                     initFromCommandResult(connection.command(namespace.getDatabaseName(),
                                                              asGetMoreCommandDocument(),
-                                                             false,
+                                                             ReadPreference.primary(),
                                                              new NoOpFieldNameValidator(),
                                                              CommandResultDocumentCodec.create(decoder, "nextBatch")));
                 } catch (MongoCommandException e) {
@@ -273,7 +274,7 @@ class QueryBatchCursor<T> implements BatchCursor<T> {
         if (serverCursor != null) {
             notNull("connection", connection);
             if (serverIsAtLeastVersionThreeDotTwo(connection.getDescription())) {
-                connection.command(namespace.getDatabaseName(), asKillCursorsCommandDocument(), false,
+                connection.command(namespace.getDatabaseName(), asKillCursorsCommandDocument(), ReadPreference.primary(),
                         new NoOpFieldNameValidator(), new BsonDocumentCodec());
             } else {
                 connection.killCursor(namespace, singletonList(serverCursor.getId()));

--- a/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
@@ -170,7 +170,7 @@ class OperationFunctionalSpecification extends Specification {
         if (checkCommand) {
             1 * connection.command(_, expectedCommand, _, _, _) >> { result }
         } else if (checkSlaveOk) {
-            1 * connection.command(_, _, readPreference.isSlaveOk(), _, _) >> { result }
+            1 * connection.command(_, _, readPreference, _, _) >> { result }
         }
 
         0 * connection.command(_, _, _, _, _) >> {
@@ -211,7 +211,7 @@ class OperationFunctionalSpecification extends Specification {
         if (checkCommand) {
             1 * connection.commandAsync(_, expectedCommand, _, _, _, _) >> { it[5].onResult(result, null) }
         } else if (checkSlaveOk) {
-            1 * connection.commandAsync(_, _, readPreference.isSlaveOk(), _, _, _) >> { it[5].onResult(result, null) }
+            1 * connection.commandAsync(_, _, readPreference, _, _, _) >> { it[5].onResult(result, null) }
         }
 
         0 * connection.commandAsync(_, _, _, _, _, _) >> {

--- a/driver-core/src/test/functional/com/mongodb/connection/ReplyHeaderSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/ReplyHeaderSpecification.groovy
@@ -19,8 +19,6 @@ package com.mongodb.connection
 
 import com.mongodb.MongoInternalException
 import org.bson.io.BasicOutputBuffer
-import org.bson.io.BsonInput
-import org.bson.io.ByteBufferBsonInput
 import spock.lang.Specification
 
 import static com.mongodb.connection.ConnectionDescription.getDefaultMaxMessageSize
@@ -39,10 +37,10 @@ class ReplyHeaderSpecification extends Specification {
             writeInt(4)
             writeInt(30)
         }
-        BsonInput buffer = new ByteBufferBsonInput(outputBuffer.byteBuffers.get(0));
+        def byteBuf = outputBuffer.byteBuffers.get(0)
 
         when:
-        def replyHeader = new ReplyHeader(buffer, new MessageHeader(buffer, getDefaultMaxMessageSize()));
+        def replyHeader = new ReplyHeader(byteBuf, new MessageHeader(byteBuf, getDefaultMaxMessageSize()));
 
         then:
         replyHeader.messageLength == 186
@@ -77,11 +75,11 @@ class ReplyHeaderSpecification extends Specification {
             writeInt(4)
             writeInt(30)
         }
-        BsonInput buffer = new ByteBufferBsonInput(outputBuffer.byteBuffers.get(0));
-        def compressedHeader = new CompressedHeader(buffer, new MessageHeader(buffer, getDefaultMaxMessageSize()))
+        def byteBuf = outputBuffer.byteBuffers.get(0)
+        def compressedHeader = new CompressedHeader(byteBuf, new MessageHeader(byteBuf, getDefaultMaxMessageSize()))
 
         when:
-        def replyHeader = new ReplyHeader(compressedHeader, buffer);
+        def replyHeader = new ReplyHeader(byteBuf, compressedHeader);
 
         then:
         replyHeader.messageLength == 274
@@ -112,14 +110,14 @@ class ReplyHeaderSpecification extends Specification {
             writeInt(0)
             writeInt(0)
         }
-        BsonInput buffer = new ByteBufferBsonInput(outputBuffer.byteBuffers.get(0));
+        def byteBuf = outputBuffer.byteBuffers.get(0)
 
         when:
-        new ReplyHeader(buffer, new MessageHeader(buffer, getDefaultMaxMessageSize()));
+        new ReplyHeader(byteBuf, new MessageHeader(byteBuf, getDefaultMaxMessageSize()));
 
         then:
         def ex = thrown(MongoInternalException)
-        ex.getMessage() == 'The reply message opCode 2 does not match the expected opCode 1'
+        ex.getMessage() == 'Unexpected reply message opCode 2'
     }
 
     def 'should throw MongoInternalException on message size < 36'() {
@@ -134,10 +132,10 @@ class ReplyHeaderSpecification extends Specification {
             writeInt(0)
             writeInt(0)
         }
-        BsonInput buffer = new ByteBufferBsonInput(outputBuffer.byteBuffers.get(0));
+        def byteBuf = outputBuffer.byteBuffers.get(0)
 
         when:
-        new ReplyHeader(buffer, new MessageHeader(buffer, getDefaultMaxMessageSize()));
+        new ReplyHeader(byteBuf, new MessageHeader(byteBuf, getDefaultMaxMessageSize()));
 
         then:
         def ex = thrown(MongoInternalException)
@@ -156,10 +154,10 @@ class ReplyHeaderSpecification extends Specification {
             writeInt(0)
             writeInt(0)
         }
-        BsonInput buffer = new ByteBufferBsonInput(outputBuffer.byteBuffers.get(0));
+        def byteBuf = outputBuffer.byteBuffers.get(0)
 
         when:
-        new ReplyHeader(buffer, new MessageHeader(buffer, 399));
+        new ReplyHeader(byteBuf, new MessageHeader(byteBuf, 399));
 
         then:
         def ex = thrown(MongoInternalException)
@@ -178,10 +176,10 @@ class ReplyHeaderSpecification extends Specification {
             writeInt(4)
             writeInt(-1)
         }
-        BsonInput buffer = new ByteBufferBsonInput(outputBuffer.byteBuffers.get(0));
+        def byteBuf = outputBuffer.byteBuffers.get(0)
 
         when:
-        new ReplyHeader(buffer, new MessageHeader(buffer, getDefaultMaxMessageSize()));
+        new ReplyHeader(byteBuf, new MessageHeader(byteBuf, getDefaultMaxMessageSize()));
 
         then:
         def ex = thrown(MongoInternalException)
@@ -204,11 +202,11 @@ class ReplyHeaderSpecification extends Specification {
             writeInt(4)
             writeInt(-1)
         }
-        BsonInput buffer = new ByteBufferBsonInput(outputBuffer.byteBuffers.get(0));
-        def compressedHeader = new CompressedHeader(buffer, new MessageHeader(buffer, getDefaultMaxMessageSize()))
+        def byteBuf = outputBuffer.byteBuffers.get(0)
+        def compressedHeader = new CompressedHeader(byteBuf, new MessageHeader(byteBuf, getDefaultMaxMessageSize()))
 
         when:
-        new ReplyHeader(compressedHeader, buffer);
+        new ReplyHeader(byteBuf, compressedHeader);
 
         then:
         def ex = thrown(MongoInternalException)

--- a/driver-core/src/test/functional/com/mongodb/connection/WriteProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/WriteProtocolCommandEventSpecification.groovy
@@ -21,6 +21,7 @@ package com.mongodb.connection
 import com.mongodb.DuplicateKeyException
 import com.mongodb.MongoCommandException
 import com.mongodb.OperationFunctionalSpecification
+import com.mongodb.ReadPreference
 import com.mongodb.ServerAddress
 import com.mongodb.bulk.DeleteRequest
 import com.mongodb.bulk.InsertRequest
@@ -95,7 +96,9 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
         cleanup:
         // force acknowledgement
         new CommandProtocol(getDatabaseName(), new BsonDocument('drop', new BsonString(getCollectionName())),
-                            new NoOpFieldNameValidator(), new BsonDocumentCodec()).execute(connection)
+                            new NoOpFieldNameValidator(), new BsonDocumentCodec())
+                .readPreference(ReadPreference.primary())
+                .execute(connection)
 
         where:
         async << [false, true]
@@ -143,7 +146,9 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
         cleanup:
         // force acknowledgement
         new CommandProtocol(getDatabaseName(), new BsonDocument('drop', new BsonString(getCollectionName())),
-                            new NoOpFieldNameValidator(), new BsonDocumentCodec()).execute(connection)
+                            new NoOpFieldNameValidator(), new BsonDocumentCodec())
+                .readPreference(ReadPreference.primary())
+                .execute(connection)
 
         where:
         async << [false, true]
@@ -254,7 +259,9 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
         cleanup:
         // force acknowledgement
         new CommandProtocol(getDatabaseName(), new BsonDocument('drop', new BsonString(getCollectionName())),
-                            new NoOpFieldNameValidator(), new BsonDocumentCodec()).execute(connection)
+                            new NoOpFieldNameValidator(), new BsonDocumentCodec())
+                .readPreference(ReadPreference.primary())
+                .execute(connection)
 
         where:
         async << [false, true]

--- a/driver-core/src/test/functional/com/mongodb/connection/WriteProtocolSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/WriteProtocolSpecification.groovy
@@ -20,6 +20,7 @@ package com.mongodb.connection
 
 import com.mongodb.DuplicateKeyException
 import com.mongodb.OperationFunctionalSpecification
+import com.mongodb.ReadPreference
 import com.mongodb.bulk.InsertRequest
 import com.mongodb.connection.netty.NettyStreamFactory
 import com.mongodb.internal.validator.NoOpFieldNameValidator
@@ -77,7 +78,9 @@ class WriteProtocolSpecification extends OperationFunctionalSpecification {
         cleanup:
         // force acknowledgement
         new CommandProtocol(getDatabaseName(), new BsonDocument('drop', new BsonString(getCollectionName())),
-                            new NoOpFieldNameValidator(), new BsonDocumentCodec()).execute(connection)
+                            new NoOpFieldNameValidator(), new BsonDocumentCodec())
+                .readPreference(ReadPreference.primary())
+                .execute(connection)
 
         where:
         async << [false, true]
@@ -124,7 +127,9 @@ class WriteProtocolSpecification extends OperationFunctionalSpecification {
         execute(protocol, connection, async)
         // force acknowledgement
         new CommandProtocol(getDatabaseName(), new BsonDocument('ping', new BsonInt32(1)),
-                new NoOpFieldNameValidator(), new BsonDocumentCodec()).execute(connection)
+                new NoOpFieldNameValidator(), new BsonDocumentCodec())
+                .readPreference(ReadPreference.primary())
+                .execute(connection)
 
         then:
         getCollectionHelper().count() == 4
@@ -175,7 +180,9 @@ class WriteProtocolSpecification extends OperationFunctionalSpecification {
         execute(protocol, connection, async)
         // force acknowledgement
         new CommandProtocol(getDatabaseName(), new BsonDocument('ping', new BsonInt32(1)),
-                new NoOpFieldNameValidator(), new BsonDocumentCodec()).execute(connection)
+                new NoOpFieldNameValidator(), new BsonDocumentCodec())
+                .readPreference(ReadPreference.primary())
+                .execute(connection)
 
         then:
         getCollectionHelper().count() == 1
@@ -203,7 +210,9 @@ class WriteProtocolSpecification extends OperationFunctionalSpecification {
         execute(protocol, connection, async)
         // force acknowledgement
         new CommandProtocol(getDatabaseName(), new BsonDocument('ping', new BsonInt32(1)),
-                new NoOpFieldNameValidator(), new BsonDocumentCodec()).execute(connection)
+                new NoOpFieldNameValidator(), new BsonDocumentCodec())
+                .readPreference(ReadPreference.primary())
+                .execute(connection)
 
         then:
         getCollectionHelper().count() == 4

--- a/driver-core/src/test/functional/com/mongodb/operation/ListCollectionsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ListCollectionsOperationSpecification.groovy
@@ -397,7 +397,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
         then:
         _ * connection.getDescription() >> helper.threeZeroConnectionDescription
-        1 * connection.command(_, _, readPreference.isSlaveOk(), _, _) >> helper.commandResult
+        1 * connection.command(_, _, readPreference, _, _) >> helper.commandResult
         1 * connection.release()
 
         where:
@@ -429,7 +429,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
         then:
         _ * connection.getDescription() >> helper.threeZeroConnectionDescription
-        1 * connection.commandAsync(helper.dbName, _, readPreference.isSlaveOk(), _, _, _) >> { it[6].onResult(helper.commandResult, _) }
+        1 * connection.commandAsync(helper.dbName, _, readPreference, _, _, _) >> { it[6].onResult(helper.commandResult, _) }
 
         where:
         readPreference << [ReadPreference.primary(), ReadPreference.secondary()]

--- a/driver-core/src/test/functional/com/mongodb/operation/ListDatabasesOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ListDatabasesOperationSpecification.groovy
@@ -130,7 +130,7 @@ class ListDatabasesOperationSpecification extends OperationFunctionalSpecificati
 
         then:
         _ * connection.getDescription() >> helper.connectionDescription
-        1 * connection.command(_, _, readPreference.isSlaveOk(), _, _) >> helper.commandResult
+        1 * connection.command(_, _, readPreference, _, _) >> helper.commandResult
         1 * connection.release()
 
         where:
@@ -154,7 +154,7 @@ class ListDatabasesOperationSpecification extends OperationFunctionalSpecificati
 
         then:
         _ * connection.getDescription() >> helper.connectionDescription
-        1 * connection.commandAsync(_, _, readPreference.isSlaveOk(), _, _, _) >> { it[5].onResult(helper.commandResult, null) }
+        1 * connection.commandAsync(_, _, readPreference, _, _, _) >> { it[5].onResult(helper.commandResult, null) }
         1 * connection.release()
 
         where:

--- a/driver-core/src/test/functional/com/mongodb/operation/ListIndexesOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ListIndexesOperationSpecification.groovy
@@ -273,7 +273,7 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
 
         then:
         _ * connection.getDescription() >> helper.threeZeroConnectionDescription
-        1 * connection.command(_, _, readPreference.isSlaveOk(), _, _) >> helper.commandResult
+        1 * connection.command(_, _, readPreference, _, _) >> helper.commandResult
         1 * connection.release()
 
         where:
@@ -305,7 +305,7 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
 
         then:
         _ * connection.getDescription() >> helper.threeZeroConnectionDescription
-        1 * connection.commandAsync(helper.dbName, _, readPreference.isSlaveOk(), _, _, _) >> { it[6].onResult(helper.commandResult, _) }
+        1 * connection.commandAsync(helper.dbName, _, readPreference, _, _, _) >> { it[6].onResult(helper.commandResult, _) }
 
         where:
         readPreference << [ReadPreference.primary(), ReadPreference.secondary()]

--- a/driver-core/src/test/functional/com/mongodb/operation/ParallelCollectionScanOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ParallelCollectionScanOperationSpecification.groovy
@@ -139,7 +139,7 @@ class ParallelCollectionScanOperationSpecification extends OperationFunctionalSp
 
         then:
         _ * connection.getDescription() >> helper.connectionDescription
-        1 * connection.command(helper.dbName, _, readPreference.isSlaveOk(), _, _) >> helper.commandResult
+        1 * connection.command(helper.dbName, _, readPreference, _, _) >> helper.commandResult
         1 * connection.release()
 
         where:
@@ -163,7 +163,7 @@ class ParallelCollectionScanOperationSpecification extends OperationFunctionalSp
 
         then:
         _ * connection.getDescription() >> helper.connectionDescription
-        1 * connection.commandAsync(helper.dbName, _, readPreference.isSlaveOk(), _, _, _) >> {
+        1 * connection.commandAsync(helper.dbName, _, readPreference, _, _, _) >> {
             it[5].onResult(helper.commandResult, null) }
         1 * connection.release()
 

--- a/driver-core/src/test/functional/com/mongodb/operation/UserOperationsSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/UserOperationsSpecification.groovy
@@ -375,7 +375,7 @@ class UserOperationsSpecification extends OperationFunctionalSpecification {
 
         then:
         _ * connection.getDescription() >> helper.twoSixConnectionDescription
-        1 * connection.command(helper.dbName, _, readPreference.isSlaveOk(), _, _) >> helper.cursorResult
+        1 * connection.command(helper.dbName, _, readPreference, _, _) >> helper.cursorResult
 
         where:
         readPreference << [ReadPreference.primary(), ReadPreference.secondary()]
@@ -406,7 +406,7 @@ class UserOperationsSpecification extends OperationFunctionalSpecification {
 
         then:
         _ * connection.getDescription() >> helper.twoSixConnectionDescription
-        1 * connection.commandAsync(helper.dbName, _, readPreference.isSlaveOk(), _, _, _) >> {
+        1 * connection.commandAsync(helper.dbName, _, readPreference, _, _, _) >> {
             it[5].onResult(helper.cursorResult, null) }
 
         where:

--- a/driver-core/src/test/unit/com/mongodb/connection/DefaultConnectionPoolSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/DefaultConnectionPoolSpecification.groovy
@@ -34,6 +34,7 @@ import spock.lang.Subject
 
 import java.util.concurrent.CountDownLatch
 
+import static com.mongodb.ReadPreference.primary
 import static com.mongodb.connection.ConnectionPoolSettings.builder
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static java.util.concurrent.TimeUnit.MINUTES
@@ -177,7 +178,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         c2 = pool.get()
 
         and:
-        c2.sendAndReceive(new SimpleCommandMessage('test', new BsonDocument('ping', new BsonInt32(1)), true,
+        c2.sendAndReceive(new SimpleCommandMessage('test', new BsonDocument('ping', new BsonInt32(1)), primary(),
                 MessageSettings.builder().serverVersion(new ServerVersion(0, 0)).build()),
                 new BsonDocumentCodec())
 
@@ -264,7 +265,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         c2 = pool.get()
 
         and:
-        c2.sendAndReceiveAsync(new SimpleCommandMessage('test', new BsonDocument('ping', new BsonInt32(1)), true,
+        c2.sendAndReceiveAsync(new SimpleCommandMessage('test', new BsonDocument('ping', new BsonInt32(1)), primary(),
                 MessageSettings.builder().serverVersion(new ServerVersion(0, 0)).build()),
                 new BsonDocumentCodec()) {
             result, t -> e = t

--- a/driver-core/src/test/unit/com/mongodb/connection/DefaultServerMonitorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/DefaultServerMonitorSpecification.groovy
@@ -30,8 +30,6 @@ import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-import static com.mongodb.connection.MessageHelper.buildSuccessfulReply
-
 @SuppressWarnings('BusyWait')
 class DefaultServerMonitorSpecification extends Specification {
 
@@ -125,8 +123,8 @@ class DefaultServerMonitorSpecification extends Specification {
 
                     sendMessage(_, _) >> { }
 
-                    sendAndReceive(_) >> { CommandMessage message ->
-                        buildSuccessfulReply(message.getId(), isMasterResponse)
+                    sendAndReceive(_, _) >> {
+                        BsonDocument.parse(isMasterResponse)
                     }
                 }
             }
@@ -198,7 +196,7 @@ class DefaultServerMonitorSpecification extends Specification {
                         connectionDescription
                     }
 
-                    sendAndReceive(_) >> {
+                    sendAndReceive(_, _) >> {
                         throw exception
                     }
                 }

--- a/driver-core/src/test/unit/com/mongodb/connection/InternalStreamConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/InternalStreamConnectionSpecification.groovy
@@ -32,6 +32,7 @@ import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.ByteBuf
 import org.bson.ByteBufNIO
+import org.bson.codecs.BsonDocumentCodec
 import org.junit.experimental.categories.Category
 import spock.lang.IgnoreIf
 import spock.lang.Specification
@@ -54,6 +55,7 @@ class InternalStreamConnectionSpecification extends Specification {
     def serverAddress = new ServerAddress()
     def connectionId = new ConnectionId(SERVER_ID, 1, 1)
     def commandListener = new TestCommandListener()
+    def messageSettings = MessageSettings.builder().serverVersion(new ServerVersion(0, 0))build()
 
     def connectionDescription = new ConnectionDescription(connectionId, new ServerVersion(), ServerType.STANDALONE,
             getDefaultMaxWriteBatchSize(), getDefaultMaxDocumentSize(),
@@ -249,7 +251,7 @@ class InternalStreamConnectionSpecification extends Specification {
 
     def 'should throw MongoInternalException when reply header message length > max message length asynchronously'() {
         given:
-        stream.readAsync(36, _) >> { int numBytes, AsyncCompletionHandler<ByteBuf> handler ->
+        stream.readAsync(16, _) >> { int numBytes, AsyncCompletionHandler<ByteBuf> handler ->
             handler.completed(helper.headerWithMessageSizeGreaterThanMax(1, connectionDescription.maxMessageSize))
         }
 
@@ -277,14 +279,14 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.writeAsync(_, _) >> { List<ByteBuf> buffers, AsyncCompletionHandler<Void> callback ->
             callback.completed(null)
         }
-        stream.readAsync(36, _) >> { int numBytes, AsyncCompletionHandler<ByteBuf> handler ->
+        stream.readAsync(16, _) >> { int numBytes, AsyncCompletionHandler<ByteBuf> handler ->
             if (seen == 0) {
                 seen += 1
                 return handler.failed(new IOException('Something went wrong'))
             }
             handler.completed(headers.pop())
         }
-        stream.readAsync(74, _) >> { int numBytes, AsyncCompletionHandler<ByteBuf> handler ->
+        stream.readAsync(94, _) >> { int numBytes, AsyncCompletionHandler<ByteBuf> handler ->
             handler.completed(helper.defaultBody())
         }
         def connection = getOpenedConnection()
@@ -294,14 +296,14 @@ class InternalStreamConnectionSpecification extends Specification {
         connection.sendMessageAsync(buffers2, messageId2, sndCallbck2)
         connection.receiveMessageAsync(messageId1, rcvdCallbck1)
         connection.receiveMessageAsync(messageId2, rcvdCallbck2)
-        rcvdCallbck1.get(10, SECONDS)
+        rcvdCallbck1.get(1, SECONDS)
 
         then:
         thrown MongoSocketReadException
         connection.isClosed()
 
         when:
-        rcvdCallbck2.get(10, SECONDS)
+        rcvdCallbck2.get(1, SECONDS)
 
         then:
         thrown MongoSocketClosedException
@@ -310,8 +312,7 @@ class InternalStreamConnectionSpecification extends Specification {
     def 'should close the stream when reading the message body throws an exception'() {
         given:
         stream.read(16) >> helper.defaultMessageHeader(1)
-        stream.read(20) >> helper.defaultReplyHeader()
-        stream.read(70) >> { throw new IOException('Something went wrong') }
+        stream.read(90) >> { throw new IOException('Something went wrong') }
 
         def connection = getOpenedConnection()
 
@@ -340,10 +341,10 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.writeAsync(_, _) >> { List<ByteBuf> buffers, AsyncCompletionHandler<Void> callback ->
             callback.completed(null)
         }
-        stream.readAsync(36, _) >> { int numBytes, AsyncCompletionHandler<ByteBuf> handler ->
+        stream.readAsync(16, _) >> { int numBytes, AsyncCompletionHandler<ByteBuf> handler ->
             handler.completed(headers.remove(0))
         }
-        stream.readAsync(70, _) >> { int numBytes, AsyncCompletionHandler<ByteBuf> handler ->
+        stream.readAsync(_, _) >> { int numBytes, AsyncCompletionHandler<ByteBuf> handler ->
             handler.failed(new IOException('Something went wrong'))
         }
         def connection = getOpenedConnection()
@@ -352,7 +353,7 @@ class InternalStreamConnectionSpecification extends Specification {
         connection.sendMessageAsync(buffers1, messageId1, sndCallbck1)
         connection.sendMessageAsync(buffers2, messageId2, sndCallbck2)
         connection.receiveMessageAsync(messageId1, rcvdCallbck1)
-        rcvdCallbck1.get(10, SECONDS)
+        rcvdCallbck1.get(1, SECONDS)
 
         then:
         thrown MongoSocketReadException
@@ -360,7 +361,7 @@ class InternalStreamConnectionSpecification extends Specification {
 
         when:
         connection.receiveMessageAsync(messageId2, rcvdCallbck2)
-        rcvdCallbck2.get(10, SECONDS)
+        rcvdCallbck2.get(1, SECONDS)
 
         then:
         thrown MongoSocketClosedException
@@ -404,14 +405,13 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, MessageSettings.builder().build())
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, messageSettings)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16) >> helper.defaultMessageHeader(commandMessage.getId())
-        stream.read(20) >> helper.defaultReplyHeader()
-        stream.read(70) >> helper.defaultBody()
+        stream.read(90) >> helper.defaultReply()
 
         when:
-        connection.sendAndReceive(commandMessage)
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec())
 
         then:
         commandListener.eventsWereDelivered([
@@ -425,12 +425,12 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, MessageSettings.builder().build())
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, messageSettings)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.write(_) >> { throw new MongoSocketWriteException('Failed to write', serverAddress, new IOException()) }
 
         when:
-        connection.sendAndReceive(commandMessage)
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec())
 
         then:
         def e = thrown(MongoSocketWriteException)
@@ -444,12 +444,12 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, MessageSettings.builder().build())
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, messageSettings)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16) >> { throw new MongoSocketReadException('Failed to read', serverAddress) }
 
         when:
-        connection.sendAndReceive(commandMessage)
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec())
 
         then:
         def e = thrown(MongoSocketReadException)
@@ -463,14 +463,13 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, MessageSettings.builder().build())
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, messageSettings)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16) >> helper.defaultMessageHeader(commandMessage.getId())
-        stream.read(20) >> helper.defaultReplyHeader()
-        stream.read(70) >> { throw new MongoSocketReadException('Failed to read', serverAddress) }
+        stream.read(90) >> { throw new MongoSocketReadException('Failed to read', serverAddress) }
 
         when:
-        connection.sendAndReceive(commandMessage)
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec())
 
         then:
         def e = thrown(MongoSocketException)
@@ -484,15 +483,14 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, MessageSettings.builder().build())
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, messageSettings)
         def response = '{ok : 0, errmsg : "failed"}'
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16) >> helper.messageHeader(commandMessage.getId(), response)
-        stream.read(20) >> helper.replyHeader()
-        stream.read(_) >> helper.body(response)
+        stream.read(_) >> helper.reply(response)
 
         when:
-        connection.sendAndReceive(commandMessage)
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec())
 
         then:
         def e = thrown(MongoCommandException)
@@ -506,14 +504,13 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def securitySensitiveCommandName = securitySensitiveCommand.keySet().iterator().next()
         def connection = getOpenedConnection()
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', securitySensitiveCommand, true, MessageSettings.builder().build())
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', securitySensitiveCommand, true, messageSettings)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16) >> helper.defaultMessageHeader(commandMessage.getId())
-        stream.read(20) >> helper.defaultReplyHeader()
-        stream.read(_) >> helper.defaultBody()
+        stream.read(90) >> helper.defaultReply()
 
         when:
-        connection.sendAndReceive(commandMessage)
+        connection.sendAndReceive(commandMessage, new BsonDocumentCodec())
 
         then:
         commandListener.eventsWereDelivered([
@@ -572,7 +569,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, MessageSettings.builder().build())
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, messageSettings)
         def callback = new FutureResultCallback()
 
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
@@ -582,15 +579,12 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.readAsync(16, _) >> { numBytes, handler ->
             handler.completed(helper.defaultMessageHeader(commandMessage.getId()))
         }
-        stream.readAsync(20, _) >> { numBytes, handler ->
-            handler.completed(helper.defaultReplyHeader())
-        }
-        stream.readAsync(70, _) >> { numBytes, handler ->
-            handler.completed(helper.defaultBody())
+        stream.readAsync(90, _) >> { numBytes, handler ->
+            handler.completed(helper.defaultReply())
         }
 
         when:
-        connection.sendAndReceiveAsync(commandMessage, callback)
+        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), callback)
         callback.get()
 
         then:
@@ -605,7 +599,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, MessageSettings.builder().build())
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, messageSettings)
         def callback = new FutureResultCallback()
 
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
@@ -614,7 +608,7 @@ class InternalStreamConnectionSpecification extends Specification {
         }
 
         when:
-        connection.sendAndReceiveAsync(commandMessage, callback)
+        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), callback)
         callback.get()
 
         then:
@@ -629,7 +623,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, MessageSettings.builder().build())
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, messageSettings)
         def callback = new FutureResultCallback()
 
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
@@ -641,7 +635,7 @@ class InternalStreamConnectionSpecification extends Specification {
         }
 
         when:
-        connection.sendAndReceiveAsync(commandMessage, callback)
+        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), callback)
         callback.get()
 
         then:
@@ -656,7 +650,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, MessageSettings.builder().build())
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, messageSettings)
         def callback = new FutureResultCallback()
 
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
@@ -666,15 +660,12 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.readAsync(16, _) >> { numBytes, handler ->
             handler.completed(helper.defaultMessageHeader(commandMessage.getId()))
         }
-        stream.readAsync(20, _) >> { numBytes, handler ->
-            handler.completed(helper.defaultReplyHeader())
-        }
-        stream.readAsync(70, _) >> { numBytes, handler ->
+        stream.readAsync(90, _) >> { numBytes, handler ->
             handler.failed(new MongoSocketReadException('Failed to read', serverAddress))
         }
 
         when:
-        connection.sendAndReceiveAsync(commandMessage, callback)
+        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), callback)
         callback.get()
 
         then:
@@ -689,7 +680,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, MessageSettings.builder().build())
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, messageSettings)
         def callback = new FutureResultCallback()
         def response = '{ok : 0, errmsg : "failed"}'
 
@@ -700,15 +691,12 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.readAsync(16, _) >> { numBytes, handler ->
             handler.completed(helper.defaultMessageHeader(commandMessage.getId()))
         }
-        stream.readAsync(20, _) >> { numBytes, handler ->
-            handler.completed(helper.defaultReplyHeader())
-        }
         stream.readAsync(_, _) >> { numBytes, handler ->
-            handler.completed(helper.body(response))
+            handler.completed(helper.reply(response))
         }
 
         when:
-        connection.sendAndReceiveAsync(commandMessage, callback)
+        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), callback)
         callback.get()
 
         then:
@@ -723,7 +711,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def securitySensitiveCommandName = securitySensitiveCommand.keySet().iterator().next()
         def connection = getOpenedConnection()
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', securitySensitiveCommand, true, MessageSettings.builder().build())
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', securitySensitiveCommand, true, messageSettings)
         def callback = new FutureResultCallback()
 
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
@@ -733,15 +721,12 @@ class InternalStreamConnectionSpecification extends Specification {
         stream.readAsync(16, _) >> { numBytes, handler ->
             handler.completed(helper.defaultMessageHeader(commandMessage.getId()))
         }
-        stream.readAsync(20, _) >> { numBytes, handler ->
-            handler.completed(helper.defaultReplyHeader())
-        }
-        stream.readAsync(70, _) >> { numBytes, handler ->
-            handler.completed(helper.defaultBody())
+        stream.readAsync(90, _) >> { numBytes, handler ->
+            handler.completed(helper.defaultReply())
         }
 
         when:
-        connection.sendAndReceiveAsync(commandMessage, callback)
+        connection.sendAndReceiveAsync(commandMessage, new BsonDocumentCodec(), callback)
         callback.get()
 
         then:

--- a/driver-core/src/test/unit/com/mongodb/connection/InternalStreamConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/InternalStreamConnectionSpecification.groovy
@@ -42,6 +42,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
+import static com.mongodb.ReadPreference.primary
 import static com.mongodb.connection.ConnectionDescription.getDefaultMaxMessageSize
 import static com.mongodb.connection.ConnectionDescription.getDefaultMaxWriteBatchSize
 import static com.mongodb.connection.ServerDescription.getDefaultMaxDocumentSize
@@ -405,7 +406,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, messageSettings)
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, primary(), messageSettings)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16) >> helper.defaultMessageHeader(commandMessage.getId())
         stream.read(90) >> helper.defaultReply()
@@ -425,7 +426,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, messageSettings)
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, primary(), messageSettings)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.write(_) >> { throw new MongoSocketWriteException('Failed to write', serverAddress, new IOException()) }
 
@@ -444,7 +445,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, messageSettings)
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, primary(), messageSettings)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16) >> { throw new MongoSocketReadException('Failed to read', serverAddress) }
 
@@ -463,7 +464,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, messageSettings)
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, primary(), messageSettings)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16) >> helper.defaultMessageHeader(commandMessage.getId())
         stream.read(90) >> { throw new MongoSocketReadException('Failed to read', serverAddress) }
@@ -483,7 +484,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, messageSettings)
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, primary(), messageSettings)
         def response = '{ok : 0, errmsg : "failed"}'
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16) >> helper.messageHeader(commandMessage.getId(), response)
@@ -504,7 +505,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def securitySensitiveCommandName = securitySensitiveCommand.keySet().iterator().next()
         def connection = getOpenedConnection()
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', securitySensitiveCommand, true, messageSettings)
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', securitySensitiveCommand, primary(), messageSettings)
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
         stream.read(16) >> helper.defaultMessageHeader(commandMessage.getId())
         stream.read(90) >> helper.defaultReply()
@@ -569,7 +570,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, messageSettings)
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, primary(), messageSettings)
         def callback = new FutureResultCallback()
 
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
@@ -599,7 +600,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, messageSettings)
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, primary(), messageSettings)
         def callback = new FutureResultCallback()
 
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
@@ -623,7 +624,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, messageSettings)
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, primary(), messageSettings)
         def callback = new FutureResultCallback()
 
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
@@ -650,7 +651,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, messageSettings)
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, primary(), messageSettings)
         def callback = new FutureResultCallback()
 
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }
@@ -680,7 +681,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def connection = getOpenedConnection()
         def pingCommandDocument = new BsonDocument('ping', new BsonInt32(1))
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, true, messageSettings)
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', pingCommandDocument, primary(), messageSettings)
         def callback = new FutureResultCallback()
         def response = '{ok : 0, errmsg : "failed"}'
 
@@ -711,7 +712,7 @@ class InternalStreamConnectionSpecification extends Specification {
         given:
         def securitySensitiveCommandName = securitySensitiveCommand.keySet().iterator().next()
         def connection = getOpenedConnection()
-        def commandMessage = new SimpleCommandMessage('admin.$cmd', securitySensitiveCommand, true, messageSettings)
+        def commandMessage = new SimpleCommandMessage('admin.$cmd', securitySensitiveCommand, primary(), messageSettings)
         def callback = new FutureResultCallback()
 
         stream.getBuffer(1024) >> { new ByteBufNIO(ByteBuffer.wrap(new byte[1024])) }

--- a/driver-core/src/test/unit/com/mongodb/connection/MessageHelper.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/MessageHelper.java
@@ -26,7 +26,6 @@ import org.bson.codecs.DecoderContext;
 import org.bson.codecs.EncoderContext;
 import org.bson.io.BasicOutputBuffer;
 import org.bson.io.BsonInput;
-import org.bson.io.ByteBufferBsonInput;
 import org.bson.io.OutputBuffer;
 import org.bson.json.JsonReader;
 
@@ -78,8 +77,8 @@ final class MessageHelper {
         headerByteBuffer.putInt(numDocuments); //numberReturned
         headerByteBuffer.flip();
 
-        ByteBufferBsonInput headerInputBuffer = new ByteBufferBsonInput(new ByteBufNIO(headerByteBuffer));
-        return new ReplyHeader(headerInputBuffer, new MessageHeader(headerInputBuffer, getDefaultMaxMessageSize()));
+        ByteBufNIO buffer = new ByteBufNIO(headerByteBuffer);
+        return new ReplyHeader(buffer, new MessageHeader(buffer, getDefaultMaxMessageSize()));
     }
 
     public static BsonDocument decodeCommand(final BsonInput bsonInput) {

--- a/driver-core/src/test/unit/com/mongodb/connection/ReplyMessageTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ReplyMessageTest.java
@@ -19,7 +19,6 @@ package com.mongodb.connection;
 import com.mongodb.MongoInternalException;
 import org.bson.ByteBufNIO;
 import org.bson.Document;
-import org.bson.io.ByteBufferBsonInput;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
@@ -45,8 +44,8 @@ public class ReplyMessageTest {
         headerByteBuffer.putInt(0);
         headerByteBuffer.flip();
 
-        ByteBufferBsonInput headerInputBuffer = new ByteBufferBsonInput(new ByteBufNIO(headerByteBuffer));
-        ReplyHeader replyHeader = new ReplyHeader(headerInputBuffer, new MessageHeader(headerInputBuffer, getDefaultMaxMessageSize()));
+        ByteBufNIO byteBuf = new ByteBufNIO(headerByteBuffer);
+        ReplyHeader replyHeader = new ReplyHeader(byteBuf, new MessageHeader(byteBuf, getDefaultMaxMessageSize()));
         new ReplyMessage<Document>(replyHeader, expectedResponseTo);
     }
 
@@ -66,8 +65,8 @@ public class ReplyMessageTest {
         headerByteBuffer.putInt(0);
         headerByteBuffer.flip();
 
-        ByteBufferBsonInput headerInputBuffer = new ByteBufferBsonInput(new ByteBufNIO(headerByteBuffer));
-        ReplyHeader replyHeader = new ReplyHeader(headerInputBuffer, new MessageHeader(headerInputBuffer, getDefaultMaxMessageSize()));
+        ByteBufNIO byteBuf = new ByteBufNIO(headerByteBuffer);
+        ReplyHeader replyHeader = new ReplyHeader(byteBuf, new MessageHeader(byteBuf, getDefaultMaxMessageSize()));
         new ReplyMessage<Document>(replyHeader, 5);
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/connection/StreamHelper.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/StreamHelper.groovy
@@ -18,6 +18,7 @@
 package com.mongodb.connection
 
 import com.mongodb.MongoNamespace
+import com.mongodb.ReadPreference
 import com.mongodb.async.FutureResultCallback
 import org.bson.BsonBinaryWriter
 import org.bson.BsonDocument
@@ -163,7 +164,7 @@ class StreamHelper {
     static isMaster() {
         CommandMessage command = new SimpleCommandMessage(new MongoNamespace('admin', COMMAND_COLLECTION_NAME).getFullName(),
                 new BsonDocument('ismaster', new BsonInt32(1)),
-                false, MessageSettings.builder().serverVersion(new ServerVersion(0, 0)).build())
+                ReadPreference.primary(), MessageSettings.builder().serverVersion(new ServerVersion(0, 0)).build())
         OutputBuffer outputBuffer = new BasicOutputBuffer()
         command.encode(outputBuffer)
         nextMessageId++

--- a/driver-core/src/test/unit/com/mongodb/connection/TestConnection.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/TestConnection.java
@@ -17,6 +17,7 @@
 package com.mongodb.connection;
 
 import com.mongodb.MongoNamespace;
+import com.mongodb.ReadPreference;
 import com.mongodb.WriteConcern;
 import com.mongodb.WriteConcernResult;
 import com.mongodb.async.SingleResultCallback;
@@ -169,9 +170,22 @@ class TestConnection implements Connection, AsyncConnection {
     }
 
     @Override
+    public <T> T command(final String database, final BsonDocument command, final ReadPreference readPreference,
+                         final FieldNameValidator fieldNameValidator, final Decoder<T> commandResultDecoder) {
+        return executeEnqueuedProtocol();
+    }
+
+    @Override
     public <T> void commandAsync(final String database, final BsonDocument command, final boolean slaveOk,
                                  final FieldNameValidator fieldNameValidator,
                                  final Decoder<T> commandResultDecoder, final SingleResultCallback<T> callback) {
+        executeEnqueuedProtocolAsync(callback);
+    }
+
+    @Override
+    public <T> void commandAsync(final String database, final BsonDocument command, final ReadPreference readPreference,
+                                 final FieldNameValidator fieldNameValidator, final Decoder<T> commandResultDecoder,
+                                 final SingleResultCallback<T> callback) {
         executeEnqueuedProtocolAsync(callback);
     }
 

--- a/driver-core/src/test/unit/com/mongodb/connection/TestConnectionPool.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/TestConnectionPool.java
@@ -19,6 +19,7 @@ package com.mongodb.connection;
 import com.mongodb.MongoException;
 import com.mongodb.async.SingleResultCallback;
 import org.bson.ByteBuf;
+import org.bson.codecs.Decoder;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -49,12 +50,13 @@ public class TestConnectionPool implements ConnectionPool {
             }
 
             @Override
-            public ResponseBuffers sendAndReceive(final CommandMessage message) {
+            public <T> T sendAndReceive(final CommandMessage message, final Decoder<T> decoder) {
                 throw new UnsupportedOperationException("Not implemented yet!");
             }
 
             @Override
-            public void sendAndReceiveAsync(final CommandMessage message, final SingleResultCallback<ResponseBuffers> callback) {
+            public <T> void sendAndReceiveAsync(final CommandMessage message, final Decoder<T> decoder,
+                                            final SingleResultCallback<T> callback) {
                 throw new UnsupportedOperationException("Not implemented yet!");
             }
 

--- a/driver-core/src/test/unit/com/mongodb/connection/TestInternalConnection.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/TestInternalConnection.java
@@ -192,9 +192,9 @@ class TestInternalConnection implements InternalConnection {
         headerByteBuffer.putInt(header.getNumberReturned());
         headerByteBuffer.flip();
 
-        ByteBufferBsonInput headerInputBuffer = new ByteBufferBsonInput(new ByteBufNIO(headerByteBuffer));
-        MessageHeader messageHeader = new MessageHeader(headerInputBuffer, ConnectionDescription.getDefaultMaxMessageSize());
-        return new ReplyHeader(headerInputBuffer, messageHeader);    }
+        ByteBufNIO buffer = new ByteBufNIO(headerByteBuffer);
+        MessageHeader messageHeader = new MessageHeader(buffer, ConnectionDescription.getDefaultMaxMessageSize());
+        return new ReplyHeader(buffer, messageHeader);    }
 
     @Override
     public ResponseBuffers receiveMessage(final int responseTo) {

--- a/driver-core/src/test/unit/com/mongodb/connection/TestInternalConnection.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/TestInternalConnection.java
@@ -139,21 +139,25 @@ class TestInternalConnection implements InternalConnection {
     }
 
     @Override
-    public ResponseBuffers sendAndReceive(final CommandMessage message) {
+    public <T> T sendAndReceive(final CommandMessage message, final Decoder<T> decoder) {
         ByteBufferBsonOutput bsonOutput = new ByteBufferBsonOutput(this);
         try {
             message.encode(bsonOutput);
             sendMessage(bsonOutput.getByteBuffers(), message.getId());
-            ResponseBuffers responseBuffers = receiveMessage(message.getId());
+        } finally {
+            bsonOutput.close();
+        }
+        ResponseBuffers responseBuffers = receiveMessage(message.getId());
+        try {
             boolean commandOk = isCommandOk(new BsonBinaryReader(new ByteBufferBsonInput(responseBuffers.getBodyByteBuffer())));
             responseBuffers.reset();
             if (!commandOk) {
                 throw getCommandFailureException(getResponseDocument(responseBuffers, message, new BsonDocumentCodec()),
                         description.getServerAddress());
             }
-            return responseBuffers;
+            return new ReplyMessage<T>(responseBuffers, decoder, message.getId()).getDocuments().get(0);
         } finally {
-            bsonOutput.close();
+            responseBuffers.close();
         }
     }
 
@@ -165,10 +169,11 @@ class TestInternalConnection implements InternalConnection {
     }
 
     @Override
-    public void sendAndReceiveAsync(final CommandMessage message, final SingleResultCallback<ResponseBuffers> callback) {
+    public <T> void sendAndReceiveAsync(final CommandMessage message, final Decoder<T> decoder,
+                                        final SingleResultCallback<T> callback) {
         try {
-            ResponseBuffers buffers = sendAndReceive(message);
-            callback.onResult(buffers, null);
+            T result = sendAndReceive(message, decoder);
+            callback.onResult(result, null);
         } catch (MongoException ex) {
             callback.onResult(null, ex);
         }

--- a/driver-core/src/test/unit/com/mongodb/connection/TestInternalConnectionFactory.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/TestInternalConnectionFactory.java
@@ -18,6 +18,7 @@ package com.mongodb.connection;
 
 import com.mongodb.async.SingleResultCallback;
 import org.bson.ByteBuf;
+import org.bson.codecs.Decoder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -84,12 +85,13 @@ class TestInternalConnectionFactory implements InternalConnectionFactory {
         }
 
         @Override
-        public ResponseBuffers sendAndReceive(final CommandMessage message) {
+        public <T> T sendAndReceive(final CommandMessage message, final Decoder<T> decoder) {
             return null;
         }
 
         @Override
-        public void sendAndReceiveAsync(final CommandMessage message, final SingleResultCallback<ResponseBuffers> callback) {
+        public <T> void sendAndReceiveAsync(final CommandMessage message, final Decoder<T> decoder,
+                                        final SingleResultCallback<T> callback) {
             callback.onResult(null, null);
         }
 

--- a/driver-core/src/test/unit/com/mongodb/connection/UsageTrackingConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/UsageTrackingConnectionSpecification.groovy
@@ -21,6 +21,7 @@ import com.mongodb.ServerAddress
 import com.mongodb.async.FutureResultCallback
 import org.bson.BsonDocument
 import org.bson.BsonInt32
+import org.bson.codecs.BsonDocumentCodec
 import org.junit.experimental.categories.Category
 import spock.lang.IgnoreIf
 import spock.lang.Specification
@@ -171,7 +172,7 @@ class UsageTrackingConnectionSpecification extends Specification {
 
         when:
         connection.sendAndReceive(new SimpleCommandMessage('test', new BsonDocument('ping', new BsonInt32(1)), true,
-                MessageSettings.builder().build()))
+                MessageSettings.builder().serverVersion(new ServerVersion(0, 0)).build()), new BsonDocumentCodec())
 
         then:
         connection.lastUsedAt >= openedLastUsedAt
@@ -187,7 +188,8 @@ class UsageTrackingConnectionSpecification extends Specification {
 
         when:
         connection.sendAndReceiveAsync(new SimpleCommandMessage('test', new BsonDocument('ping', new BsonInt32(1)), true,
-                MessageSettings.builder().build()), futureResultCallback)
+                MessageSettings.builder().serverVersion(new ServerVersion(0, 0)).build()),
+                new BsonDocumentCodec(), futureResultCallback)
         futureResultCallback.get(60, SECONDS)
 
         then:

--- a/driver-core/src/test/unit/com/mongodb/connection/UsageTrackingConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/UsageTrackingConnectionSpecification.groovy
@@ -26,6 +26,7 @@ import org.junit.experimental.categories.Category
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 
+import static com.mongodb.ReadPreference.primary
 import static java.util.concurrent.TimeUnit.SECONDS
 
 class UsageTrackingConnectionSpecification extends Specification {
@@ -171,7 +172,7 @@ class UsageTrackingConnectionSpecification extends Specification {
         def openedLastUsedAt = connection.lastUsedAt
 
         when:
-        connection.sendAndReceive(new SimpleCommandMessage('test', new BsonDocument('ping', new BsonInt32(1)), true,
+        connection.sendAndReceive(new SimpleCommandMessage('test', new BsonDocument('ping', new BsonInt32(1)), primary(),
                 MessageSettings.builder().serverVersion(new ServerVersion(0, 0)).build()), new BsonDocumentCodec())
 
         then:
@@ -187,7 +188,7 @@ class UsageTrackingConnectionSpecification extends Specification {
         def futureResultCallback = new FutureResultCallback<Void>()
 
         when:
-        connection.sendAndReceiveAsync(new SimpleCommandMessage('test', new BsonDocument('ping', new BsonInt32(1)), true,
+        connection.sendAndReceiveAsync(new SimpleCommandMessage('test', new BsonDocument('ping', new BsonInt32(1)), primary(),
                 MessageSettings.builder().serverVersion(new ServerVersion(0, 0)).build()),
                 new BsonDocumentCodec(), futureResultCallback)
         futureResultCallback.get(60, SECONDS)

--- a/driver-core/src/test/unit/com/mongodb/connection/WriteCommandLimitsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/WriteCommandLimitsSpecification.groovy
@@ -38,7 +38,10 @@ class WriteCommandLimitsSpecification extends Specification {
 
         def buffer = new ByteBufferBsonOutput(new SimpleBufferProvider());
         def message = new InsertCommandMessage(new MongoNamespace('test', 'test'), true, WriteConcern.ACKNOWLEDGED, null,
-                                               MessageSettings.builder().maxBatchCount(3).build(), inserts);
+                MessageSettings.builder().maxBatchCount(3)
+                        .serverVersion(new ServerVersion(3, 4))
+                        .build(),
+                inserts);
 
         when:
         message.encode(buffer)
@@ -58,7 +61,10 @@ class WriteCommandLimitsSpecification extends Specification {
 
         def buffer = new ByteBufferBsonOutput(new SimpleBufferProvider());
         def message = new InsertCommandMessage(new MongoNamespace('test', 'test'), true, WriteConcern.ACKNOWLEDGED, null,
-                                               MessageSettings.builder().maxDocumentSize(113).build(), inserts);
+                MessageSettings.builder().maxDocumentSize(113)
+                        .serverVersion(new ServerVersion(3, 4))
+                        .build(),
+                inserts);
 
         when:
         message.encode(buffer)
@@ -78,7 +84,10 @@ class WriteCommandLimitsSpecification extends Specification {
 
         def buffer = new ByteBufferBsonOutput(new SimpleBufferProvider());
         def message = new DeleteCommandMessage(new MongoNamespace('test', 'test'), true, WriteConcern.ACKNOWLEDGED,
-                                               MessageSettings.builder().maxBatchCount(3).build(), deletes);
+                MessageSettings.builder().maxBatchCount(3)
+                        .serverVersion(new ServerVersion(3, 4))
+                        .build(),
+                deletes);
 
         when:
         message.encode(buffer)
@@ -98,7 +107,10 @@ class WriteCommandLimitsSpecification extends Specification {
 
         def buffer = new ByteBufferBsonOutput(new SimpleBufferProvider());
         def message = new DeleteCommandMessage(new MongoNamespace('test', 'test'), true, WriteConcern.ACKNOWLEDGED,
-                                               MessageSettings.builder().maxDocumentSize(187).build(), deletes);
+                MessageSettings.builder().maxDocumentSize(187)
+                        .serverVersion(new ServerVersion(3, 4))
+                        .build(),
+                deletes);
 
         when:
         message.encode(buffer)
@@ -118,7 +130,10 @@ class WriteCommandLimitsSpecification extends Specification {
 
         def buffer = new ByteBufferBsonOutput(new SimpleBufferProvider());
         def message = new UpdateCommandMessage(new MongoNamespace('test', 'test'), true, WriteConcern.ACKNOWLEDGED, null,
-                                               MessageSettings.builder().maxBatchCount(3).build(), replaces);
+                MessageSettings.builder().maxBatchCount(3)
+                        .serverVersion(new ServerVersion(3, 4))
+                        .build(),
+                replaces);
 
         when:
         message.encode(buffer)
@@ -138,7 +153,10 @@ class WriteCommandLimitsSpecification extends Specification {
 
         def buffer = new ByteBufferBsonOutput(new SimpleBufferProvider());
         def message = new UpdateCommandMessage(new MongoNamespace('test', 'test'), true, WriteConcern.ACKNOWLEDGED, null,
-                                               MessageSettings.builder().maxDocumentSize(175).build(), replaces);
+                MessageSettings.builder().maxDocumentSize(175)
+                        .serverVersion(new ServerVersion(3, 4))
+                        .build(),
+                replaces);
 
         when:
         message.encode(buffer)

--- a/driver-core/src/test/unit/com/mongodb/operation/AsyncQueryBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/AsyncQueryBatchCursorSpecification.groovy
@@ -36,6 +36,7 @@ import org.bson.Document
 import org.bson.codecs.DocumentCodec
 import spock.lang.Specification
 
+import static com.mongodb.ReadPreference.primary
 import static java.util.concurrent.TimeUnit.SECONDS
 
 class AsyncQueryBatchCursorSpecification extends Specification {
@@ -97,7 +98,7 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         then:
         if (firstBatch.getCursor() != null) {
             if (serverVersion.compareTo(new ServerVersion(3, 2)) >= 0) {
-                1 * connection.commandAsync(NAMESPACE.databaseName, createKillCursorsDocument(firstBatch.cursor), false, _, _, _) >> {
+                1 * connection.commandAsync(NAMESPACE.databaseName, createKillCursorsDocument(firstBatch.cursor), primary(), _, _, _) >> {
                     it[5].onResult(null, null)
                 }
             } else {
@@ -228,7 +229,7 @@ class AsyncQueryBatchCursorSpecification extends Specification {
 
         then:
         if (serverVersion.compareTo(new ServerVersion(3, 2)) >= 0) {
-            1 * connection.commandAsync(NAMESPACE.databaseName, createKillCursorsDocument(queryResult.cursor), false, _, _, _) >> {
+            1 * connection.commandAsync(NAMESPACE.databaseName, createKillCursorsDocument(queryResult.cursor), primary(), _, _, _) >> {
                 it[5].onResult(null, null)
             }
         } else {
@@ -329,7 +330,7 @@ class AsyncQueryBatchCursorSpecification extends Specification {
             1 * connection.commandAsync(_, _, _, _, _, _) >> {
                 it[5].onResult(response, null)
             }
-            1 * connection.commandAsync(NAMESPACE.databaseName, createKillCursorsDocument(initialResult.cursor), false, _, _, _) >> {
+            1 * connection.commandAsync(NAMESPACE.databaseName, createKillCursorsDocument(initialResult.cursor), primary(), _, _, _) >> {
                 it[5].onResult(null, null)
             }
         } else {
@@ -382,7 +383,7 @@ class AsyncQueryBatchCursorSpecification extends Specification {
                 cursor.close()
                 it[5].onResult(response, null)
             }
-            1 * connectionB.commandAsync(NAMESPACE.databaseName, createKillCursorsDocument(initialResult.cursor), false, _, _, _) >> {
+            1 * connectionB.commandAsync(NAMESPACE.databaseName, createKillCursorsDocument(initialResult.cursor), primary(), _, _, _) >> {
                 it[5].onResult(null, null)
             }
         } else {

--- a/driver-core/src/test/unit/com/mongodb/operation/CommandOperationHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/CommandOperationHelperSpecification.groovy
@@ -36,6 +36,7 @@ import org.bson.BsonString
 import org.bson.codecs.Decoder
 import spock.lang.Specification
 
+import static com.mongodb.ReadPreference.primary
 import static com.mongodb.operation.CommandOperationHelper.executeWrappedCommandProtocol
 import static com.mongodb.operation.CommandOperationHelper.executeWrappedCommandProtocolAsync
 import static com.mongodb.operation.CommandOperationHelper.isNamespaceError
@@ -104,7 +105,7 @@ class CommandOperationHelperSpecification extends Specification {
                                                              new ServerAddress()), 'some value') == 'some value'
     }
 
-    def 'should set slaveOK to false when using WriteBinding'() {
+    def 'should set read preference to primary to false when using WriteBinding'() {
         given:
         def dbName = 'db'
         def command = new BsonDocument()
@@ -124,11 +125,11 @@ class CommandOperationHelperSpecification extends Specification {
 
         then:
         _ * connection.getDescription() >> connectionDescription
-        1 * connection.command(dbName, command, false, _, decoder)
+        1 * connection.command(dbName, command, primary(), _, decoder)
         1 * connection.release()
     }
 
-    def 'should use the ReadBindings readPreference to set slaveOK'() {
+    def 'should use the ReadBindings readPreference'() {
         given:
         def dbName = 'db'
         def command = new BsonDocument()
@@ -149,14 +150,14 @@ class CommandOperationHelperSpecification extends Specification {
 
         then:
         _ * connection.getDescription() >> connectionDescription
-        1 * connection.command(dbName, command, readPreference.isSlaveOk(), _, decoder)
+        1 * connection.command(dbName, command, readPreference, _, decoder)
         1 * connection.release()
 
         where:
-        readPreference << [ReadPreference.primary(), ReadPreference.secondary()]
+        readPreference << [primary(), ReadPreference.secondary()]
     }
 
-    def 'should set slaveOK to false when using AsyncWriteBinding'() {
+    def 'should set read preference to primary to false when using AsyncWriteBinding'() {
         given:
         def dbName = 'db'
         def command = new BsonDocument()
@@ -177,11 +178,11 @@ class CommandOperationHelperSpecification extends Specification {
 
         then:
         _ * connection.getDescription() >> connectionDescription
-        1 * connection.commandAsync(dbName, command, false, _, decoder, _) >> { it[5].onResult(1, null) }
+        1 * connection.commandAsync(dbName, command, primary(), _, decoder, _) >> { it[5].onResult(1, null) }
         1 * connection.release()
     }
 
-    def 'should use the AsyncReadBindings readPreference to set slaveOK'() {
+    def 'should use the AsyncReadBindings readPreference'() {
         given:
         def dbName = 'db'
         def command = new BsonDocument()
@@ -203,11 +204,11 @@ class CommandOperationHelperSpecification extends Specification {
 
         then:
         _ * connection.getDescription() >> connectionDescription
-        1 * connection.commandAsync(dbName, command, readPreference.isSlaveOk(), _, decoder, _) >> { it[5].onResult(1, null) }
+        1 * connection.commandAsync(dbName, command, readPreference, _, decoder, _) >> { it[5].onResult(1, null) }
         1 * connection.release()
 
         where:
-        readPreference << [ReadPreference.primary(), ReadPreference.secondary()]
+        readPreference << [primary(), ReadPreference.secondary()]
     }
 
 }

--- a/driver-core/src/test/unit/com/mongodb/operation/OperationUnitSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/OperationUnitSpecification.groovy
@@ -80,7 +80,7 @@ class OperationUnitSpecification extends Specification {
         if (checkCommand) {
             1 * connection.command(_, expectedCommand, _, _, _) >> { result }
         } else if (checkSlaveOk) {
-            1 * connection.command(_, _, readPreference.isSlaveOk(), _, _) >> { result }
+            1 * connection.command(_, _, readPreference, _, _) >> { result }
         }
 
         0 * connection.command(_, _, _, _, _) >> {
@@ -121,7 +121,7 @@ class OperationUnitSpecification extends Specification {
         if (checkCommand) {
             1 * connection.commandAsync(_, expectedCommand, _, _, _, _) >> { it[5].onResult(result, null) }
         } else if (checkSlaveOk) {
-            1 * connection.commandAsync(_, _, readPreference.isSlaveOk(), _, _, _) >> { it[5].onResult(result, null) }
+            1 * connection.commandAsync(_, _, readPreference, _, _, _) >> { it[5].onResult(result, null) }
         }
 
         0 * connection.commandAsync(_, _, _, _, _, _) >> {

--- a/driver/src/test/functional/com/mongodb/client/CommandMonitoringTest.java
+++ b/driver/src/test/functional/com/mongodb/client/CommandMonitoringTest.java
@@ -59,6 +59,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -306,17 +307,21 @@ public class CommandMonitoringTest {
             String eventType = curExpectedEventDocument.keySet().iterator().next();
             BsonDocument eventDescriptionDocument = curExpectedEventDocument.getDocument(eventType);
             CommandEvent commandEvent;
+            String commandName = eventDescriptionDocument.getString("command_name").getValue();
             if (eventType.equals("command_started_event")) {
-                commandEvent = new CommandStartedEvent(1, null, databaseName,
-                                                       eventDescriptionDocument.getString("command_name").getValue(),
-                                                       eventDescriptionDocument.getDocument("command"));
+                BsonDocument commandDocument = eventDescriptionDocument.getDocument("command");
+                // TODO: excluding write commands is temporary
+                if (serverVersionAtLeast(3, 5)
+                            && !Arrays.asList("insert", "update", "delete").contains(commandName)) {
+                    commandDocument.put("$db", new BsonString(databaseName));
+                }
+                commandEvent = new CommandStartedEvent(1, null, databaseName, commandName, commandDocument);
             } else if (eventType.equals("command_succeeded_event")) {
                 BsonDocument replyDocument = eventDescriptionDocument.get("reply").asDocument();
-                commandEvent = new CommandSucceededEvent(1, null, eventDescriptionDocument.getString("command_name").getValue(),
-                                                         replyDocument, 1);
+                commandEvent = new CommandSucceededEvent(1, null, commandName, replyDocument, 1);
 
             } else if (eventType.equals("command_failed_event")) {
-                commandEvent = new CommandFailedEvent(1, null, eventDescriptionDocument.getString("command_name").getValue(), 1, null);
+                commandEvent = new CommandFailedEvent(1, null, commandName, 1, null);
             } else {
                 throw new UnsupportedOperationException("Unsupported command event type: " + eventType);
             }

--- a/driver/src/test/functional/com/mongodb/client/CommandMonitoringTest.java
+++ b/driver/src/test/functional/com/mongodb/client/CommandMonitoringTest.java
@@ -310,10 +310,16 @@ public class CommandMonitoringTest {
             String commandName = eventDescriptionDocument.getString("command_name").getValue();
             if (eventType.equals("command_started_event")) {
                 BsonDocument commandDocument = eventDescriptionDocument.getDocument("command");
-                // TODO: excluding write commands is temporary
-                if (serverVersionAtLeast(3, 5)
-                            && !Arrays.asList("insert", "update", "delete").contains(commandName)) {
-                    commandDocument.put("$db", new BsonString(databaseName));
+                if (serverVersionAtLeast(3, 5)) {
+                    // TODO: excluding write commands is temporary
+                    if (!Arrays.asList("insert", "update", "delete").contains(commandName)) {
+                        commandDocument.put("$db", new BsonString(databaseName));
+                    }
+                    // TODO: not clear whether this should be included, but also not clear how to efficiently exclude it
+                    BsonDocument operation = definition.getDocument("operation");
+                    if (operation.containsKey("read_preference")) {
+                        commandDocument.put("$readPreference", operation.getDocument("read_preference"));
+                    }
                 }
                 commandEvent = new CommandStartedEvent(1, null, databaseName, commandName, commandDocument);
             } else if (eventType.equals("command_succeeded_event")) {

--- a/driver/src/test/functional/com/mongodb/client/CommandMonitoringTest.java
+++ b/driver/src/test/functional/com/mongodb/client/CommandMonitoringTest.java
@@ -22,6 +22,7 @@ import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
 import com.mongodb.client.test.CollectionHelper;
 import com.mongodb.connection.ServerVersion;
 import com.mongodb.connection.TestCommandListener;
@@ -59,7 +60,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -310,12 +310,11 @@ public class CommandMonitoringTest {
             String commandName = eventDescriptionDocument.getString("command_name").getValue();
             if (eventType.equals("command_started_event")) {
                 BsonDocument commandDocument = eventDescriptionDocument.getDocument("command");
+                // Not clear whether these global fields should be included, but also not clear how to efficiently exclude them
                 if (serverVersionAtLeast(3, 5)) {
-                    // TODO: excluding write commands is temporary
-                    if (!Arrays.asList("insert", "update", "delete").contains(commandName)) {
+                    if (!isUnacknowledgedWrite()) {
                         commandDocument.put("$db", new BsonString(databaseName));
                     }
-                    // TODO: not clear whether this should be included, but also not clear how to efficiently exclude it
                     BsonDocument operation = definition.getDocument("operation");
                     if (operation.containsKey("read_preference")) {
                         commandDocument.put("$readPreference", operation.getDocument("read_preference"));
@@ -334,6 +333,15 @@ public class CommandMonitoringTest {
             expectedEvents.add(commandEvent);
         }
         return expectedEvents;
+    }
+
+    private boolean isUnacknowledgedWrite() {
+        BsonDocument arguments = definition.getDocument("operation").getDocument("arguments");
+        if (arguments.containsKey("writeConcern")) {
+            WriteConcern writeConcern = new WriteConcern(arguments.getDocument("writeConcern").getInt32("w").intValue());
+            return !writeConcern.isAcknowledged();
+        }
+        return false;
     }
 
 


### PR DESCRIPTION
* Supports sync and async
* Supports top level and embedded in OP_COMPRESSED
* Pushes command wrapping down from operation into SimpleCommandMessage
* Uses the ElementExtendingBsonWriter

Test coverage is sufficient IMO.  There are unit tests for most of InternalStreamConnection.  The compression path is not unit tested but is well-covered in integration tests.  I could be convinced otherwise though.

The first two commits are refactoring so you may want to look at those first, and then go one by one through each commit.  Up to you.

Note: this is rebased on j2527-take-two, which is also currently under review.

Patch build [here](https://evergreen.mongodb.com/version/59945e29e3c3313b8b000607).

The failures are due to this [issue](https://jira.mongodb.org/projects/HELP/queues/issue/HELP-4792).