### PR TITLE
JAVA-2580: Remove 2.4 support

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/DeleteProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/DeleteProtocol.java
@@ -96,12 +96,6 @@ class DeleteProtocol extends WriteProtocol {
     }
 
     @Override
-    protected void appendToWriteCommandResponseDocument(final RequestMessage curMessage, final RequestMessage nextMessage,
-                                                        final WriteConcernResult writeConcernResult, final BsonDocument response) {
-        response.append("n", new BsonInt32(writeConcernResult.getCount()));
-    }
-
-    @Override
     protected Logger getLogger() {
         return LOGGER;
     }

--- a/driver-core/src/main/com/mongodb/connection/InsertProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/InsertProtocol.java
@@ -25,7 +25,6 @@ import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
-import org.bson.BsonInt32;
 
 import java.util.List;
 
@@ -95,14 +94,6 @@ class InsertProtocol extends WriteProtocol {
 
     protected RequestMessage createRequestMessage(final MessageSettings settings) {
         return new InsertMessage(getNamespace().getFullName(), isOrdered(), getWriteConcern(), insertRequestList, settings);
-    }
-
-    @Override
-    protected void appendToWriteCommandResponseDocument(final RequestMessage curMessage, final RequestMessage nextMessage,
-                                                        final WriteConcernResult writeConcernResult, final BsonDocument response) {
-        response.append("n", new BsonInt32(nextMessage == null ? ((InsertMessage) curMessage).getInsertRequestList().size()
-                                                               : ((InsertMessage) curMessage).getInsertRequestList().size()
-                                                                 - ((InsertMessage) nextMessage).getInsertRequestList().size()));
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/connection/UpdateProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/UpdateProtocol.java
@@ -26,8 +26,6 @@ import com.mongodb.diagnostics.logging.Loggers;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
-import org.bson.BsonInt32;
-import org.bson.BsonValue;
 
 import java.util.List;
 
@@ -101,29 +99,6 @@ class UpdateProtocol extends WriteProtocol {
     @Override
     protected RequestMessage createRequestMessage(final MessageSettings settings) {
         return new UpdateMessage(getNamespace().getFullName(), updates, settings);
-    }
-
-    @Override
-    protected void appendToWriteCommandResponseDocument(final RequestMessage curMessage, final RequestMessage nextMessage,
-                                                        final WriteConcernResult writeConcernResult, final BsonDocument response) {
-        response.append("n", new BsonInt32(writeConcernResult.getCount()));
-
-        UpdateMessage updateMessage = (UpdateMessage) curMessage;
-        UpdateRequest updateRequest = updateMessage.getUpdateRequests().get(0);
-        BsonValue upsertedId = null;
-        if (writeConcernResult.getUpsertedId() != null) {
-            upsertedId = writeConcernResult.getUpsertedId();
-        } else if (!writeConcernResult.isUpdateOfExisting() && updateRequest.isUpsert()) {
-            if (updateRequest.getUpdate().containsKey("_id")) {
-                upsertedId = updateRequest.getUpdate().get("_id");
-            } else if (updateRequest.getFilter().containsKey("_id")) {
-                upsertedId = updateRequest.getFilter().get("_id");
-            }
-        }
-        if (upsertedId != null) {
-            response.append("upserted", new BsonArray(singletonList(new BsonDocument("index", new BsonInt32(0))
-                                                                    .append("_id", upsertedId))));
-        }
     }
 
     @Override

--- a/driver-core/src/test/functional/com/mongodb/connection/WriteProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/WriteProtocolCommandEventSpecification.groovy
@@ -18,16 +18,12 @@
 
 package com.mongodb.connection
 
-import com.mongodb.DuplicateKeyException
-import com.mongodb.MongoCommandException
 import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.ReadPreference
-import com.mongodb.ServerAddress
 import com.mongodb.bulk.DeleteRequest
 import com.mongodb.bulk.InsertRequest
 import com.mongodb.bulk.UpdateRequest
 import com.mongodb.connection.netty.NettyStreamFactory
-import com.mongodb.event.CommandFailedEvent
 import com.mongodb.event.CommandStartedEvent
 import com.mongodb.event.CommandSucceededEvent
 import com.mongodb.internal.validator.NoOpFieldNameValidator
@@ -46,10 +42,8 @@ import static com.mongodb.ClusterFixture.getPrimary
 import static com.mongodb.ClusterFixture.getSslSettings
 import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
-import static com.mongodb.WriteConcern.ACKNOWLEDGED
 import static com.mongodb.WriteConcern.UNACKNOWLEDGED
 import static com.mongodb.bulk.WriteRequest.Type.UPDATE
-import static com.mongodb.connection.MessageHelper.buildSuccessfulReply
 import static com.mongodb.connection.ProtocolTestHelper.execute
 
 class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecification {
@@ -154,82 +148,6 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
         async << [false, true]
     }
 
-    def 'should deliver started and completed command events when there is a write error'() {
-        given:
-        def document = new BsonDocument('_id', new BsonInt32(1))
-
-        def insertRequest = [new InsertRequest(document)]
-        def protocol = new InsertProtocol(getNamespace(), true, ACKNOWLEDGED, insertRequest)
-        protocol.execute(connection)  // insert here, to force a duplicate key error on the second time
-
-        def commandListener = new TestCommandListener()
-        protocol.commandListener = commandListener
-
-        when:
-        execute(protocol, connection, async)
-
-        then:
-        def e = thrown(DuplicateKeyException)
-
-        and:
-        def expectedEvents = [
-                new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'insert',
-                        new BsonDocument('insert', new BsonString(getCollectionName()))
-                                .append('ordered', BsonBoolean.TRUE)
-                                .append('documents', new BsonArray(
-                                [new BsonDocument('_id', new BsonInt32(1))]))),
-                new CommandSucceededEvent(1, connection.getDescription(), 'insert',
-                        new BsonDocument('ok', new BsonInt32(1)).append('n', new BsonInt32(0))
-                                .append('writeErrors', new BsonArray([
-                                new BsonDocument().append('index', new BsonInt32(0))
-                                        .append('code', new BsonInt32(e.getCode()))
-                                        .append('errmsg', new BsonString(e.getErrorMessage()))])), 0)]
-
-        then:
-        commandListener.eventsWereDelivered(expectedEvents)
-
-        where:
-        async << [false, true]
-    }
-
-    def 'should deliver started and failed command events when there is a command failure'() {
-        given:
-        // need a test connection to generate an ok : 0 response
-        def connection = new TestInternalConnection(new ServerId(new ClusterId(), new ServerAddress('localhost', 27017)));
-        connection.enqueueReply(buildSuccessfulReply('{ ok : 0, errmsg : "some error"}'))
-
-        def document = new BsonDocument('_id', new BsonInt32(1))
-
-        def insertRequest = [new InsertRequest(document)]
-        def protocol = new InsertProtocol(getNamespace(), true, ACKNOWLEDGED, insertRequest)
-
-        def commandListener = new TestCommandListener()
-        protocol.commandListener = commandListener
-
-        when:
-        execute(protocol, connection, async)
-
-        then:
-        def e = thrown(MongoCommandException)
-
-        and:
-        def expectedEvents = [
-                new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'insert',
-                        new BsonDocument('insert', new BsonString(getCollectionName()))
-                                .append('ordered', BsonBoolean.TRUE)
-                                .append('documents', new BsonArray(
-                                [new BsonDocument('_id', new BsonInt32(1))]))),
-                new CommandFailedEvent(1, connection.getDescription(), 'insert', 0, e)]
-
-        then:
-        commandListener.eventsWereDelivered(expectedEvents)
-
-        where:
-        async << [false, true]
-    }
-
-
-
     def 'should deliver started and completed command events for a single unacknowleded update'() {
         given:
         def filter = new BsonDocument('_id', new BsonInt32(1))
@@ -297,108 +215,10 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
         async << [false, true]
     }
 
-    def 'should deliver started and completed command events for a single acknowleded insert'() {
-        given:
-        def document = new BsonDocument('_id', new BsonInt32(1))
-
-        def insertRequest = [new InsertRequest(document)]
-        def protocol = new InsertProtocol(getNamespace(), true, ACKNOWLEDGED, insertRequest)
-        def commandListener = new TestCommandListener()
-        protocol.commandListener = commandListener
-
-        def expectedEvents = [
-                new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'insert',
-                        new BsonDocument('insert', new BsonString(getCollectionName()))
-                                .append('ordered', BsonBoolean.TRUE)
-                                .append('documents', new BsonArray(
-                                [new BsonDocument('_id', new BsonInt32(1))]))),
-                new CommandSucceededEvent(1, connection.getDescription(), 'insert',
-                        new BsonDocument('ok', new BsonInt32(1))
-                                .append('n', new BsonInt32(1)), 0)]
-
-        when:
-        execute(protocol, connection, async)
-
-        then:
-        commandListener.eventsWereDelivered(expectedEvents)
-
-        where:
-        async << [false, true]
-    }
-
-    def 'should deliver started and completed command events for a single acknowleded delete'() {
-        given:
-        def document = new BsonDocument('_id', new BsonInt32(1))
-
-        def insertRequest = [new InsertRequest(document)]
-        def protocol = new InsertProtocol(getNamespace(), true, ACKNOWLEDGED, insertRequest)
-        protocol.execute(connection)
-
-        def deleteRequest = [new DeleteRequest(document)]
-        protocol = new DeleteProtocol(getNamespace(), true, ACKNOWLEDGED, deleteRequest)
-        def commandListener = new TestCommandListener()
-        protocol.commandListener = commandListener
-
-        def expectedEvents = [
-                new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'delete',
-                        new BsonDocument('delete', new BsonString(getCollectionName()))
-                                .append('ordered', BsonBoolean.TRUE)
-                                .append('deletes', new BsonArray(
-                                [new BsonDocument('q', document)
-                                         .append('limit', new BsonInt32(0))]))),
-                new CommandSucceededEvent(1, connection.getDescription(), 'delete',
-                        new BsonDocument('ok', new BsonInt32(1))
-                                .append('n', new BsonInt32(1)), 0)]
-
-        when:
-        execute(protocol, connection, async)
-
-        then:
-        commandListener.eventsWereDelivered(expectedEvents)
-
-        where:
-        async << [false, true]
-    }
-
-    def 'should deliver started and completed command events for a single acknowleded update'() {
-        given:
-        def filter = new BsonDocument('_id', new BsonInt32(1))
-        def update = new BsonDocument('$set', new BsonDocument('x', new BsonInt32(1)))
-        def updateRequest = [new UpdateRequest(filter, update, UPDATE).multi(true).upsert(true)]
-        def protocol = new UpdateProtocol(getNamespace(), true, ACKNOWLEDGED, updateRequest)
-        def commandListener = new TestCommandListener()
-        protocol.commandListener = commandListener
-
-        def expectedEvents = [
-                new CommandStartedEvent(1, connection.getDescription(), getDatabaseName(), 'update',
-                        new BsonDocument('update', new BsonString(getCollectionName()))
-                                .append('ordered', BsonBoolean.TRUE)
-                                .append('updates', new BsonArray(
-                                [new BsonDocument('q', filter)
-                                         .append('u', update)
-                                         .append('multi', BsonBoolean.TRUE)
-                                         .append('upsert', BsonBoolean.TRUE)]))),
-                new CommandSucceededEvent(1, connection.getDescription(), 'update',
-                        new BsonDocument('ok', new BsonInt32(1))
-                                .append('n', new BsonInt32(1))
-                                .append('upserted',
-                                new BsonArray([new BsonDocument('index',
-                                        new BsonInt32(0)).append('_id', filter.get('_id'))])), 0)]
-
-        when:
-        execute(protocol, connection, async)
-
-        then:
-        commandListener.eventsWereDelivered(expectedEvents)
-
-        where:
-        async << [false, true]
-    }
-
     def 'should not deliver any events if encoding fails'() {
         given:
         def insertRequest = [new InsertRequest(new BsonDocument('$set', new BsonInt32(1)))]
-        def protocol = new InsertProtocol(getNamespace(), true, ACKNOWLEDGED, insertRequest)
+        def protocol = new InsertProtocol(getNamespace(), true, UNACKNOWLEDGED, insertRequest)
         def commandListener = new TestCommandListener()
         protocol.commandListener = commandListener
 

--- a/driver-core/src/test/unit/com/mongodb/connection/CommandEventOnConnectionFailureSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/CommandEventOnConnectionFailureSpecification.groovy
@@ -29,7 +29,6 @@ import org.bson.codecs.DocumentCodec
 import spock.lang.Shared
 import spock.lang.Specification
 
-import static com.mongodb.WriteConcern.ACKNOWLEDGED
 import static com.mongodb.WriteConcern.UNACKNOWLEDGED
 import static com.mongodb.connection.ProtocolTestHelper.execute
 
@@ -68,9 +67,6 @@ class CommandEventOnConnectionFailureSpecification extends Specification {
                                    ['find',
                                     new QueryProtocol(namespace, 0, 1, 1, new BsonDocument(), new BsonDocument(), new DocumentCodec())],
                                    ['delete',
-                                    new DeleteProtocol(namespace, true, ACKNOWLEDGED,
-                                            [new DeleteRequest(new BsonDocument('_id', new BsonInt32(1)))])],
-                                   ['delete',
                                     new DeleteProtocol(namespace, true, UNACKNOWLEDGED,
                                             [new DeleteRequest(new BsonDocument('_id', new BsonInt32(1)))])],
                                   ],
@@ -99,9 +95,6 @@ class CommandEventOnConnectionFailureSpecification extends Specification {
                                     new GetMoreProtocol(namespace, 42L, 1, new DocumentCodec())],
                                    ['find',
                                     new QueryProtocol(namespace, 0, 1, 1, new BsonDocument(), new BsonDocument(), new DocumentCodec())],
-                                   ['delete',
-                                    new DeleteProtocol(namespace, true, ACKNOWLEDGED,
-                                            [new DeleteRequest(new BsonDocument('_id', new BsonInt32(1)))])],
                                   ],
                                   [false, true]].combinations()
     }

