### PR TITLE
JAVA-2580: Remove 2.4 support

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -389,10 +389,6 @@ axes:
         display_name: "2.6"
         variables:
            VERSION: "2.6"
-      - id: "2.4"
-        display_name: "2.4"
-        variables:
-           VERSION: "2.4"
   - id: os
     display_name: OS
     values:
@@ -465,7 +461,6 @@ buildvariants:
 
 - matrix_name: "tests-jdk6"
   matrix_spec: { auth: "*", ssl: "*", jdk: "jdk6", version: "*", topology: "*", os: "*" }
-  exclude_spec: { version: "2.4", ssl: "ssl", jdk: "*", auth: "*", topology: "*", os: "*" }
   display_name: "${version} ${topology} ${auth} ${ssl} ${jdk} ${os} "
   tags: ["tests-variant"]
   tasks:

--- a/driver-async/src/examples/documentation/DocumentationSamples.java
+++ b/driver-async/src/examples/documentation/DocumentationSamples.java
@@ -37,7 +37,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.async.client.Fixture.getDefaultDatabaseName;
 import static com.mongodb.async.client.Fixture.initializeCollection;
 
@@ -69,7 +68,6 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
 
 
 public final class DocumentationSamples extends DatabaseTestCase {
@@ -846,7 +844,6 @@ public final class DocumentationSamples extends DatabaseTestCase {
 
     @Test
     public void testUpdates() throws InterruptedException, ExecutionException, TimeoutException {
-        assumeTrue(serverVersionAtLeast(2, 6));
         //Start Example 51
         final CountDownLatch insertLatch = new CountDownLatch(1);
         collection.insertMany(asList(

--- a/driver-async/src/examples/primer/UpdatePrimer.java
+++ b/driver-async/src/examples/primer/UpdatePrimer.java
@@ -23,15 +23,11 @@ import org.bson.Document;
 import com.mongodb.async.SingleResultCallback;
 import com.mongodb.client.result.UpdateResult;
 // @import: end
-import static com.mongodb.ClusterFixture.serverVersionAtLeast;
-import static org.junit.Assume.assumeTrue;
 
 public class UpdatePrimer extends PrimerTestCase {
 
     @Test
     public void updateTopLevelFields() {
-        assumeTrue(serverVersionAtLeast(2, 6));
-
         // @begin: update-top-level-fields
         db.getCollection("restaurants").updateOne(new Document("name", "Juni"),
                 new Document("$set", new Document("cuisine", "American (New)"))
@@ -78,7 +74,6 @@ public class UpdatePrimer extends PrimerTestCase {
 
     @Test
     public void updateMultipleDocuments() {
-        assumeTrue(serverVersionAtLeast(2, 6));
 
         // @begin: update-multiple-documents
         db.getCollection("restaurants").updateMany(new Document("address.zipcode", "10016").append("cuisine", "Other"),

--- a/driver-async/src/test/functional/com/mongodb/async/client/SmokeTestSpecification.groovy
+++ b/driver-async/src/test/functional/com/mongodb/async/client/SmokeTestSpecification.groovy
@@ -20,7 +20,6 @@ import com.mongodb.MongoNamespace
 import org.bson.Document
 import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.async.client.Fixture.getMongoClient
 import static com.mongodb.async.client.Fixture.isSharded
 import static com.mongodb.async.client.TestHelper.run
@@ -74,7 +73,6 @@ class SmokeTestSpecification extends FunctionalSpecification {
         run(collection.distinct('id', String).&into, []) == ['a', 'b', 'c']
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'should aggregate to collection'() {
         given:
         def mongoClient = getMongoClient()

--- a/driver-core/src/main/com/mongodb/connection/ServerDescription.java
+++ b/driver-core/src/main/com/mongodb/connection/ServerDescription.java
@@ -45,8 +45,8 @@ import static com.mongodb.connection.ServerType.UNKNOWN;
 @Immutable
 public class ServerDescription {
 
-    static final int MIN_DRIVER_WIRE_VERSION = 0;
-    static final int MAX_DRIVER_WIRE_VERSION = 3;
+    static final int MIN_DRIVER_WIRE_VERSION = 1;
+    static final int MAX_DRIVER_WIRE_VERSION = 6;
 
     private static final int DEFAULT_MAX_DOCUMENT_SIZE = 0x1000000;  // 16MB
 

--- a/driver-core/src/main/com/mongodb/operation/AggregateOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/AggregateOperation.java
@@ -54,7 +54,6 @@ import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.cursorDocumentToQueryResult;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotSix;
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionTwoDotSix;
 import static com.mongodb.operation.OperationHelper.validateReadConcernAndCollation;
 import static com.mongodb.operation.OperationHelper.withConnection;
 
@@ -328,8 +327,7 @@ public class AggregateOperation<T> implements AsyncReadOperation<AsyncBatchCurso
     }
 
     private boolean isInline(final ConnectionDescription description) {
-        return !serverIsAtLeastVersionThreeDotSix(description)
-                       && ((useCursor != null && !useCursor) || !serverIsAtLeastVersionTwoDotSix(description));
+        return !serverIsAtLeastVersionThreeDotSix(description) && ((useCursor != null && !useCursor));
     }
 
     private BsonDocument getCommand(final ConnectionDescription description) {

--- a/driver-core/src/main/com/mongodb/operation/BaseWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/BaseWriteOperation.java
@@ -48,7 +48,6 @@ import static com.mongodb.operation.OperationHelper.CallableWithConnection;
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.checkBypassDocumentValidationIsSupported;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionTwoDotSix;
 import static com.mongodb.operation.OperationHelper.withConnection;
 
 
@@ -135,7 +134,7 @@ public abstract class BaseWriteOperation implements AsyncWriteOperation<WriteCon
             public WriteConcernResult call(final Connection connection) {
                 try {
                     checkBypassDocumentValidationIsSupported(connection, bypassDocumentValidation, writeConcern);
-                    if (writeConcern.isAcknowledged() && serverIsAtLeastVersionTwoDotSix(connection.getDescription())) {
+                    if (writeConcern.isAcknowledged()) {
                         return translateBulkWriteResult(executeCommandProtocol(connection));
                     } else {
                         return executeProtocol(connection);
@@ -165,7 +164,7 @@ public abstract class BaseWriteOperation implements AsyncWriteOperation<WriteCon
                                     } else {
                                         final SingleResultCallback<WriteConcernResult> wrappedCallback =
                                                 releasingCallback(errHandlingCallback, connection);
-                                        if (writeConcern.isAcknowledged() && serverIsAtLeastVersionTwoDotSix(connection.getDescription())) {
+                                        if (writeConcern.isAcknowledged()) {
                                             executeCommandProtocolAsync(connection, new SingleResultCallback<BulkWriteResult>() {
                                                 @Override
                                                 public void onResult(final BulkWriteResult result, final Throwable t) {

--- a/driver-core/src/main/com/mongodb/operation/CreateUserOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateUserOperation.java
@@ -18,13 +18,10 @@ package com.mongodb.operation;
 
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoCredential;
-import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
-import com.mongodb.WriteConcernResult;
 import com.mongodb.async.SingleResultCallback;
 import com.mongodb.binding.AsyncWriteBinding;
 import com.mongodb.binding.WriteBinding;
-import com.mongodb.bulk.InsertRequest;
 import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.Connection;
 import com.mongodb.connection.ConnectionDescription;
@@ -38,15 +35,12 @@ import static com.mongodb.operation.OperationHelper.AsyncCallableWithConnection;
 import static com.mongodb.operation.OperationHelper.CallableWithConnection;
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionTwoDotSix;
 import static com.mongodb.operation.OperationHelper.withConnection;
-import static com.mongodb.operation.UserOperationHelper.asCollectionInsertDocument;
 import static com.mongodb.operation.UserOperationHelper.asCommandDocument;
 import static com.mongodb.operation.UserOperationHelper.translateUserCommandException;
 import static com.mongodb.operation.UserOperationHelper.userCommandCallback;
 import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.WriteConcernHelper.writeConcernErrorTransformer;
-import static java.util.Arrays.asList;
 
 /**
  * An operation to create a user.
@@ -108,15 +102,11 @@ public class CreateUserOperation implements AsyncWriteOperation<Void>, WriteOper
         return withConnection(binding, new CallableWithConnection<Void>() {
             @Override
             public Void call(final Connection connection) {
-                if (serverIsAtLeastVersionTwoDotSix(connection.getDescription())) {
-                    try {
-                        executeWrappedCommandProtocol(binding, getCredential().getSource(), getCommand(connection.getDescription()),
-                                connection, writeConcernErrorTransformer());
-                    } catch (MongoCommandException e) {
-                        translateUserCommandException(e);
-                    }
-                } else {
-                    connection.insert(getNamespace(), true, WriteConcern.ACKNOWLEDGED, asList(getInsertRequest()));
+                try {
+                    executeWrappedCommandProtocol(binding, getCredential().getSource(), getCommand(connection.getDescription()),
+                            connection, writeConcernErrorTransformer());
+                } catch (MongoCommandException e) {
+                    translateUserCommandException(e);
                 }
                 return null;
             }
@@ -133,29 +123,11 @@ public class CreateUserOperation implements AsyncWriteOperation<Void>, WriteOper
                     errHandlingCallback.onResult(null, t);
                 } else {
                     final SingleResultCallback<Void> wrappedCallback = releasingCallback(errHandlingCallback, connection);
-                    if (serverIsAtLeastVersionTwoDotSix(connection.getDescription())) {
-                        executeWrappedCommandProtocolAsync(binding, credential.getSource(), getCommand(connection.getDescription()),
-                                connection, writeConcernErrorTransformer(), userCommandCallback(wrappedCallback));
-                    } else {
-                        connection.insertAsync(getNamespace(), true, WriteConcern.ACKNOWLEDGED,
-                                               asList(getInsertRequest()), new SingleResultCallback<WriteConcernResult>() {
-                            @Override
-                            public void onResult(final WriteConcernResult result, final Throwable t) {
-                                wrappedCallback.onResult(null, t);
-                            }
-                        });
-                    }
+                    executeWrappedCommandProtocolAsync(binding, credential.getSource(), getCommand(connection.getDescription()),
+                            connection, writeConcernErrorTransformer(), userCommandCallback(wrappedCallback));
                 }
             }
         });
-    }
-
-    private InsertRequest getInsertRequest() {
-        return new InsertRequest(asCollectionInsertDocument(credential, readOnly));
-    }
-
-    private MongoNamespace getNamespace() {
-        return new MongoNamespace(credential.getSource(), "system.users");
     }
 
     private BsonDocument getCommand(final ConnectionDescription description) {

--- a/driver-core/src/main/com/mongodb/operation/OperationHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/OperationHelper.java
@@ -367,10 +367,6 @@ final class OperationHelper {
         }
     }
 
-    static boolean serverIsAtLeastVersionTwoDotSix(final ConnectionDescription description) {
-        return serverIsAtLeastVersion(description, new ServerVersion(2, 6));
-    }
-
     static boolean serverIsAtLeastVersionThreeDotZero(final ConnectionDescription description) {
         return serverIsAtLeastVersion(description, new ServerVersion(3, 0));
     }

--- a/driver-core/src/main/com/mongodb/operation/UpdateUserOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/UpdateUserOperation.java
@@ -18,14 +18,10 @@ package com.mongodb.operation;
 
 import com.mongodb.MongoCommandException;
 import com.mongodb.MongoCredential;
-import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
-import com.mongodb.WriteConcernResult;
 import com.mongodb.async.SingleResultCallback;
 import com.mongodb.binding.AsyncWriteBinding;
 import com.mongodb.binding.WriteBinding;
-import com.mongodb.bulk.UpdateRequest;
-import com.mongodb.bulk.WriteRequest;
 import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.Connection;
 import com.mongodb.connection.ConnectionDescription;
@@ -39,16 +35,12 @@ import static com.mongodb.operation.OperationHelper.AsyncCallableWithConnection;
 import static com.mongodb.operation.OperationHelper.CallableWithConnection;
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionTwoDotSix;
 import static com.mongodb.operation.OperationHelper.withConnection;
-import static com.mongodb.operation.UserOperationHelper.asCollectionQueryDocument;
-import static com.mongodb.operation.UserOperationHelper.asCollectionUpdateDocument;
 import static com.mongodb.operation.UserOperationHelper.asCommandDocument;
 import static com.mongodb.operation.UserOperationHelper.translateUserCommandException;
 import static com.mongodb.operation.UserOperationHelper.userCommandCallback;
 import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.WriteConcernHelper.writeConcernErrorTransformer;
-import static java.util.Arrays.asList;
 
 /**
  * An operation that updates a user.
@@ -110,15 +102,11 @@ public class UpdateUserOperation implements AsyncWriteOperation<Void>, WriteOper
         return withConnection(binding, new CallableWithConnection<Void>() {
             @Override
             public Void call(final Connection connection) {
-                if (serverIsAtLeastVersionTwoDotSix(connection.getDescription())) {
-                    try {
-                        executeWrappedCommandProtocol(binding, getCredential().getSource(), getCommand(connection.getDescription()),
-                                connection, writeConcernErrorTransformer());
-                    } catch (MongoCommandException e) {
-                        translateUserCommandException(e);
-                    }
-                } else {
-                    connection.update(getNamespace(), true, WriteConcern.ACKNOWLEDGED, asList(getUpdateRequest()));
+                try {
+                    executeWrappedCommandProtocol(binding, getCredential().getSource(), getCommand(connection.getDescription()),
+                            connection, writeConcernErrorTransformer());
+                } catch (MongoCommandException e) {
+                    translateUserCommandException(e);
                 }
                 return null;
             }
@@ -135,30 +123,11 @@ public class UpdateUserOperation implements AsyncWriteOperation<Void>, WriteOper
                     errHandlingCallback.onResult(null, t);
                 } else {
                     final SingleResultCallback<Void> wrappedCallback = releasingCallback(errHandlingCallback, connection);
-                    if (serverIsAtLeastVersionTwoDotSix(connection.getDescription())) {
-                        executeWrappedCommandProtocolAsync(binding, credential.getSource(), getCommand(connection.getDescription()),
-                                connection, writeConcernErrorTransformer(), userCommandCallback(wrappedCallback));
-                    } else {
-                        connection.updateAsync(getNamespace(), true, WriteConcern.ACKNOWLEDGED, asList(getUpdateRequest()),
-                                               new SingleResultCallback<WriteConcernResult>() {
-                                                   @Override
-                                                   public void onResult(final WriteConcernResult result, final Throwable t) {
-                                                       wrappedCallback.onResult(null, t);
-                                                   }
-                                               });
-                    }
+                    executeWrappedCommandProtocolAsync(binding, credential.getSource(), getCommand(connection.getDescription()),
+                            connection, writeConcernErrorTransformer(), userCommandCallback(wrappedCallback));
                 }
             }
         });
-    }
-
-    private UpdateRequest getUpdateRequest() {
-        return new UpdateRequest(asCollectionQueryDocument(credential), asCollectionUpdateDocument(credential, readOnly),
-                                 WriteRequest.Type.REPLACE);
-    }
-
-    private MongoNamespace getNamespace() {
-        return new MongoNamespace(credential.getSource(), "system.users");
     }
 
     private BsonDocument getCommand(final ConnectionDescription description) {

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -342,7 +342,7 @@ public final class ClusterFixture {
 
     public static void disableMaxTimeFailPoint() {
         assumeThat(isSharded(), is(false));
-        if (serverVersionAtLeast(2, 6) && !isSharded()) {
+        if (!isSharded()) {
             new CommandWriteOperation<BsonDocument>("admin",
                                                     new BsonDocumentWrapper<Document>(new Document("configureFailPoint",
                                                                                                    "maxTimeAlwaysTimeOut")

--- a/driver-core/src/test/functional/com/mongodb/client/model/AggregatesFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/AggregatesFunctionalSpecification.groovy
@@ -183,7 +183,6 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
                                                                      new Document('_id', false).append('acc', [false])])
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def '$out'() {
         given:
         def outCollectionName = getCollectionName() + '.out'

--- a/driver-core/src/test/functional/com/mongodb/client/model/ArrayUpdatesFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/ArrayUpdatesFunctionalSpecification.groovy
@@ -17,9 +17,7 @@ package com.mongodb.client.model
 import com.mongodb.OperationFunctionalSpecification
 import org.bson.Document
 import org.bson.conversions.Bson
-import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.client.model.Updates.addEachToSet
 import static com.mongodb.client.model.Updates.addToSet
 import static com.mongodb.client.model.Updates.combine
@@ -91,7 +89,6 @@ class ArrayUpdatesFunctionalSpecification extends OperationFunctionalSpecificati
 
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'push with each'() {
         when:
         updateOne(pushEach('x', [4, 4, 4, 5, 6], new PushOptions()))

--- a/driver-core/src/test/functional/com/mongodb/client/model/BitwiseUpdatesFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/BitwiseUpdatesFunctionalSpecification.groovy
@@ -17,9 +17,7 @@ package com.mongodb.client.model
 import com.mongodb.OperationFunctionalSpecification
 import org.bson.Document
 import org.bson.conversions.Bson
-import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.client.model.Updates.bitwiseAnd
 import static com.mongodb.client.model.Updates.bitwiseOr
 import static com.mongodb.client.model.Updates.bitwiseXor
@@ -61,7 +59,6 @@ class BitwiseUpdatesFunctionalSpecification extends OperationFunctionalSpecifica
         find() == [new Document('_id', 1).append('x', NUM | INT_MASK)]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'integer bitwiseXor'() {
         when:
         updateOne(bitwiseXor('x', INT_MASK))
@@ -78,7 +75,6 @@ class BitwiseUpdatesFunctionalSpecification extends OperationFunctionalSpecifica
         find() == [new Document('_id', 1).append('x', NUM & LONG_MASK)]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })     // a bug in the 2.4 server prevents this test from passing
     def 'long bitwiseOr'() {
         when:
         updateOne(bitwiseOr('x', LONG_MASK))
@@ -87,7 +83,6 @@ class BitwiseUpdatesFunctionalSpecification extends OperationFunctionalSpecifica
         find() == [new Document('_id', 1).append('x', NUM | LONG_MASK)]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'long bitwiseXor'() {
         when:
         updateOne(bitwiseXor('x', LONG_MASK))

--- a/driver-core/src/test/functional/com/mongodb/client/model/FiltersFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/FiltersFunctionalSpecification.groovy
@@ -85,7 +85,6 @@ class FiltersFunctionalSpecification extends OperationFunctionalSpecification {
         find(ne('x', 1)) == [b, c]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def '$not'() {
         expect:
         find(not(eq('x', 1))) == [b, c]
@@ -252,7 +251,6 @@ class FiltersFunctionalSpecification extends OperationFunctionalSpecification {
     }
 
     @SuppressWarnings('deprecated')
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'should render $text'() {
         given:
         getCollectionHelper().createIndex(new Document('y', 'text'))

--- a/driver-core/src/test/functional/com/mongodb/client/model/GeoFiltersFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/GeoFiltersFunctionalSpecification.groovy
@@ -17,9 +17,7 @@ package com.mongodb.client.model
 import com.mongodb.OperationFunctionalSpecification
 import org.bson.Document
 import org.bson.conversions.Bson
-import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.client.model.Filters.geoWithinBox
 import static com.mongodb.client.model.Filters.geoWithinCenter
 import static com.mongodb.client.model.Filters.geoWithinCenterSphere
@@ -51,25 +49,21 @@ class GeoFiltersFunctionalSpecification extends OperationFunctionalSpecification
         find(nearSphere('geo', 1.01d, 1.01d, 0.1d, 0.0d)) == [firstPoint, thirdPoint]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 4) })
     def '$geoWithin $box'() {
         expect:
         find(geoWithinBox('geo', 0d, 0d, 4d, 4d)) == [firstPoint, thirdPoint]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 4) })
     def '$geoWithin $polygon'() {
         expect:
         find(geoWithinPolygon('geo', [[0d, 0d], [0d, 4d], [4d, 4d], [4d, 0d]])) == [firstPoint, thirdPoint]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 4) })
     def '$geoWithin $center'() {
         expect:
         find(geoWithinCenter('geo', 2d, 2d, 4d)) == [firstPoint, thirdPoint]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def '$geoWithin $centerSphere'() {
         expect:
         find(geoWithinCenterSphere('geo', 2d, 2d, 4d)) == [firstPoint, secondPoint, thirdPoint]

--- a/driver-core/src/test/functional/com/mongodb/client/model/GeoJsonFiltersFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/GeoJsonFiltersFunctionalSpecification.groovy
@@ -20,9 +20,7 @@ import com.mongodb.client.model.geojson.Polygon
 import com.mongodb.client.model.geojson.Position
 import org.bson.Document
 import org.bson.conversions.Bson
-import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.client.model.Filters.geoIntersects
 import static com.mongodb.client.model.Filters.geoWithin
 import static com.mongodb.client.model.Filters.near
@@ -47,7 +45,6 @@ class GeoJsonFiltersFunctionalSpecification extends OperationFunctionalSpecifica
         getCollectionHelper().find(filter, new Document('_id', 1)) // sort by _id
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 4) })
     def '$geoWithin'() {
         given:
         def polygon = new Polygon([new Position(0d, 0d), new Position(4d, 0d), new Position(4d, 4d), new Position(0d, 4d),
@@ -57,7 +54,6 @@ class GeoJsonFiltersFunctionalSpecification extends OperationFunctionalSpecifica
         find(geoWithin('geo', polygon)) == [firstPoint, secondPoint, thirdPoint]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 4) })
     def '$geoIntersects'() {
         given:
         def polygon = new Polygon([new Position(0d, 0d), new Position(4d, 0d), new Position(4d, 4d), new Position(0d, 4d),
@@ -67,13 +63,11 @@ class GeoJsonFiltersFunctionalSpecification extends OperationFunctionalSpecifica
         find(geoIntersects('geo', polygon)) == [firstPoint, secondPoint, thirdPoint, firstPolygon]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 4) })
     def '$near'() {
         expect:
         find(near('geo', new Point(new Position(1.01d, 1.01d)), 10000d, null)) == [firstPoint]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 4) })
     def '$nearSphere'() {
         expect:
         find(nearSphere('geo', new Point(new Position(1.01d, 1.01d)), 10000d, null)) == [firstPoint]

--- a/driver-core/src/test/functional/com/mongodb/client/model/IndexesFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/IndexesFunctionalSpecification.groovy
@@ -17,9 +17,7 @@
 package com.mongodb.client.model
 
 import com.mongodb.OperationFunctionalSpecification
-import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.client.model.Indexes.ascending
 import static com.mongodb.client.model.Indexes.compoundIndex
 import static com.mongodb.client.model.Indexes.descending
@@ -108,7 +106,6 @@ class IndexesFunctionalSpecification extends OperationFunctionalSpecification {
         getCollectionHelper().listIndexes()*.get('key').contains(parse('{x : "geoHaystack", b: -1}'))
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'text'() {
         when:
         getCollectionHelper().createIndex(text('x'))
@@ -117,7 +114,6 @@ class IndexesFunctionalSpecification extends OperationFunctionalSpecification {
         getCollectionHelper().listIndexes()*.get('key').contains(parse('{_fts: "text", _ftsx: 1}'))
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 4) })
     def 'hashed'() {
         when:
         getCollectionHelper().createIndex(hashed('x'))

--- a/driver-core/src/test/functional/com/mongodb/client/model/ProjectionFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/ProjectionFunctionalSpecification.groovy
@@ -20,9 +20,7 @@ import com.mongodb.MongoQueryException
 import com.mongodb.OperationFunctionalSpecification
 import org.bson.Document
 import org.bson.conversions.Bson
-import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.client.model.Filters.and
 import static com.mongodb.client.model.Filters.eq
 import static com.mongodb.client.model.Projections.elemMatch
@@ -98,7 +96,6 @@ class ProjectionFunctionalSpecification extends OperationFunctionalSpecification
         find(slice('y', 1, 2)) == [aYSlice12]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'metaTextScore'() {
         given:
         getCollectionHelper().createIndex(new Document('y', 'text'))

--- a/driver-core/src/test/functional/com/mongodb/client/model/SortsFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/SortsFunctionalSpecification.groovy
@@ -19,9 +19,7 @@ package com.mongodb.client.model
 import com.mongodb.OperationFunctionalSpecification
 import org.bson.Document
 import org.bson.conversions.Bson
-import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.client.model.Sorts.ascending
 import static com.mongodb.client.model.Sorts.descending
 import static com.mongodb.client.model.Sorts.metaTextScore
@@ -63,7 +61,6 @@ class SortsFunctionalSpecification extends OperationFunctionalSpecification {
         find(descending('x', 'y')) == [c, a, b]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'metaTextScore'() {
         given:
         getCollectionHelper().createIndex(new Document('y', 'text'))

--- a/driver-core/src/test/functional/com/mongodb/client/model/UpdatesFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/UpdatesFunctionalSpecification.groovy
@@ -18,9 +18,7 @@ import com.mongodb.OperationFunctionalSpecification
 import org.bson.BsonTimestamp
 import org.bson.Document
 import org.bson.conversions.Bson
-import spock.lang.IgnoreIf
 
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.client.model.Updates.combine
 import static com.mongodb.client.model.Updates.currentDate
 import static com.mongodb.client.model.Updates.currentTimestamp
@@ -65,7 +63,6 @@ class UpdatesFunctionalSpecification extends OperationFunctionalSpecification {
         find() == [new Document('_id', 1).append('x', 5)]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'setOnInsert'() {
         when:
         updateOne(setOnInsert('y', 5))
@@ -116,7 +113,6 @@ class UpdatesFunctionalSpecification extends OperationFunctionalSpecification {
         find() == [new Document('_id', 1).append('x', 14.4)]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'mul'() {
         when:
         updateOne(mul('x', 5))
@@ -137,7 +133,6 @@ class UpdatesFunctionalSpecification extends OperationFunctionalSpecification {
         find() == [new Document('_id', 1).append('x', 87.5)]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'min'() {
         when:
         updateOne(min('x', -1))
@@ -146,7 +141,6 @@ class UpdatesFunctionalSpecification extends OperationFunctionalSpecification {
         find() == [new Document('_id', 1).append('x', -1)]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'max'() {
         when:
         updateOne(max('x', 5))
@@ -155,7 +149,6 @@ class UpdatesFunctionalSpecification extends OperationFunctionalSpecification {
         find() == [new Document('_id', 1).append('x', 5)]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'currentDate'() {
         when:
         updateOne(currentDate('y'))

--- a/driver-core/src/test/functional/com/mongodb/connection/QueryProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/QueryProtocolCommandEventSpecification.groovy
@@ -34,13 +34,11 @@ import org.bson.BsonInt64
 import org.bson.BsonString
 import org.bson.BsonTimestamp
 import org.bson.codecs.BsonDocumentCodec
-import spock.lang.IgnoreIf
 import spock.lang.Shared
 
 import static com.mongodb.ClusterFixture.getCredentialList
 import static com.mongodb.ClusterFixture.getPrimary
 import static com.mongodb.ClusterFixture.getSslSettings
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.connection.ProtocolTestHelper.execute
 import static org.bson.BsonDocument.parse
 
@@ -209,7 +207,6 @@ class QueryProtocolCommandEventSpecification extends OperationFunctionalSpecific
         async << [false, true]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'should deliver start and completed command events with meta operators'() {
         given:
         def documents = [new BsonDocument('_id', new BsonInt32(1)),

--- a/driver-core/src/test/functional/com/mongodb/connection/WriteCommandProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/WriteCommandProtocolCommandEventSpecification.groovy
@@ -35,18 +35,15 @@ import org.bson.BsonBoolean
 import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.BsonString
-import spock.lang.IgnoreIf
 import spock.lang.Shared
 
 import static com.mongodb.ClusterFixture.getCredentialList
 import static com.mongodb.ClusterFixture.getPrimary
 import static com.mongodb.ClusterFixture.getSslSettings
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.WriteConcern.ACKNOWLEDGED
 import static com.mongodb.connection.MessageHelper.buildSuccessfulReply
 import static com.mongodb.connection.ProtocolTestHelper.execute
 
-@IgnoreIf({ !serverVersionAtLeast(2, 6) })
 class WriteCommandProtocolCommandEventSpecification extends OperationFunctionalSpecification {
     @Shared
     InternalStreamConnection connection;

--- a/driver-core/src/test/functional/com/mongodb/connection/WriteCommandProtocolSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/WriteCommandProtocolSpecification.groovy
@@ -30,17 +30,14 @@ import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.codecs.BsonDocumentCodec
 import org.junit.experimental.categories.Category
-import spock.lang.IgnoreIf
 import spock.lang.Shared
 
 import static com.mongodb.ClusterFixture.getCredentialList
 import static com.mongodb.ClusterFixture.getPrimary
 import static com.mongodb.ClusterFixture.getSslSettings
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.WriteConcern.ACKNOWLEDGED
 import static com.mongodb.connection.ProtocolTestHelper.execute
 
-@IgnoreIf({ !serverVersionAtLeast(2, 6) })
 class WriteCommandProtocolSpecification extends OperationFunctionalSpecification {
 
     @Shared

--- a/driver-core/src/test/functional/com/mongodb/connection/WriteProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/WriteProtocolCommandEventSpecification.groovy
@@ -101,7 +101,7 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
         async << [false, true]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 4) || (serverVersionAtLeast(3, 5) && isSharded()) })
+    @IgnoreIf({ (serverVersionAtLeast(3, 5) && isSharded()) })
     def 'should deliver started and completed command events for split unacknowleded inserts'() {
         given:
         def binary = new BsonBinary(new byte[15000000])

--- a/driver-core/src/test/functional/com/mongodb/operation/AggregateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/AggregateOperationSpecification.groovy
@@ -222,7 +222,6 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         [async, useCursor] << [[true, false], useCursorOptions()].combinations()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'should allow disk usage'() {
         when:
         AggregateOperation operation = new AggregateOperation<Document>(getNamespace(), [], new DocumentCodec()).allowDiskUse(allowDiskUse)
@@ -235,7 +234,6 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         allowDiskUse << [null, true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'should allow batch size'() {
         when:
         AggregateOperation operation = new AggregateOperation<Document>(getNamespace(), [], new DocumentCodec()).batchSize(batchSize)
@@ -248,7 +246,6 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         batchSize << [null, 0, 10]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'should throw execution timeout exception from execute'() {
         given:
         def operation = new AggregateOperation<Document>(getNamespace(), [], new DocumentCodec()).maxTime(1, SECONDS)
@@ -267,7 +264,6 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'should be able to explain an empty pipeline'() {
         given:
         def operation = new AggregateOperation(getNamespace(), [], new BsonDocumentCodec())
@@ -306,9 +302,6 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         def operation = new AggregateOperation(helper.namespace, [], new BsonDocumentCodec())
 
         then:
-        testOperationSlaveOk(operation, [2, 4, 0], readPreference, async, helper.inlineResult)
-
-        then:
         testOperationSlaveOk(operation, [2, 6, 0], readPreference, async, helper.cursorResult)
 
         where:
@@ -318,9 +311,6 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
     def helper = [
             dbName: 'db',
             namespace: new MongoNamespace('db', 'coll'),
-            twoFourConnectionDescription: Stub(ConnectionDescription) {
-                getServerVersion() >> new ServerVersion([2, 4, 0])
-            },
             twoSixConnectionDescription : Stub(ConnectionDescription) {
                 getServerVersion() >> new ServerVersion([2, 6, 0])
             },

--- a/driver-core/src/test/functional/com/mongodb/operation/AggregateToCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/AggregateToCollectionOperationSpecification.groovy
@@ -108,7 +108,6 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
         thrown(IllegalArgumentException)
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'should be able to output to a collection'() {
         when:
         AggregateToCollectionOperation operation =
@@ -123,7 +122,6 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'should be able to match then output to a collection'() {
         when:
         AggregateToCollectionOperation operation =
@@ -139,7 +137,6 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'should throw execution timeout exception from execute'() {
         given:
         AggregateToCollectionOperation operation =

--- a/driver-core/src/test/functional/com/mongodb/operation/CommandOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/CommandOperationSpecification.groovy
@@ -33,7 +33,6 @@ import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isSharded
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
 
 class CommandOperationSpecification extends OperationFunctionalSpecification {
 
@@ -110,7 +109,7 @@ class CommandOperationSpecification extends OperationFunctionalSpecification {
         result.containsKey('value')
     }
 
-    @IgnoreIf({ isSharded() || !serverVersionAtLeast(2, 6) })
+    @IgnoreIf({ isSharded() })
     def 'should throw execution timeout exception from execute'() {
         given:
         def commandOperation = new CommandReadOperation<BsonDocument>(getNamespace().databaseName,
@@ -130,7 +129,7 @@ class CommandOperationSpecification extends OperationFunctionalSpecification {
     }
 
     @Category(Async)
-    @IgnoreIf({ isSharded() || !serverVersionAtLeast(2, 6) })
+    @IgnoreIf({ isSharded() })
     def 'should throw execution timeout exception from executeAsync'() {
         given:
         def commandOperation = new CommandReadOperation<BsonDocument>(getNamespace().databaseName,

--- a/driver-core/src/test/functional/com/mongodb/operation/CreateIndexesOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/CreateIndexesOperationSpecification.groovy
@@ -18,7 +18,6 @@ package com.mongodb.operation
 
 import com.mongodb.DuplicateKeyException
 import com.mongodb.MongoCommandException
-import com.mongodb.MongoException
 import com.mongodb.MongoWriteConcernException
 import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.WriteConcern
@@ -89,7 +88,6 @@ class CreateIndexesOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'should be able to create multiple indexes'() {
         given:
         def keysForFirstIndex = new BsonDocument('field', new BsonInt32(1))
@@ -102,24 +100,6 @@ class CreateIndexesOperationSpecification extends OperationFunctionalSpecificati
 
         then:
         getUserCreatedIndexes('key') == [field1Index, field2Index]
-
-        where:
-        async << [true, false]
-    }
-
-    @IgnoreIf({ serverVersionAtLeast(2, 6) })
-    def 'should fail to create multiple indexes with server that does not support createIndexesCommand'() {
-        given:
-        def keysForFirstIndex = new BsonDocument('field', new BsonInt32(1))
-        def keysForSecondIndex = new BsonDocument('field2', new BsonInt32(1))
-        def operation = new CreateIndexesOperation(getNamespace(), [new IndexRequest(keysForFirstIndex),
-                                                                    new IndexRequest(keysForSecondIndex)])
-
-        when:
-        execute(operation, async)
-
-        then:
-        thrown(MongoException)
 
         where:
         async << [true, false]
@@ -173,7 +153,6 @@ class CreateIndexesOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'should throw when trying to build an invalid index'() {
         given:
         def operation = new CreateIndexesOperation(getNamespace(), [new IndexRequest(new BsonDocument())])
@@ -304,7 +283,6 @@ class CreateIndexesOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 4) })
     def 'should be able to create a 2dSphereIndex'() {
         given:
         def operation = new CreateIndexesOperation(getNamespace(),
@@ -315,13 +293,11 @@ class CreateIndexesOperationSpecification extends OperationFunctionalSpecificati
 
         then:
         getUserCreatedIndexes('key') == [['field' :'2dsphere']]
-        if (serverVersionAtLeast(2, 6)) { getUserCreatedIndexes('2dsphereIndexVersion') == [2] }
 
         where:
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'should be able to create a 2dSphereIndex with version 1'() {
         given:
         def operation = new CreateIndexesOperation(getNamespace(),
@@ -338,7 +314,6 @@ class CreateIndexesOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'should be able to create a textIndex'() {
         given:
         def operation = new CreateIndexesOperation(getNamespace(),
@@ -360,7 +335,6 @@ class CreateIndexesOperationSpecification extends OperationFunctionalSpecificati
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'should be able to create a textIndexVersion'() {
         given:
         def operation = new CreateIndexesOperation(getNamespace(),
@@ -371,13 +345,11 @@ class CreateIndexesOperationSpecification extends OperationFunctionalSpecificati
 
         then:
         getUserCreatedIndexes().size() == 1
-        if (serverVersionAtLeast(2, 6)) { getUserCreatedIndexes('textIndexVersion') == [2] }
 
         where:
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'should be able to create a textIndexVersion with version 1'() {
         given:
         def operation = new CreateIndexesOperation(getNamespace(),

--- a/driver-core/src/test/functional/com/mongodb/operation/DistinctOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/DistinctOperationSpecification.groovy
@@ -171,7 +171,6 @@ class DistinctOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     def 'should throw execution timeout exception from execute'() {
         given:
         def operation = new DistinctOperation(getNamespace(), 'name', stringDecoder).maxTime(1, SECONDS)

--- a/driver-core/src/test/functional/com/mongodb/operation/FindOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/FindOperationSpecification.groovy
@@ -323,7 +323,7 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
-    @IgnoreIf({ isSharded() || !serverVersionAtLeast(2, 6) })
+    @IgnoreIf({ isSharded() })
     def 'should throw execution timeout exception from execute'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document())

--- a/driver-core/src/test/functional/com/mongodb/operation/ListCollectionsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ListCollectionsOperationSpecification.groovy
@@ -335,7 +335,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
         cursor.getBatchSize() == 2
     }
 
-    @IgnoreIf({ isSharded() || !serverVersionAtLeast(2, 6) })
+    @IgnoreIf({ isSharded() })
     def 'should throw execution timeout exception from execute'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document())
@@ -354,7 +354,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
     }
 
     @Category(Async)
-    @IgnoreIf({ isSharded() || !serverVersionAtLeast(2, 6) })
+    @IgnoreIf({ isSharded() })
     def 'should throw execution timeout exception from executeAsync'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document())

--- a/driver-core/src/test/functional/com/mongodb/operation/ListDatabasesOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ListDatabasesOperationSpecification.groovy
@@ -41,7 +41,6 @@ import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isSharded
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
 class ListDatabasesOperationSpecification extends OperationFunctionalSpecification {
@@ -76,7 +75,7 @@ class ListDatabasesOperationSpecification extends OperationFunctionalSpecificati
         names.contains(getDatabaseName())
     }
 
-    @IgnoreIf({ isSharded() || !serverVersionAtLeast(2, 6) })
+    @IgnoreIf({ isSharded() })
     def 'should throw execution timeout exception from execute'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document())
@@ -95,7 +94,7 @@ class ListDatabasesOperationSpecification extends OperationFunctionalSpecificati
     }
 
     @Category(Async)
-    @IgnoreIf({ isSharded() || !serverVersionAtLeast(2, 6) })
+    @IgnoreIf({ isSharded() })
     def 'should throw execution timeout exception from executeAsync'() {
         given:
         getCollectionHelper().insertDocuments(new DocumentCodec(), new Document())

--- a/driver-core/src/test/functional/com/mongodb/operation/ListIndexesOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ListIndexesOperationSpecification.groovy
@@ -52,7 +52,6 @@ import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isSharded
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
 class ListIndexesOperationSpecification extends OperationFunctionalSpecification {
@@ -210,7 +209,7 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
         cursor.getBatchSize() == 2
     }
 
-    @IgnoreIf({ isSharded() || !serverVersionAtLeast(2, 6) })
+    @IgnoreIf({ isSharded() })
     def 'should throw execution timeout exception from execute'() {
         given:
         def operation = new ListIndexesOperation(getNamespace(), new DocumentCodec()).maxTime(1000, MILLISECONDS)
@@ -229,7 +228,7 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
     }
 
     @Category(Async)
-    @IgnoreIf({ isSharded() || !serverVersionAtLeast(2, 6) })
+    @IgnoreIf({ isSharded() })
     def 'should throw execution timeout exception from executeAsync'() {
         given:
         def operation = new ListIndexesOperation(getNamespace(), new DocumentCodec()).maxTime(1000, MILLISECONDS)

--- a/driver-core/src/test/functional/com/mongodb/operation/MixedBulkWriteOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/MixedBulkWriteOperationSpecification.groovy
@@ -903,6 +903,6 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
     }
 
     private static Integer expectedModifiedCount(final int expectedCountForServersThatSupportIt) {
-        (serverVersionAtLeast(2, 6)) ? expectedCountForServersThatSupportIt : null
+        expectedCountForServersThatSupportIt
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/operation/ParallelCollectionScanOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ParallelCollectionScanOperationSpecification.groovy
@@ -48,10 +48,9 @@ import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.ClusterFixture.loopCursor
-import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static org.junit.Assert.assertTrue
 
-@IgnoreIf({ isSharded() || !serverVersionAtLeast(2, 6) })
+@IgnoreIf({ isSharded() })
 @Category(Slow)
 class ParallelCollectionScanOperationSpecification extends OperationFunctionalSpecification {
     Map<Integer, Boolean> ids = [] as ConcurrentHashMap

--- a/driver-core/src/test/functional/com/mongodb/operation/UpdateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/UpdateOperationSpecification.groovy
@@ -131,7 +131,7 @@ class UpdateOperationSpecification extends OperationFunctionalSpecification {
         then:
         result.wasAcknowledged()
         result.count == 1
-        result.upsertedId == (serverVersionAtLeast(2, 6) ? new BsonInt32(1) : null)
+        result.upsertedId == new BsonInt32(1)
         !result.isUpdateOfExisting()
         getCollectionHelper().count(new Document('y', 2)) == 1
 
@@ -139,7 +139,6 @@ class UpdateOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
     @Category(Slow)
     def 'should allow update larger than 16MB'() {
         // small enough so the update document is 16MB, but enough to push the the request as a whole over 16MB

--- a/driver-core/src/test/functional/com/mongodb/operation/UserOperationsSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/UserOperationsSpecification.groovy
@@ -366,14 +366,6 @@ class UserOperationsSpecification extends OperationFunctionalSpecification {
         operation.execute(readBinding)
 
         then:
-        _ * connection.getDescription() >> helper.twoFourConnectionDescription
-        1 * connection.query(_, _, _, _, _, _, readPreference.isSlaveOk(), _, _, _, _, _, _) >>  helper.queryResult
-        1 * connection.release()
-
-        when: '2.6.0'
-        operation.execute(readBinding)
-
-        then:
         _ * connection.getDescription() >> helper.twoSixConnectionDescription
         1 * connection.command(helper.dbName, _, readPreference.isSlaveOk(), _, _) >> helper.cursorResult
 
@@ -397,14 +389,6 @@ class UserOperationsSpecification extends OperationFunctionalSpecification {
         operation.executeAsync(readBinding, Stub(SingleResultCallback))
 
         then:
-        _ * connection.getDescription() >> helper.twoFourConnectionDescription
-        1 * connection.queryAsync(_, _, _, _, _, _, readPreference.isSlaveOk(), _, _, _, _, _, _, _) >> {
-            it[13].onResult(helper.queryResult, null) }
-
-        when: '2.6.0'
-        operation.executeAsync(readBinding, Stub(SingleResultCallback))
-
-        then:
         _ * connection.getDescription() >> helper.twoSixConnectionDescription
         1 * connection.commandAsync(helper.dbName, _, readPreference.isSlaveOk(), _, _, _) >> {
             it[5].onResult(helper.cursorResult, null) }
@@ -416,9 +400,6 @@ class UserOperationsSpecification extends OperationFunctionalSpecification {
     def helper = [
             dbName: 'db',
             namespace: new MongoNamespace('db', 'coll'),
-            twoFourConnectionDescription: Stub(ConnectionDescription) {
-                getServerVersion() >> new ServerVersion([2, 4, 0])
-            },
             twoSixConnectionDescription : Stub(ConnectionDescription) {
                 getServerVersion() >> new ServerVersion([2, 6, 0])
             },

--- a/driver-core/src/test/unit/com/mongodb/connection/MultiServerClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/MultiServerClusterSpecification.groovy
@@ -475,6 +475,7 @@ class MultiServerClusterSpecification extends Specification {
                 .setName('test')
                 .canonicalAddress(firstServer.toString())
                 .setVersion(1)
+                .maxWireVersion(1)
                 .build()
 
         when:

--- a/driver-core/src/test/unit/com/mongodb/connection/TestClusterableServerFactory.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/TestClusterableServerFactory.java
@@ -143,6 +143,7 @@ public class TestClusterableServerFactory implements ClusterableServerFactory {
                                 .passives(passivesSet)
                                 .setName(setName)
                                 .electionId(electionId)
+                                .maxWireVersion(1)
                                 .setVersion(1);
     }
 }

--- a/driver/src/examples/documentation/DocumentationSamples.java
+++ b/driver/src/examples/documentation/DocumentationSamples.java
@@ -30,7 +30,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
-import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.Fixture.getDefaultDatabaseName;
 import static com.mongodb.Fixture.getMongoClient;
 
@@ -62,7 +61,6 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
 
 
 public final class DocumentationSamples extends DatabaseTestCase {
@@ -510,7 +508,6 @@ public final class DocumentationSamples extends DatabaseTestCase {
 
     @Test
     public void testUpdates() {
-        assumeTrue(serverVersionAtLeast(2, 6));
         //Start Example 51
         collection.insertMany(asList(
                 Document.parse("{ item: 'canvas', qty: 100, size: { h: 28, w: 35.5, uom: 'cm' }, status: 'A' }"),

--- a/driver/src/examples/primer/UpdatePrimer.java
+++ b/driver/src/examples/primer/UpdatePrimer.java
@@ -23,16 +23,11 @@ import org.bson.Document;
 import static java.util.Arrays.asList;
 // @import: end
 
-import static com.mongodb.ClusterFixture.serverVersionAtLeast;
-import static org.junit.Assume.assumeTrue;
-
 
 public class UpdatePrimer extends PrimerTestCase {
 
     @Test
     public void updateTopLevelFields() {
-        assumeTrue(serverVersionAtLeast(2, 6));
-
         // @begin: update-top-level-fields
         // @code: start
         db.getCollection("restaurants").updateOne(new Document("name", "Juni"),
@@ -69,8 +64,6 @@ public class UpdatePrimer extends PrimerTestCase {
 
     @Test
     public void updateMultipleDocuments() {
-        assumeTrue(serverVersionAtLeast(2, 6));
-
         // @begin: update-multiple-documents
         // @code: start
         db.getCollection("restaurants").updateMany(new Document("address.zipcode", "10016").append("cuisine", "Other"),
@@ -89,8 +82,6 @@ public class UpdatePrimer extends PrimerTestCase {
 
     @Test
     public void replaceDocument() {
-        assumeTrue(serverVersionAtLeast(2, 6));
-
         // @begin: replace-document
         // @code: start
         db.getCollection("restaurants").replaceOne(new Document("restaurant_id", "41704620"),

--- a/driver/src/test/functional/com/mongodb/DBCollectionAggregationTest.java
+++ b/driver/src/test/functional/com/mongodb/DBCollectionAggregationTest.java
@@ -81,8 +81,6 @@ public class DBCollectionAggregationTest extends DatabaseTestCase {
 
     @Test
     public void testAggregationCursor() {
-        assumeTrue(serverVersionAtLeast(2, 6));
-
         List<DBObject> pipeline = prepareData();
 
         verify(pipeline, AggregationOptions.builder()
@@ -105,7 +103,6 @@ public class DBCollectionAggregationTest extends DatabaseTestCase {
 
     @Test
     public void testInlineAndDollarOut() {
-        assumeTrue(serverVersionAtLeast(2, 6));
         String aggCollection = "aggCollection";
         database.getCollection(aggCollection)
             .drop();
@@ -124,7 +121,6 @@ public class DBCollectionAggregationTest extends DatabaseTestCase {
 
     @Test
     public void testDollarOut() {
-        assumeTrue(serverVersionAtLeast(2, 6));
         String aggCollection = "aggCollection";
         database.getCollection(aggCollection)
             .drop();
@@ -142,7 +138,6 @@ public class DBCollectionAggregationTest extends DatabaseTestCase {
 
     @Test
     public void testDollarOutOnSecondary() throws UnknownHostException, InterruptedException {
-        assumeTrue(serverVersionAtLeast(2, 6));
         assumeTrue(clusterIsType(REPLICA_SET));
 
         List<DBObject> pipeline = new ArrayList<DBObject>(prepareData());
@@ -174,7 +169,6 @@ public class DBCollectionAggregationTest extends DatabaseTestCase {
 
     @Test
     public void testOldAggregationWithOut() {
-        assumeTrue(serverVersionAtLeast(2, 6));
         collection.drop();
         List<DBObject> pipeline = new ArrayList<DBObject>(prepareData());
         pipeline.add(new BasicDBObject("$out", "aggCollection"));
@@ -188,7 +182,6 @@ public class DBCollectionAggregationTest extends DatabaseTestCase {
 
     @Test
     public void testOldAggregationWithOutOnSecondary() throws UnknownHostException, InterruptedException {
-        assumeTrue(serverVersionAtLeast(2, 6));
         collection.drop();
         List<DBObject> pipeline = new ArrayList<DBObject>(prepareData());
         pipeline.add(new BasicDBObject("$out", "aggCollection"));
@@ -202,7 +195,6 @@ public class DBCollectionAggregationTest extends DatabaseTestCase {
 
     @Test
     public void testExplain() {
-        assumeTrue(serverVersionAtLeast(2, 6));
         List<DBObject> pipeline = new ArrayList<DBObject>(prepareData());
         pipeline.add(new BasicDBObject("$out", "aggCollection"));
         CommandResult out = collection.explainAggregate(pipeline, AggregationOptions.builder()
@@ -222,7 +214,6 @@ public class DBCollectionAggregationTest extends DatabaseTestCase {
     @Test
     public void testMaxTime() {
         assumeThat(isSharded(), is(false));
-        assumeTrue(serverVersionAtLeast(2, 6));
         enableMaxTimeFailPoint();
         DBCollection collection = database.getCollection("testMaxTime");
         try {

--- a/driver/src/test/functional/com/mongodb/DBCollectionTest.java
+++ b/driver/src/test/functional/com/mongodb/DBCollectionTest.java
@@ -244,7 +244,6 @@ public class DBCollectionTest extends DatabaseTestCase {
 
     @Test(expected = MongoCommandException.class)
     public void testCreateIndexWithInvalidIndexType() {
-        assumeThat(serverVersionAtLeast(2, 6), is(true));
         DBObject index = new BasicDBObject("x", "funny");
         collection.createIndex(index);
     }
@@ -317,7 +316,6 @@ public class DBCollectionTest extends DatabaseTestCase {
 
     @Test
     public void testCreateIndexAsText() {
-        assumeThat(serverVersionAtLeast(2, 6), is(true));
         DBObject index = new BasicDBObject("x", "text");
         collection.createIndex(index);
 
@@ -445,7 +443,6 @@ public class DBCollectionTest extends DatabaseTestCase {
     @Test(expected = MongoExecutionTimeoutException.class)
     public void testFindAndUpdateTimeout() {
         assumeThat(ClusterFixture.isAuthenticated(), is(false));
-        assumeThat(serverVersionAtLeast(2, 6), is(true));
         collection.insert(new BasicDBObject("_id", 1));
         enableMaxTimeFailPoint();
         try {
@@ -459,7 +456,6 @@ public class DBCollectionTest extends DatabaseTestCase {
     @Test(expected = MongoExecutionTimeoutException.class)
     public void testFindAndReplaceTimeout() {
         assumeThat(isSharded(), is(false));
-        assumeThat(serverVersionAtLeast(2, 6), is(true));
         collection.insert(new BasicDBObject("_id", 1));
         enableMaxTimeFailPoint();
         try {
@@ -473,7 +469,6 @@ public class DBCollectionTest extends DatabaseTestCase {
     @Test(expected = MongoExecutionTimeoutException.class)
     public void testFindAndRemoveTimeout() {
         assumeThat(isSharded(), is(false));
-        assumeThat(serverVersionAtLeast(2, 6), is(true));
         collection.insert(new BasicDBObject("_id", 1));
         enableMaxTimeFailPoint();
         try {
@@ -975,7 +970,6 @@ public class DBCollectionTest extends DatabaseTestCase {
     @Category(Slow.class)
     public void testParallelScan() throws UnknownHostException {
         assumeThat(isSharded(), is(false));
-        assumeThat(serverVersionAtLeast(2, 6), is(true));
 
         Set<Integer> ids = new HashSet<Integer>();
         List<BasicDBObject> documents = new ArrayList<BasicDBObject>(2000);
@@ -1356,8 +1350,6 @@ public class DBCollectionTest extends DatabaseTestCase {
     @Test
     @SuppressWarnings("deprecation")
     public void testBypassDocumentValidationForAggregateDollarOut() {
-        assumeThat(serverVersionAtLeast(2, 6), is(true));
-
         //given
         DBObject options = new BasicDBObject("validator", QueryBuilder.start("level").greaterThanEquals(10).get());
         DBCollection cOut = database.createCollection(collectionName + ".out", options);

--- a/driver/src/test/functional/com/mongodb/DBCursorFunctionalSpecification.groovy
+++ b/driver/src/test/functional/com/mongodb/DBCursorFunctionalSpecification.groovy
@@ -69,7 +69,7 @@ class DBCursorFunctionalSpecification extends FunctionalSpecification {
     }
 
     @IgnoreIf({ !serverVersionAtLeast(3, 0) })
-    def 'should use provided hints for queries mongod > 2.7'() {
+    def 'should use provided hints for queries mongod > 3.0'() {
         given:
         collection.createIndex(new BasicDBObject('a', 1))
 
@@ -152,24 +152,15 @@ class DBCursorFunctionalSpecification extends FunctionalSpecification {
         collection.createIndex(new BasicDBObject('x', 1), new BasicDBObject('sparse', true));
 
         then:
-        collection.find(new BasicDBObject('a', 1)).hint('x_1').count() == (serverVersionAtLeast(2, 6) ? 0 : 1)
+        collection.find(new BasicDBObject('a', 1)).hint('x_1').count() == 0
         collection.find().hint('a_1').count() == 2
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(2, 6) })
-    def 'should throw with bad hint with mongod 2.6+'() {
+    def 'should throw with bad hint'() {
         when:
         collection.find(new BasicDBObject('a', 1)).hint('BAD HINT').count()
         then:
         thrown(MongoException)
-    }
-
-    @IgnoreIf({ serverVersionAtLeast(2, 6) })
-    def 'should ignore bad hints with mongod < 2.6'() {
-        when:
-        collection.find(new BasicDBObject('a', 1)).hint('BAD HINT').count()
-        then:
-        notThrown(MongoException)
     }
 
     def 'should be able to use addSpecial with count'() {
@@ -190,7 +181,7 @@ class DBCursorFunctionalSpecification extends FunctionalSpecification {
         def countWithHint = collection.find(new BasicDBObject('a', 1)).addSpecial('$hint', 'x_1').count()
 
         then:
-        countWithHint == (serverVersionAtLeast(2, 6) ? 0 : 1)
+        countWithHint == 0
     }
 
     @IgnoreIf({ serverVersionAtLeast(3, 0) })

--- a/driver/src/test/functional/com/mongodb/DBCursorTest.java
+++ b/driver/src/test/functional/com/mongodb/DBCursorTest.java
@@ -454,7 +454,6 @@ public class DBCursorTest extends DatabaseTestCase {
 
     @Test
     public void testMaxTimeForIterator() {
-        assumeThat(serverVersionAtLeast(2, 6), is(true));
         enableMaxTimeFailPoint();
         DBCursor cursor = new DBCursor(collection, new BasicDBObject("x", 1), new BasicDBObject(), ReadPreference.primary());
         cursor.maxTime(1, TimeUnit.SECONDS);
@@ -471,7 +470,6 @@ public class DBCursorTest extends DatabaseTestCase {
     @Test
     public void testMaxTimeForIterable() {
         assumeThat(isSharded(), is(false));
-        assumeThat(serverVersionAtLeast(2, 6), is(true));
         enableMaxTimeFailPoint();
         DBCursor cursor = new DBCursor(collection, new BasicDBObject("x", 1), new BasicDBObject(), ReadPreference.primary());
         cursor.maxTime(1, TimeUnit.SECONDS);
@@ -488,7 +486,6 @@ public class DBCursorTest extends DatabaseTestCase {
     @Test
     public void testMaxTimeForOne() {
         assumeThat(isSharded(), is(false));
-        assumeThat(serverVersionAtLeast(2, 6), is(true));
         enableMaxTimeFailPoint();
         DBCursor cursor = new DBCursor(collection, new BasicDBObject("x", 1), new BasicDBObject(), ReadPreference.primary());
         cursor.maxTime(1, TimeUnit.SECONDS);
@@ -505,7 +502,6 @@ public class DBCursorTest extends DatabaseTestCase {
     @Test
     public void testMaxTimeForCount() {
         assumeThat(isSharded(), is(false));
-        assumeThat(serverVersionAtLeast(2, 6), is(true));
         enableMaxTimeFailPoint();
         DBCursor cursor = new DBCursor(collection, new BasicDBObject("x", 1), new BasicDBObject(), ReadPreference.primary());
         cursor.maxTime(1, TimeUnit.SECONDS);
@@ -522,7 +518,6 @@ public class DBCursorTest extends DatabaseTestCase {
     @Test
     public void testMaxTimeForSize() {
         assumeThat(isSharded(), is(false));
-        assumeThat(serverVersionAtLeast(2, 6), is(true));
         enableMaxTimeFailPoint();
         DBCursor cursor = new DBCursor(collection, new BasicDBObject("x", 1), new BasicDBObject(), ReadPreference.primary());
         cursor.maxTime(1, TimeUnit.SECONDS);

--- a/driver/src/test/functional/com/mongodb/DBTest.java
+++ b/driver/src/test/functional/com/mongodb/DBTest.java
@@ -283,7 +283,6 @@ public class DBTest extends DatabaseTestCase {
     @Test(expected = MongoExecutionTimeoutException.class)
     public void shouldTimeOutCommand() {
         assumeThat(isSharded(), is(false));
-        assumeTrue(serverVersionAtLeast(2, 6));
         enableMaxTimeFailPoint();
         try {
             database.command(new BasicDBObject("isMaster", 1).append("maxTimeMS", 1));

--- a/driver/src/test/functional/com/mongodb/MapReduceTest.java
+++ b/driver/src/test/functional/com/mongodb/MapReduceTest.java
@@ -88,7 +88,6 @@ public class MapReduceTest extends DatabaseTestCase {
     @Test(expected = MongoExecutionTimeoutException.class)
     public void testMapReduceExecutionTimeout() {
         assumeThat(isSharded(), is(false));
-        assumeThat(serverVersionAtLeast(2, 6), is(true));
         enableMaxTimeFailPoint();
         try {
             MapReduceCommand command = new MapReduceCommand(collection,

--- a/driver/src/test/functional/com/mongodb/QueryBuilderTest.java
+++ b/driver/src/test/functional/com/mongodb/QueryBuilderTest.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.regex.Pattern;
 
-import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -323,10 +322,6 @@ public class QueryBuilderTest extends DatabaseTestCase {
 
     @Test
     public void textTest() {
-        if (!serverVersionAtLeast(2, 6)) {
-            return;
-        }
-
         BasicDBObject enableTextCommand = new BasicDBObject("setParameter", 1).append("textSearchEnabled", true);
         database.getSisterDB("admin").command(enableTextCommand);
         DBCollection collection = database.getCollection("text-test");

--- a/driver/src/test/functional/com/mongodb/client/CommandMonitoringTest.java
+++ b/driver/src/test/functional/com/mongodb/client/CommandMonitoringTest.java
@@ -66,7 +66,6 @@ import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
 import static com.mongodb.ClusterFixture.isSharded;
-import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.Fixture.getMongoClientURI;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -175,9 +174,6 @@ public class CommandMonitoringTest {
 
     @Test
     public void shouldPassAllOutcomes() {
-        // On server <= 2.4, insertMany generates an insert command for every document, so the test fails
-        assumeFalse(filename.startsWith("insertMany") && !serverVersionAtLeast(2, 6));
-
         executeOperation();
 
         List<CommandEvent> expectedEvents = getExpectedEvents(definition.getArray("expectations"));

--- a/driver/src/test/functional/com/mongodb/client/JsonPoweredCrudTestHelper.java
+++ b/driver/src/test/functional/com/mongodb/client/JsonPoweredCrudTestHelper.java
@@ -43,7 +43,6 @@ import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.BsonNull;
 import org.bson.BsonValue;
-import org.junit.Assume;
 import org.junit.AssumptionViolatedException;
 
 import java.lang.reflect.InvocationTargetException;
@@ -51,8 +50,6 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
-import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 
 public class JsonPoweredCrudTestHelper {
     private final String description;
@@ -124,10 +121,6 @@ public class JsonPoweredCrudTestHelper {
     }
 
     BsonDocument getAggregateResult(final BsonDocument arguments) {
-        if (!serverVersionAtLeast(2, 6)) {
-            Assume.assumeFalse(description.contains("$out"));
-        }
-
         List<BsonDocument> pipeline = new ArrayList<BsonDocument>();
         for (BsonValue stage : arguments.getArray("pipeline")) {
             pipeline.add(stage.asDocument());
@@ -226,9 +219,6 @@ public class JsonPoweredCrudTestHelper {
     }
 
     BsonDocument getFindOneAndReplaceResult(final BsonDocument arguments) {
-        // in 2.4 the server can ignore the supplied _id and creates an ObjectID
-        Assume.assumeTrue(serverVersionAtLeast(2, 6));
-
         FindOneAndReplaceOptions options = new FindOneAndReplaceOptions();
         if (arguments.containsKey("projection")) {
             options.projection(arguments.getDocument("projection"));

--- a/driver/src/test/functional/com/mongodb/client/MongoCollectionTest.java
+++ b/driver/src/test/functional/com/mongodb/client/MongoCollectionTest.java
@@ -33,14 +33,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static java.util.Arrays.asList;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assume.assumeTrue;
 
 public class MongoCollectionTest extends DatabaseTestCase {
 
@@ -143,8 +141,6 @@ public class MongoCollectionTest extends DatabaseTestCase {
 
     @Test
     public void testAggregationToACollection() {
-        assumeTrue(serverVersionAtLeast(2, 6));
-
         // given
         List<Document> documents = asList(new Document("_id", 1), new Document("_id", 2));
 


### PR DESCRIPTION
Nice to remove some of the cruft and shrink the Evergreen matrix.  Maybe this will make retryable writes a bit simpler in MixedBulkWriteOperation.