### PR TITLE
JAVA-2527

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/InternalStreamConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/InternalStreamConnection.java
@@ -249,7 +249,6 @@ class InternalStreamConnection implements InternalConnection {
             sendCommandMessage(message, commandEventSender, bsonOutput);
             return receiveCommandMessageResponse(message, decoder, commandEventSender);
         } catch (RuntimeException e) {
-            close();
             commandEventSender.sendFailedEvent(e);
             throw e;
         }
@@ -344,7 +343,6 @@ class InternalStreamConnection implements InternalConnection {
                         public void onResult(final ResponseBuffers responseBuffers, final Throwable t) {
                             if (t != null) {
                                 commandEventSender.sendFailedEvent(t);
-                                close();
                                 callback.onResult(null, t);
                                 return;
                             }


### PR DESCRIPTION
Fixes a regression introduced when moving command monitoring/encoding/decoding responsibility to InternalStreamConnection.

Ensure that the InternalStreamConnection is not closed when an exception is raised that's unrelated to a failure of the underlying Stream.

I noticed this while running the tests and seeing that every time the collection was dropped in the test setup, the connection was closed, as the drop command always fails with "ns not found".  No reason to close the connection for that.  

Patch build: https://evergreen.mongodb.com/version/59973c65e3c33104980005c2