--- a/driver-core/src/test/unit/com/mongodb/connection/DefaultServerConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/DefaultServerConnectionSpecification.groovy
@@ -35,6 +35,7 @@ import spock.lang.Specification
 
 import static com.mongodb.CustomMatchers.compare
 import static com.mongodb.WriteConcern.ACKNOWLEDGED
+import static com.mongodb.WriteConcern.UNACKNOWLEDGED
 import static com.mongodb.connection.ServerType.SHARD_ROUTER
 import static com.mongodb.connection.ServerType.STANDALONE
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback
@@ -58,10 +59,10 @@ class DefaultServerConnectionSpecification extends Specification {
         def inserts = asList(new InsertRequest(new BsonDocument()))
 
         when:
-        connection.insert(namespace, true, ACKNOWLEDGED, inserts)
+        connection.insert(namespace, true, UNACKNOWLEDGED, inserts)
 
         then:
-        1 * executor.execute({ compare(new InsertProtocol(namespace, true, ACKNOWLEDGED, inserts), it) }, internalConnection)
+        1 * executor.execute({ compare(new InsertProtocol(namespace, true, UNACKNOWLEDGED, inserts), it) }, internalConnection)
     }
 
     def 'should execute update protocol'() {
@@ -69,10 +70,10 @@ class DefaultServerConnectionSpecification extends Specification {
         def updates = asList(new UpdateRequest(new BsonDocument(), new BsonDocument(), WriteRequest.Type.REPLACE))
 
         when:
-        connection.update(namespace, true, ACKNOWLEDGED, updates)
+        connection.update(namespace, true, UNACKNOWLEDGED, updates)
 
         then:
-        1 * executor.execute({ compare(new UpdateProtocol(namespace, true, ACKNOWLEDGED, updates), it) }, internalConnection)
+        1 * executor.execute({ compare(new UpdateProtocol(namespace, true, UNACKNOWLEDGED, updates), it) }, internalConnection)
     }
 
     def 'should execute delete protocol'() {
@@ -80,10 +81,10 @@ class DefaultServerConnectionSpecification extends Specification {
         def deletes = asList(new DeleteRequest(new BsonDocument()))
 
         when:
-        connection.delete(namespace, true, ACKNOWLEDGED, deletes)
+        connection.delete(namespace, true, UNACKNOWLEDGED, deletes)
 
         then:
-        1 * executor.execute({ compare(new DeleteProtocol(namespace, true, ACKNOWLEDGED, deletes), it) }, internalConnection)
+        1 * executor.execute({ compare(new DeleteProtocol(namespace, true, UNACKNOWLEDGED, deletes), it) }, internalConnection)
     }
 
     def 'should execute insert command protocol'() {
@@ -244,10 +245,11 @@ class DefaultServerConnectionSpecification extends Specification {
         def inserts = asList(new InsertRequest(new BsonDocument()))
 
         when:
-        connection.insertAsync(namespace, true, ACKNOWLEDGED, inserts, callback)
+        connection.insertAsync(namespace, true, UNACKNOWLEDGED, inserts, callback)
 
         then:
-        1 * executor.executeAsync({ compare(new InsertProtocol(namespace, true, ACKNOWLEDGED, inserts), it) }, internalConnection, callback)
+        1 * executor.executeAsync({ compare(new InsertProtocol(namespace, true, UNACKNOWLEDGED, inserts), it) }, internalConnection,
+                callback)
     }
 
     def 'should execute update protocol asynchronously'() {
@@ -255,10 +257,10 @@ class DefaultServerConnectionSpecification extends Specification {
         def updates = asList(new UpdateRequest(new BsonDocument(), new BsonDocument(), WriteRequest.Type.REPLACE))
 
         when:
-        connection.updateAsync(namespace, true, ACKNOWLEDGED, updates, callback)
+        connection.updateAsync(namespace, true, UNACKNOWLEDGED, updates, callback)
 
         then:
-        1 * executor.executeAsync({ compare(new UpdateProtocol(namespace, true, ACKNOWLEDGED, updates), it) },
+        1 * executor.executeAsync({ compare(new UpdateProtocol(namespace, true, UNACKNOWLEDGED, updates), it) },
                                   internalConnection, callback)
     }
 
@@ -267,10 +269,11 @@ class DefaultServerConnectionSpecification extends Specification {
         def deletes = asList(new DeleteRequest(new BsonDocument()))
 
         when:
-        connection.deleteAsync(namespace, true, ACKNOWLEDGED, deletes, callback)
+        connection.deleteAsync(namespace, true, UNACKNOWLEDGED, deletes, callback)
 
         then:
-        1 * executor.executeAsync({ compare(new DeleteProtocol(namespace, true, ACKNOWLEDGED, deletes), it) }, internalConnection, callback)
+        1 * executor.executeAsync({ compare(new DeleteProtocol(namespace, true, UNACKNOWLEDGED, deletes), it) }, internalConnection,
+                callback)
     }
 
     def 'should execute insert command protocol asynchronously'() {


### PR DESCRIPTION
Missed this one on the first pull request.

Remove support for acknowledged writes that use the legacy wire protocol for writes, since as as 2.6 legacy wire protocol is only used for unacknowledged writes.