### PR TITLE
JAVA-2564: Client session context for the core driver

### DIFF
--- a/driver-core/src/main/com/mongodb/binding/AsyncClusterBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/AsyncClusterBinding.java
@@ -22,6 +22,8 @@ import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.Cluster;
 import com.mongodb.connection.Server;
 import com.mongodb.connection.ServerDescription;
+import com.mongodb.connection.SessionContext;
+import com.mongodb.internal.connection.NoOpSessionContext;
 import com.mongodb.selector.ReadPreferenceServerSelector;
 import com.mongodb.selector.ServerSelector;
 import com.mongodb.selector.WritableServerSelector;
@@ -61,6 +63,11 @@ public class AsyncClusterBinding extends AbstractReferenceCounted implements Asy
     }
 
     @Override
+    public SessionContext getSessionContext() {
+        return NoOpSessionContext.INSTANCE;
+    }
+
+    @Override
     public void getReadConnectionSource(final SingleResultCallback<AsyncConnectionSource> callback) {
         getAsyncClusterBindingConnectionSource(new ReadPreferenceServerSelector(readPreference), callback);
     }
@@ -95,6 +102,11 @@ public class AsyncClusterBinding extends AbstractReferenceCounted implements Asy
         @Override
         public ServerDescription getServerDescription() {
             return server.getDescription();
+        }
+
+        @Override
+        public SessionContext getSessionContext() {
+            return NoOpSessionContext.INSTANCE;
         }
 
         @Override

--- a/driver-core/src/main/com/mongodb/binding/AsyncConnectionSource.java
+++ b/driver-core/src/main/com/mongodb/binding/AsyncConnectionSource.java
@@ -19,6 +19,7 @@ package com.mongodb.binding;
 import com.mongodb.async.SingleResultCallback;
 import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.ServerDescription;
+import com.mongodb.connection.SessionContext;
 
 /**
  * A source of connections to a single MongoDB server.
@@ -33,6 +34,15 @@ public interface AsyncConnectionSource extends ReferenceCounted {
      * @return the current details of the server state.
      */
     ServerDescription getServerDescription();
+
+    /**
+     * Gets the session context for this source
+     *
+     * @return the session context, which may not be null
+     *
+     * @since 3.6
+     */
+    SessionContext getSessionContext();
 
     /**
      * Gets a connection from this source.

--- a/driver-core/src/main/com/mongodb/binding/AsyncReadBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/AsyncReadBinding.java
@@ -18,6 +18,7 @@ package com.mongodb.binding;
 
 import com.mongodb.ReadPreference;
 import com.mongodb.async.SingleResultCallback;
+import com.mongodb.connection.SessionContext;
 
 /**
  * An asynchronous factory of connection sources to servers that can be read from and that satisfy the specified read preference.
@@ -30,6 +31,15 @@ public interface AsyncReadBinding extends ReferenceCounted {
      * @return the non-null read preference
      */
     ReadPreference getReadPreference();
+
+    /**
+     * Gets the session context for this binding.
+     *
+     * @return the session context, which may not be null
+     *
+     * @since 3.6
+     */
+    SessionContext getSessionContext();
 
     /**
      * Returns a connection source to a server that satisfies the specified read preference.

--- a/driver-core/src/main/com/mongodb/binding/AsyncSingleConnectionReadBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/AsyncSingleConnectionReadBinding.java
@@ -20,6 +20,8 @@ import com.mongodb.ReadPreference;
 import com.mongodb.async.SingleResultCallback;
 import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.ServerDescription;
+import com.mongodb.connection.SessionContext;
+import com.mongodb.internal.connection.NoOpSessionContext;
 
 import static com.mongodb.assertions.Assertions.notNull;
 
@@ -53,6 +55,11 @@ public class AsyncSingleConnectionReadBinding extends AbstractReferenceCounted i
     }
 
     @Override
+    public SessionContext getSessionContext() {
+        return NoOpSessionContext.INSTANCE;
+    }
+
+    @Override
     public void getReadConnectionSource(final SingleResultCallback<AsyncConnectionSource> callback) {
           callback.onResult(new AsyncSingleConnectionSource(), null);
     }
@@ -79,6 +86,11 @@ public class AsyncSingleConnectionReadBinding extends AbstractReferenceCounted i
         @Override
         public ServerDescription getServerDescription() {
             return serverDescription;
+        }
+
+        @Override
+        public SessionContext getSessionContext() {
+            return NoOpSessionContext.INSTANCE;
         }
 
         @Override

--- a/driver-core/src/main/com/mongodb/binding/AsyncWriteBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/AsyncWriteBinding.java
@@ -17,6 +17,7 @@
 package com.mongodb.binding;
 
 import com.mongodb.async.SingleResultCallback;
+import com.mongodb.connection.SessionContext;
 
 /**
  * An asynchronous factory of connection sources to servers that can be written to, e.g, a standalone, a mongos, or a replica set primary.
@@ -31,6 +32,15 @@ public interface AsyncWriteBinding extends ReferenceCounted {
      * @param callback the to be passed the connection source
      */
     void getWriteConnectionSource(SingleResultCallback<AsyncConnectionSource> callback);
+
+    /**
+     * Gets the session context for this binding.
+     *
+     * @return the session context, which may not be null
+     *
+     * @since 3.6
+     */
+    SessionContext getSessionContext();
 
     @Override
     AsyncWriteBinding retain();

--- a/driver-core/src/main/com/mongodb/binding/ClusterBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/ClusterBinding.java
@@ -21,6 +21,8 @@ import com.mongodb.connection.Cluster;
 import com.mongodb.connection.Connection;
 import com.mongodb.connection.Server;
 import com.mongodb.connection.ServerDescription;
+import com.mongodb.connection.SessionContext;
+import com.mongodb.internal.connection.NoOpSessionContext;
 import com.mongodb.selector.ReadPreferenceServerSelector;
 import com.mongodb.selector.ServerSelector;
 import com.mongodb.selector.WritableServerSelector;
@@ -64,6 +66,11 @@ public class ClusterBinding extends AbstractReferenceCounted implements ReadWrit
     }
 
     @Override
+    public SessionContext getSessionContext() {
+        return NoOpSessionContext.INSTANCE;
+    }
+
+    @Override
     public ConnectionSource getWriteConnectionSource() {
         return new ClusterBindingConnectionSource(new WritableServerSelector());
     }
@@ -79,6 +86,11 @@ public class ClusterBinding extends AbstractReferenceCounted implements ReadWrit
         @Override
         public ServerDescription getServerDescription() {
             return server.getDescription();
+        }
+
+        @Override
+        public SessionContext getSessionContext() {
+            return NoOpSessionContext.INSTANCE;
         }
 
         @Override

--- a/driver-core/src/main/com/mongodb/binding/ConnectionSource.java
+++ b/driver-core/src/main/com/mongodb/binding/ConnectionSource.java
@@ -18,6 +18,7 @@ package com.mongodb.binding;
 
 import com.mongodb.connection.Connection;
 import com.mongodb.connection.ServerDescription;
+import com.mongodb.connection.SessionContext;
 
 /**
  * A source of connections to a single MongoDB server.
@@ -32,6 +33,15 @@ public interface ConnectionSource extends ReferenceCounted {
      * @return the current details of the server state.
      */
     ServerDescription getServerDescription();
+
+    /**
+     * Gets the session context for this source
+     *
+     * @return the session context, which may not be null
+     *
+     * @since 3.6
+     */
+    SessionContext getSessionContext();
 
     /**
      * Gets a connection from this source.

--- a/driver-core/src/main/com/mongodb/binding/ReadBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/ReadBinding.java
@@ -17,6 +17,7 @@
 package com.mongodb.binding;
 
 import com.mongodb.ReadPreference;
+import com.mongodb.connection.SessionContext;
 
 /**
  * A factory of connection sources to servers that can be read from and that satisfy the specified read preference.
@@ -35,6 +36,15 @@ public interface ReadBinding extends ReferenceCounted {
      * @return the connection source
      */
     ConnectionSource getReadConnectionSource();
+
+    /**
+     * Gets the session context for this binding.
+     *
+     * @return the session context, which may not be null
+     *
+     * @since 3.6
+     */
+    SessionContext getSessionContext();
 
     @Override
     ReadBinding retain();

--- a/driver-core/src/main/com/mongodb/binding/SingleConnectionReadBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/SingleConnectionReadBinding.java
@@ -19,6 +19,8 @@ package com.mongodb.binding;
 import com.mongodb.ReadPreference;
 import com.mongodb.connection.Connection;
 import com.mongodb.connection.ServerDescription;
+import com.mongodb.connection.SessionContext;
+import com.mongodb.internal.connection.NoOpSessionContext;
 
 import static com.mongodb.assertions.Assertions.notNull;
 
@@ -58,6 +60,11 @@ public class SingleConnectionReadBinding extends AbstractReferenceCounted implem
     }
 
     @Override
+    public SessionContext getSessionContext() {
+        return NoOpSessionContext.INSTANCE;
+    }
+
+    @Override
     public ReadBinding retain() {
         super.retain();
         return this;
@@ -80,6 +87,11 @@ public class SingleConnectionReadBinding extends AbstractReferenceCounted implem
         @Override
         public ServerDescription getServerDescription() {
             return serverDescription;
+        }
+
+        @Override
+        public SessionContext getSessionContext() {
+            return NoOpSessionContext.INSTANCE;
         }
 
         @Override

--- a/driver-core/src/main/com/mongodb/binding/SingleServerBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/SingleServerBinding.java
@@ -22,6 +22,8 @@ import com.mongodb.connection.Cluster;
 import com.mongodb.connection.Connection;
 import com.mongodb.connection.Server;
 import com.mongodb.connection.ServerDescription;
+import com.mongodb.connection.SessionContext;
+import com.mongodb.internal.connection.NoOpSessionContext;
 import com.mongodb.selector.ServerAddressSelector;
 
 import static com.mongodb.assertions.Assertions.notNull;
@@ -73,6 +75,11 @@ public class SingleServerBinding extends AbstractReferenceCounted implements Rea
     }
 
     @Override
+    public SessionContext getSessionContext() {
+        return NoOpSessionContext.INSTANCE;
+    }
+
+    @Override
     public SingleServerBinding retain() {
         super.retain();
         return this;
@@ -89,6 +96,11 @@ public class SingleServerBinding extends AbstractReferenceCounted implements Rea
         @Override
         public ServerDescription getServerDescription() {
             return server.getDescription();
+        }
+
+        @Override
+        public SessionContext getSessionContext() {
+            return NoOpSessionContext.INSTANCE;
         }
 
         @Override

--- a/driver-core/src/main/com/mongodb/binding/WriteBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/WriteBinding.java
@@ -16,6 +16,8 @@
 
 package com.mongodb.binding;
 
+import com.mongodb.connection.SessionContext;
+
 /**
  * A factory of connection sources to servers that can be written to, e.g, a standalone, a mongos, or a replica set primary.
  *
@@ -28,6 +30,15 @@ public interface WriteBinding extends ReferenceCounted {
      * @return a connection source
      */
     ConnectionSource getWriteConnectionSource();
+
+    /**
+     * Gets the session context for this binding.
+     *
+     * @return the session context, which may not be null
+     *
+     * @since 3.6
+     */
+    SessionContext getSessionContext();
 
     @Override
     WriteBinding retain();

--- a/driver-core/src/main/com/mongodb/connection/AsyncConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/AsyncConnection.java
@@ -117,9 +117,28 @@ public interface AsyncConnection extends ReferenceCounted {
      * @param callback                 the callback to be passed the bulk write result
      * @since 3.2
      * @mongodb.driver.manual reference/command/insert/ Insert
+     * @deprecated Prefer {@link #insertCommandAsync(MongoNamespace, boolean, WriteConcern, Boolean, List, SessionContext,
+     * SingleResultCallback)}
      */
+    @Deprecated
     void insertCommandAsync(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, Boolean bypassDocumentValidation,
                             List<InsertRequest> inserts, SingleResultCallback<BulkWriteResult> callback);
+
+    /**
+     * Insert the documents using the insert command asynchronously.
+     *
+     * @param namespace                the namespace
+     * @param ordered                  whether the writes are ordered
+     * @param writeConcern             the write concern
+     * @param bypassDocumentValidation the bypassDocumentValidation flag
+     * @param inserts                  the inserts
+     * @param sessionContext           the session context
+     * @param callback                 the callback to be passed the bulk write result
+     * @since 3.6
+     * @mongodb.driver.manual reference/command/insert/ Insert
+     */
+    void insertCommandAsync(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, Boolean bypassDocumentValidation,
+                            List<InsertRequest> inserts, SessionContext sessionContext, SingleResultCallback<BulkWriteResult> callback);
 
     /**
      * Update the documents using the update command asynchronously.
@@ -147,9 +166,28 @@ public interface AsyncConnection extends ReferenceCounted {
      * @param callback                 the callback to be passed the BulkWriteResult
      * @since 3.2
      * @mongodb.driver.manual reference/command/update/ Update
+     * @deprecated Prefer {@link #updateCommandAsync(MongoNamespace, boolean, WriteConcern, Boolean, List, SessionContext,
+     * SingleResultCallback)}
      */
+    @Deprecated
     void updateCommandAsync(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, Boolean bypassDocumentValidation,
                             List<UpdateRequest> updates, SingleResultCallback<BulkWriteResult> callback);
+
+    /**
+     * Update the documents using the update command asynchronously.
+     *
+     * @param namespace                the namespace
+     * @param ordered                  whether the writes are ordered
+     * @param writeConcern             the write concern
+     * @param bypassDocumentValidation the bypassDocumentValidation flag
+     * @param updates                  the updates
+     * @param sessionContext           the session context
+     * @param callback                 the callback to be passed the BulkWriteResult
+     * @since 3.6
+     * @mongodb.driver.manual reference/command/update/ Update
+     */
+    void updateCommandAsync(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, Boolean bypassDocumentValidation,
+                            List<UpdateRequest> updates, SessionContext sessionContext, SingleResultCallback<BulkWriteResult> callback);
 
     /**
      * Delete the documents using the delete command asynchronously.
@@ -159,9 +197,25 @@ public interface AsyncConnection extends ReferenceCounted {
      * @param writeConcern the write concern
      * @param deletes      the deletes
      * @param callback     the callback to be passed the BulkWriteResult
+     * @deprecated Prefer {@link #deleteCommandAsync(MongoNamespace, boolean, WriteConcern, List, SessionContext, SingleResultCallback)}
      */
+    @Deprecated
     void deleteCommandAsync(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, List<DeleteRequest> deletes,
                             SingleResultCallback<BulkWriteResult> callback);
+
+    /**
+     * Delete the documents using the delete command asynchronously.
+     *
+     * @param namespace    the namespace
+     * @param ordered      whether the writes are ordered
+     * @param writeConcern the write concern
+     * @param deletes      the deletes
+     * @param sessionContext the session context
+     * @param callback     the callback to be passed the BulkWriteResult
+     * @since 3.6
+     */
+    void deleteCommandAsync(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, List<DeleteRequest> deletes,
+                            SessionContext sessionContext, SingleResultCallback<BulkWriteResult> callback);
 
     /**
      * Execute the command asynchronously.
@@ -173,7 +227,8 @@ public interface AsyncConnection extends ReferenceCounted {
      * @param commandResultDecoder the decoder for the result
      * @param callback             the callback to be passed the command result
      * @param <T>                  the type of the result
-     * @deprecated Prefer {@link #commandAsync(String, BsonDocument, ReadPreference, FieldNameValidator, Decoder, SingleResultCallback)}
+     * @deprecated Prefer {@link #commandAsync(String, BsonDocument, ReadPreference, FieldNameValidator, Decoder, SessionContext,
+     * SingleResultCallback)}
      */
     @Deprecated
     <T> void commandAsync(String database, BsonDocument command, boolean slaveOk, FieldNameValidator fieldNameValidator,
@@ -182,17 +237,17 @@ public interface AsyncConnection extends ReferenceCounted {
     /**
      * Execute the command asynchronously.
      *
+     * @param <T>                  the type of the result
      * @param database             the database to execute the command in
      * @param command              the command document
      * @param readPreference       the read preference that was applied to get this connection
      * @param fieldNameValidator   the field name validator for the command document
      * @param commandResultDecoder the decoder for the result
-     * @param callback             the callback to be passed the command result
-     * @param <T>                  the type of the result
-     * @since 3.6
+     * @param sessionContext       the session context
+     * @param callback             the callback to be passed the command result  @since 3.6
      */
     <T> void commandAsync(String database, BsonDocument command, ReadPreference readPreference, FieldNameValidator fieldNameValidator,
-                          Decoder<T> commandResultDecoder, SingleResultCallback<T> callback);
+                          Decoder<T> commandResultDecoder, SessionContext sessionContext, SingleResultCallback<T> callback);
 
     /**
      * Execute the query asynchronously.

--- a/driver-core/src/main/com/mongodb/connection/BaseCluster.java
+++ b/driver-core/src/main/com/mongodb/connection/BaseCluster.java
@@ -64,6 +64,7 @@ abstract class BaseCluster implements Cluster {
     private final ClusterListener clusterListener;
     private final Deque<ServerSelectionRequest> waitQueue = new ConcurrentLinkedDeque<ServerSelectionRequest>();
     private final AtomicInteger waitQueueSize = new AtomicInteger(0);
+    private final ClusterClock clusterClock = new ClusterClock();
     private Thread waitQueueHandler;
 
     private volatile boolean isClosed;
@@ -356,7 +357,7 @@ abstract class BaseCluster implements Cluster {
     }
 
     protected ClusterableServer createServer(final ServerAddress serverAddress, final ServerListener serverListener) {
-        return serverFactory.create(serverAddress, createServerListener(serverFactory.getSettings(), serverListener));
+        return serverFactory.create(serverAddress, createServerListener(serverFactory.getSettings(), serverListener), clusterClock);
     }
 
     private void throwIfIncompatible(final ClusterDescription curDescription) {

--- a/driver-core/src/main/com/mongodb/connection/BaseQueryMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/BaseQueryMessage.java
@@ -23,7 +23,7 @@ import org.bson.io.BsonOutput;
  *
  * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-query OP_QUERY
  */
-abstract class BaseQueryMessage extends RequestMessage {
+abstract class BaseQueryMessage extends LegacyMessage {
     private final int skip;
     private final int numberToReturn;
     private boolean tailableCursor;

--- a/driver-core/src/main/com/mongodb/connection/ClusterClock.java
+++ b/driver-core/src/main/com/mongodb/connection/ClusterClock.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.connection;
+
+import org.bson.BsonDocument;
+
+class ClusterClock {
+    private static final Object CLUSTER_TIME_KEY = "clusterTime";
+    private BsonDocument clusterTime;
+
+    public synchronized BsonDocument getCurrent() {
+        return clusterTime;
+    }
+
+    public synchronized void advance(final BsonDocument other) {
+        this.clusterTime = greaterOf(other);
+    }
+
+    public synchronized BsonDocument greaterOf(final BsonDocument other) {
+        if (other == null) {
+            return clusterTime;
+        } else if (clusterTime == null) {
+            return other;
+        } else {
+            return other.getTimestamp(CLUSTER_TIME_KEY).compareTo(clusterTime.getTimestamp(CLUSTER_TIME_KEY)) > 0 ? other : clusterTime;
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/connection/ClusterableServerFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/ClusterableServerFactory.java
@@ -20,7 +20,7 @@ import com.mongodb.ServerAddress;
 import com.mongodb.event.ServerListener;
 
 interface ClusterableServerFactory {
-    ClusterableServer create(ServerAddress serverAddress, ServerListener serverListener);
+    ClusterableServer create(ServerAddress serverAddress, ServerListener serverListener, ClusterClock clusterClock);
 
     ServerSettings getSettings();
 }

--- a/driver-core/src/main/com/mongodb/connection/CommandHelper.java
+++ b/driver-core/src/main/com/mongodb/connection/CommandHelper.java
@@ -19,6 +19,7 @@ package com.mongodb.connection;
 import com.mongodb.MongoNamespace;
 import com.mongodb.MongoServerException;
 import com.mongodb.async.SingleResultCallback;
+import com.mongodb.internal.connection.NoOpSessionContext;
 import org.bson.BsonDocument;
 import org.bson.BsonValue;
 import org.bson.codecs.BsonDocumentCodec;
@@ -48,15 +49,16 @@ final class CommandHelper {
                                                         .serverVersion(internalConnection.getDescription().getServerVersion())
                                                         .build());
 
-        internalConnection.sendAndReceiveAsync(message, new BsonDocumentCodec(), new SingleResultCallback<BsonDocument>() {
-            @Override
-            public void onResult(final BsonDocument result, final Throwable t) {
-                if (t != null) {
-                    callback.onResult(null, t);
-                } else {
-                    callback.onResult(result, null);
-                }
-            }
+        internalConnection.sendAndReceiveAsync(message, new BsonDocumentCodec(), NoOpSessionContext.INSTANCE,
+                new SingleResultCallback<BsonDocument>() {
+                    @Override
+                    public void onResult(final BsonDocument result, final Throwable t) {
+                        if (t != null) {
+                            callback.onResult(null, t);
+                        } else {
+                            callback.onResult(result, null);
+                        }
+                    }
         });
     }
 
@@ -86,7 +88,7 @@ final class CommandHelper {
                                                                                .serverVersion(internalConnection.getDescription()
                                                                                                       .getServerVersion())
                                                                                .build());
-        return internalConnection.sendAndReceive(message, new BsonDocumentCodec());
+        return internalConnection.sendAndReceive(message, new BsonDocumentCodec(), NoOpSessionContext.INSTANCE);
     }
 
     private CommandHelper() {

--- a/driver-core/src/main/com/mongodb/connection/CommandMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/CommandMessage.java
@@ -17,6 +17,8 @@
 
 package com.mongodb.connection;
 
+import org.bson.io.BsonOutput;
+
 abstract class CommandMessage extends RequestMessage {
     CommandMessage(final String collectionName, final OpCode opCode, final MessageSettings settings) {
         super(collectionName, opCode, settings);
@@ -24,11 +26,23 @@ abstract class CommandMessage extends RequestMessage {
 
     abstract boolean isResponseExpected();
 
+    abstract EncodingMetadata encodeMessageBodyWithMetadata(BsonOutput bsonOutput, SessionContext sessionContext);
+
+    @Override
+    protected EncodingMetadata encodeMessageBodyWithMetadata(final BsonOutput bsonOutput, final int messageStartPosition,
+                                                             final SessionContext sessionContext) {
+        return encodeMessageBodyWithMetadata(bsonOutput, sessionContext);
+    }
+
     protected static OpCode getOpCode(final MessageSettings settings) {
         return useOpMsg(settings) ? OpCode.OP_MSG : OpCode.OP_QUERY;
     }
 
     protected static boolean useOpMsg(final MessageSettings settings) {
+        return isServerVersionAtLeastThreeDotSix(settings);
+    }
+
+    private static boolean isServerVersionAtLeastThreeDotSix(final MessageSettings settings) {
         return settings.getServerVersion().compareTo(new ServerVersion(3, 5)) >= 0;
     }
 

--- a/driver-core/src/main/com/mongodb/connection/CommandProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/CommandProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008-2016 MongoDB, Inc.
+ * Copyright 2017 MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,100 +12,18 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package com.mongodb.connection;
 
-import com.mongodb.MongoNamespace;
-import com.mongodb.ReadPreference;
 import com.mongodb.async.SingleResultCallback;
-import com.mongodb.diagnostics.logging.Logger;
-import com.mongodb.diagnostics.logging.Loggers;
-import com.mongodb.event.CommandListener;
-import org.bson.BsonDocument;
-import org.bson.FieldNameValidator;
-import org.bson.codecs.Decoder;
 
-import static com.mongodb.assertions.Assertions.notNull;
-import static com.mongodb.connection.ProtocolHelper.getMessageSettings;
-import static java.lang.String.format;
+interface CommandProtocol<T> {
 
-/**
- * A protocol for executing a command against a MongoDB server using the OP_QUERY wire protocol message.
- *
- * @param <T> the type returned from execution
- * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-query OP_QUERY
- */
-class CommandProtocol<T> implements Protocol<T> {
+    T execute(InternalConnection connection);
 
-    public static final Logger LOGGER = Loggers.getLogger("protocol.command");
+    void executeAsync(InternalConnection connection, SingleResultCallback<T> callback);
 
-    private final MongoNamespace namespace;
-    private final BsonDocument command;
-    private final Decoder<T> commandResultDecoder;
-    private final FieldNameValidator fieldNameValidator;
-    private ReadPreference readPreference;
-
-    CommandProtocol(final String database, final BsonDocument command, final FieldNameValidator fieldNameValidator,
-                    final Decoder<T> commandResultDecoder) {
-        notNull("database", database);
-        this.namespace = new MongoNamespace(database, MongoNamespace.COMMAND_COLLECTION_NAME);
-        this.command = notNull("command", command);
-        this.commandResultDecoder = notNull("commandResultDecoder", commandResultDecoder);
-        this.fieldNameValidator = notNull("fieldNameValidator", fieldNameValidator);
-    }
-
-    public CommandProtocol<T> readPreference(final ReadPreference readPreference) {
-        this.readPreference = readPreference;
-        return this;
-    }
-
-    @Override
-    public T execute(final InternalConnection connection) {
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(format("Sending command {%s : %s} to database %s on connection [%s] to server %s",
-                                getCommandName(), command.values().iterator().next(),
-                                namespace.getDatabaseName(), connection.getDescription().getConnectionId(),
-                                connection.getDescription().getServerAddress()));
-        }
-        SimpleCommandMessage commandMessage = new SimpleCommandMessage(namespace.getFullName(), command, readPreference, fieldNameValidator,
-                                                                              getMessageSettings(connection.getDescription()));
-        T retval = connection.sendAndReceive(commandMessage, commandResultDecoder);
-        LOGGER.debug("Command execution completed");
-        return retval;
-    }
-
-    @Override
-    public void executeAsync(final InternalConnection connection, final SingleResultCallback<T> callback) {
-        final SimpleCommandMessage message = new SimpleCommandMessage(namespace.getFullName(), command, readPreference, fieldNameValidator,
-                getMessageSettings(connection.getDescription()));
-        try {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(format("Asynchronously sending command {%s : %s} to database %s on connection [%s] to server %s",
-                                    getCommandName(), command.values().iterator().next(),
-                                    namespace.getDatabaseName(), connection.getDescription().getConnectionId(),
-                                    connection.getDescription().getServerAddress()));
-            }
-            connection.sendAndReceiveAsync(message, commandResultDecoder, new SingleResultCallback<T>() {
-                @Override
-                public void onResult(final T result, final Throwable t) {
-                    if (t != null) {
-                        callback.onResult(null, t);
-                    } else {
-                        callback.onResult(result, null);
-                    }
-                }
-            });
-        } catch (Throwable t) {
-            callback.onResult(null, t);
-        }
-    }
-
-    @Override
-    public void setCommandListener(final CommandListener commandListener) {
-    }
-
-    private String getCommandName() {
-        return command.keySet().iterator().next();
-    }
+    CommandProtocol<T> sessionContext(SessionContext sessionContext);
 }

--- a/driver-core/src/main/com/mongodb/connection/CompressedMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/CompressedMessage.java
@@ -38,7 +38,8 @@ class CompressedMessage extends RequestMessage {
     }
 
     @Override
-    protected EncodingMetadata encodeMessageBodyWithMetadata(final BsonOutput bsonOutput, final int messageStartPosition) {
+    protected EncodingMetadata encodeMessageBodyWithMetadata(final BsonOutput bsonOutput, final int messageStartPosition,
+                                                             final SessionContext sessionContext) {
         bsonOutput.writeInt32(wrappedOpcode.getValue());
         bsonOutput.writeInt32(getWrappedMessageSize(wrappedMessageBuffers) - MESSAGE_HEADER_LENGTH);
         bsonOutput.writeByte(compressor.getId());

--- a/driver-core/src/main/com/mongodb/connection/Connection.java
+++ b/driver-core/src/main/com/mongodb/connection/Connection.java
@@ -114,9 +114,27 @@ public interface Connection extends ReferenceCounted {
      * @return the bulk write result
      * @since 3.2
      * @mongodb.driver.manual reference/command/insert/ Insert
+     * @deprecated Prefer {@link #insertCommand(MongoNamespace, boolean, WriteConcern, Boolean, List, SessionContext)}
      */
+    @Deprecated
     BulkWriteResult insertCommand(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, Boolean bypassDocumentValidation,
                                   List<InsertRequest> inserts);
+
+    /**
+     * Insert the documents using the insert command.
+     *
+     * @param namespace                 the namespace
+     * @param ordered                   whether the writes are ordered
+     * @param writeConcern              the write concern
+     * @param bypassDocumentValidation  the bypassDocumentValidation flag
+     * @param inserts                   the inserts
+     * @param sessionContext            the session context
+     * @return the bulk write result
+     * @since 3.6
+     * @mongodb.driver.manual reference/command/insert/ Insert
+     */
+    BulkWriteResult insertCommand(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, Boolean bypassDocumentValidation,
+                                  List<InsertRequest> inserts, SessionContext sessionContext);
 
     /**
      * Update the documents using the update command.
@@ -126,7 +144,7 @@ public interface Connection extends ReferenceCounted {
      * @param writeConcern the write concern
      * @param updates      the updates
      * @return the bulk write result
-     * @deprecated Replaced by {@link Connection#updateCommand(MongoNamespace, boolean, WriteConcern, Boolean, List)}}
+     * @deprecated Replaced by {@link Connection#updateCommand(MongoNamespace, boolean, WriteConcern, Boolean, List, SessionContext)}}
      */
     @Deprecated
     BulkWriteResult updateCommand(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, List<UpdateRequest> updates);
@@ -142,9 +160,27 @@ public interface Connection extends ReferenceCounted {
      * @return the bulk write result
      * @since 3.2
      * @mongodb.driver.manual reference/command/update/ Update
+     * @deprecated Prefer {@link #updateCommand(MongoNamespace, boolean, WriteConcern, Boolean, List, SessionContext)}
      */
+    @Deprecated
     BulkWriteResult updateCommand(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, Boolean bypassDocumentValidation,
                                   List<UpdateRequest> updates);
+
+    /**
+     * Update the documents using the update command.
+     *
+     * @param namespace                 the namespace
+     * @param ordered                   whether the writes are ordered
+     * @param writeConcern              the write concern
+     * @param bypassDocumentValidation  the bypassDocumentValidation flag
+     * @param updates                   the updates
+     * @param sessionContext            the session context
+     * @return the bulk write result
+     * @since 3.6
+     * @mongodb.driver.manual reference/command/update/ Update
+     */
+    BulkWriteResult updateCommand(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, Boolean bypassDocumentValidation,
+                                  List<UpdateRequest> updates, SessionContext sessionContext);
 
     /**
      * Delete the documents using the delete command.
@@ -154,8 +190,24 @@ public interface Connection extends ReferenceCounted {
      * @param writeConcern the write concern
      * @param deletes      the deletes
      * @return the bulk write result
+     * @deprecated Prefer {@link #deleteCommand(MongoNamespace, boolean, WriteConcern, List, SessionContext)}
      */
+    @Deprecated
     BulkWriteResult deleteCommand(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, List<DeleteRequest> deletes);
+
+    /**
+     * Delete the documents using the delete command.
+     *
+     * @param namespace    the namespace
+     * @param ordered      whether the writes are ordered
+     * @param writeConcern the write concern
+     * @param deletes      the deletes
+     * @param sessionContext            the session context
+     * @return the bulk write result
+     * @since 3.6
+     */
+    BulkWriteResult deleteCommand(MongoNamespace namespace, boolean ordered, WriteConcern writeConcern, List<DeleteRequest> deletes,
+                                  SessionContext sessionContext);
 
     /**
      * Execute the command.
@@ -167,7 +219,7 @@ public interface Connection extends ReferenceCounted {
      * @param commandResultDecoder the decoder for the result
      * @param <T>                  the type of the result
      * @return the command result
-     * @deprecated Prefer {@link #command(String, BsonDocument, ReadPreference, FieldNameValidator, Decoder)}
+     * @deprecated Prefer {@link #command(String, BsonDocument, ReadPreference, FieldNameValidator, Decoder, SessionContext)}
      */
     @Deprecated
     <T> T command(String database, BsonDocument command, boolean slaveOk, FieldNameValidator fieldNameValidator,
@@ -176,17 +228,18 @@ public interface Connection extends ReferenceCounted {
     /**
      * Execute the command.
      *
+     * @param <T>                  the type of the result
      * @param database             the database to execute the command in
      * @param command              the command document
      * @param readPreference       the read preference that was applied to get this connection
      * @param fieldNameValidator   the field name validator for the command document
      * @param commandResultDecoder the decoder for the result
-     * @param <T>                  the type of the result
+     * @param sessionContext       the session context
      * @return the command result
      * @since 3.6
      */
     <T> T command(String database, BsonDocument command, ReadPreference readPreference, FieldNameValidator fieldNameValidator,
-                  Decoder<T> commandResultDecoder);
+                  Decoder<T> commandResultDecoder, SessionContext sessionContext);
 
     /**
      * Execute the query.

--- a/driver-core/src/main/com/mongodb/connection/DefaultClusterableServerFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/DefaultClusterableServerFactory.java
@@ -59,7 +59,8 @@ class DefaultClusterableServerFactory implements ClusterableServerFactory {
     }
 
     @Override
-    public ClusterableServer create(final ServerAddress serverAddress, final ServerListener serverListener) {
+    public ClusterableServer create(final ServerAddress serverAddress, final ServerListener serverListener,
+                                    final ClusterClock clusterClock) {
         ConnectionPool connectionPool = new DefaultConnectionPool(new ServerId(clusterId, serverAddress),
                 new InternalStreamConnectionFactory(streamFactory, credentialList, applicationName,
                         mongoDriverInformation, compressorList, commandListener), connectionPoolSettings);
@@ -69,7 +70,7 @@ class DefaultClusterableServerFactory implements ClusterableServerFactory {
                             mongoDriverInformation, Collections.<MongoCompressor>emptyList(), null), connectionPool);
 
         return new DefaultServer(new ServerId(clusterId, serverAddress), clusterSettings.getMode(), connectionPool,
-                new DefaultConnectionFactory(), serverMonitorFactory, serverListener, commandListener);
+                new DefaultConnectionFactory(), serverMonitorFactory, serverListener, commandListener, clusterClock);
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/connection/DefaultConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/connection/DefaultConnectionPool.java
@@ -433,10 +433,10 @@ class DefaultConnectionPool implements ConnectionPool {
         }
 
         @Override
-        public <T> T sendAndReceive(final CommandMessage message, final Decoder<T> decoder) {
+        public <T> T sendAndReceive(final CommandMessage message, final Decoder<T> decoder, final SessionContext sessionContext) {
             isTrue("open", !isClosed.get());
             try {
-                return wrapped.sendAndReceive(message, decoder);
+                return wrapped.sendAndReceive(message, decoder, sessionContext);
             } catch (MongoException e) {
                 incrementGenerationOnSocketException(this, e);
                 throw e;
@@ -445,9 +445,9 @@ class DefaultConnectionPool implements ConnectionPool {
 
         @Override
         public <T> void sendAndReceiveAsync(final CommandMessage message, final Decoder<T> decoder,
-                                            final SingleResultCallback<T> callback) {
+                                            final SessionContext sessionContext, final SingleResultCallback<T> callback) {
             isTrue("open", !isClosed.get());
-            wrapped.sendAndReceiveAsync(message, decoder, new SingleResultCallback<T>() {
+            wrapped.sendAndReceiveAsync(message, decoder, sessionContext, new SingleResultCallback<T>() {
                 @Override
                 public void onResult(final T result, final Throwable t) {
                     if (t != null) {

--- a/driver-core/src/main/com/mongodb/connection/DefaultServer.java
+++ b/driver-core/src/main/com/mongodb/connection/DefaultServer.java
@@ -30,6 +30,8 @@ import com.mongodb.event.ServerClosedEvent;
 import com.mongodb.event.ServerDescriptionChangedEvent;
 import com.mongodb.event.ServerListener;
 import com.mongodb.event.ServerOpeningEvent;
+import org.bson.BsonDocument;
+import org.bson.BsonTimestamp;
 
 import static com.mongodb.assertions.Assertions.isTrue;
 import static com.mongodb.assertions.Assertions.notNull;
@@ -46,14 +48,16 @@ class DefaultServer implements ClusterableServer {
     private final ChangeListener<ServerDescription> serverStateListener;
     private final ServerListener serverListener;
     private final CommandListener commandListener;
+    private final ClusterClock clusterClock;
     private volatile ServerDescription description;
     private volatile boolean isClosed;
 
     DefaultServer(final ServerId serverId, final ClusterConnectionMode clusterConnectionMode, final ConnectionPool connectionPool,
                   final ConnectionFactory connectionFactory, final ServerMonitorFactory serverMonitorFactory,
-                  final ServerListener serverListener, final CommandListener commandListener) {
+                  final ServerListener serverListener, final CommandListener commandListener, final ClusterClock clusterClock) {
         this.serverListener = notNull("serverListener", serverListener);
         this.commandListener = commandListener;
+        this.clusterClock = notNull("clusterClock", clusterClock);
         notNull("serverAddress", serverId);
         notNull("serverMonitorFactory", serverMonitorFactory);
         this.clusterConnectionMode = notNull("clusterConnectionMode", clusterConnectionMode);
@@ -153,7 +157,7 @@ class DefaultServer implements ClusterableServer {
 
     private class DefaultServerProtocolExecutor implements ProtocolExecutor {
         @Override
-        public <T> T execute(final Protocol<T> protocol, final InternalConnection connection) {
+        public <T> T execute(final LegacyProtocol<T> protocol, final InternalConnection connection) {
             try {
                 protocol.setCommandListener(commandListener);
                 return protocol.execute(connection);
@@ -164,7 +168,7 @@ class DefaultServer implements ClusterableServer {
         }
 
         @Override
-        public <T> void executeAsync(final Protocol<T> protocol, final InternalConnection connection,
+        public <T> void executeAsync(final LegacyProtocol<T> protocol, final InternalConnection connection,
                                      final SingleResultCallback<T> callback) {
             protocol.setCommandListener(commandListener);
             protocol.executeAsync(connection, errorHandlingCallback(new SingleResultCallback<T>() {
@@ -177,6 +181,35 @@ class DefaultServer implements ClusterableServer {
                 }
             }, LOGGER));
         }
+
+        @Override
+        public <T> T execute(final CommandProtocol<T> protocol, final InternalConnection connection,
+                             final SessionContext sessionContext) {
+            try {
+                protocol.sessionContext(new ClusterClockAdvancingSessionContext(sessionContext));
+                return protocol.execute(connection);
+            } catch (MongoException e) {
+                handleThrowable(e);
+                throw e;
+            }
+        }
+
+        @Override
+        public <T> void executeAsync(final CommandProtocol<T> protocol, final InternalConnection connection,
+                                     final SessionContext sessionContext, final SingleResultCallback<T> callback) {
+            protocol.sessionContext(new ClusterClockAdvancingSessionContext(sessionContext));
+            protocol.executeAsync(connection, errorHandlingCallback(new SingleResultCallback<T>() {
+                @Override
+                public void onResult(final T result, final Throwable t) {
+                    if (t != null) {
+                        handleThrowable(t);
+                        callback.onResult(null, t);
+                    } else {
+                        callback.onResult(result, null);
+                    }
+                }
+            }, LOGGER));
+        }
     }
 
     private final class DefaultServerStateListener implements ChangeListener<ServerDescription> {
@@ -185,6 +218,46 @@ class DefaultServer implements ClusterableServer {
             ServerDescription oldDescription = description;
             description = event.getNewValue();
             serverListener.serverDescriptionChanged(new ServerDescriptionChangedEvent(serverId, description, oldDescription));
+        }
+    }
+
+    private final class ClusterClockAdvancingSessionContext implements SessionContext {
+
+        private SessionContext wrapped;
+
+        private ClusterClockAdvancingSessionContext(final SessionContext wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public boolean hasSession() {
+            return wrapped.hasSession();
+        }
+
+        @Override
+        public BsonDocument getSessionId() {
+            return wrapped.getSessionId();
+        }
+
+        @Override
+        public long advanceTransactionNumber() {
+            return wrapped.advanceTransactionNumber();
+        }
+
+        @Override
+        public void advanceOperationTime(final BsonTimestamp operationTime) {
+            wrapped.advanceOperationTime(operationTime);
+        }
+
+        @Override
+        public BsonDocument getClusterTime() {
+            return clusterClock.greaterOf(wrapped.getClusterTime());
+        }
+
+        @Override
+        public void advanceClusterTime(final BsonDocument clusterTime) {
+            wrapped.advanceClusterTime(clusterTime);
+            clusterClock.advance(clusterTime);
         }
     }
 }

--- a/driver-core/src/main/com/mongodb/connection/DefaultServerConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/DefaultServerConnection.java
@@ -27,6 +27,7 @@ import com.mongodb.bulk.InsertRequest;
 import com.mongodb.bulk.UpdateRequest;
 import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
+import com.mongodb.internal.connection.NoOpSessionContext;
 import org.bson.BsonDocument;
 import org.bson.FieldNameValidator;
 import org.bson.codecs.Decoder;
@@ -116,88 +117,138 @@ class DefaultServerConnection extends AbstractReferenceCounted implements Connec
     @Override
     public BulkWriteResult insertCommand(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
                                          final Boolean bypassDocumentValidation, final List<InsertRequest> inserts) {
-        return executeProtocol(new InsertCommandProtocol(namespace, ordered, writeConcern, bypassDocumentValidation, inserts));
+        return executeProtocol(new InsertCommandProtocol(namespace, ordered, writeConcern, bypassDocumentValidation, inserts),
+                NoOpSessionContext.INSTANCE);
+    }
+
+    @Override
+    public BulkWriteResult insertCommand(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
+                                         final Boolean bypassDocumentValidation, final List<InsertRequest> inserts,
+                                         final SessionContext sessionContext) {
+        return executeProtocol(new InsertCommandProtocol(namespace, ordered, writeConcern, bypassDocumentValidation, inserts),
+                sessionContext);
+
     }
 
     @Override
     public void insertCommandAsync(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
                                    final List<InsertRequest> inserts, final SingleResultCallback<BulkWriteResult> callback) {
-        insertCommandAsync(namespace, ordered, writeConcern, null, inserts, callback);
+        insertCommandAsync(namespace, ordered, writeConcern, null, inserts, NoOpSessionContext.INSTANCE, callback);
     }
 
     @Override
     public void insertCommandAsync(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
                                    final Boolean bypassDocumentValidation, final List<InsertRequest> inserts,
                                    final SingleResultCallback<BulkWriteResult> callback) {
-        executeProtocolAsync(new InsertCommandProtocol(namespace, ordered, writeConcern, bypassDocumentValidation, inserts), callback);
+        insertCommandAsync(namespace, ordered, writeConcern, bypassDocumentValidation, inserts, NoOpSessionContext.INSTANCE, callback);
+    }
+
+    @Override
+    public void insertCommandAsync(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
+                                   final Boolean bypassDocumentValidation, final List<InsertRequest> inserts,
+                                   final SessionContext sessionContext, final SingleResultCallback<BulkWriteResult> callback) {
+        executeProtocolAsync(new InsertCommandProtocol(namespace, ordered, writeConcern, bypassDocumentValidation, inserts),
+                sessionContext, callback);
     }
 
     @Override
     public BulkWriteResult updateCommand(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
                                          final List<UpdateRequest> updates) {
-        return updateCommand(namespace, ordered, writeConcern, null, updates);
+        return updateCommand(namespace, ordered, writeConcern, null, updates, NoOpSessionContext.INSTANCE);
     }
 
     @Override
     public BulkWriteResult updateCommand(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
                                          final Boolean bypassDocumentValidation, final List<UpdateRequest> updates) {
-        return executeProtocol(new UpdateCommandProtocol(namespace, ordered, writeConcern, bypassDocumentValidation, updates));
+        return executeProtocol(new UpdateCommandProtocol(namespace, ordered, writeConcern, bypassDocumentValidation, updates),
+                NoOpSessionContext.INSTANCE);
+    }
+
+    @Override
+    public BulkWriteResult updateCommand(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
+                                         final Boolean bypassDocumentValidation, final List<UpdateRequest> updates,
+                                         final SessionContext sessionContext) {
+        return executeProtocol(new UpdateCommandProtocol(namespace, ordered, writeConcern, bypassDocumentValidation, updates),
+                sessionContext);
     }
 
     @Override
     public void updateCommandAsync(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
                                    final List<UpdateRequest> updates, final SingleResultCallback<BulkWriteResult> callback) {
-        updateCommandAsync(namespace, ordered, writeConcern, null, updates, callback);
+        updateCommandAsync(namespace, ordered, writeConcern, null, updates, NoOpSessionContext.INSTANCE, callback);
     }
 
     @Override
     public void updateCommandAsync(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
                                    final Boolean bypassDocumentValidation, final List<UpdateRequest> updates,
                                    final SingleResultCallback<BulkWriteResult> callback) {
-        executeProtocolAsync(new UpdateCommandProtocol(namespace, ordered, writeConcern, bypassDocumentValidation, updates), callback);
+        updateCommandAsync(namespace, ordered, writeConcern, bypassDocumentValidation, updates, NoOpSessionContext.INSTANCE, callback);
+    }
+
+    @Override
+    public void updateCommandAsync(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
+                                   final Boolean bypassDocumentValidation, final List<UpdateRequest> updates,
+                                   final SessionContext sessionContext, final SingleResultCallback<BulkWriteResult> callback) {
+        executeProtocolAsync(new UpdateCommandProtocol(namespace, ordered, writeConcern, bypassDocumentValidation, updates), sessionContext,
+                callback);
     }
 
     @Override
     public BulkWriteResult deleteCommand(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
                                          final List<DeleteRequest> deletes) {
-        return executeProtocol(new DeleteCommandProtocol(namespace, ordered, writeConcern, deletes));
+        return executeProtocol(new DeleteCommandProtocol(namespace, ordered, writeConcern, deletes), NoOpSessionContext.INSTANCE);
+    }
 
+    @Override
+    public BulkWriteResult deleteCommand(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
+                                         final List<DeleteRequest> deletes, final SessionContext sessionContext) {
+        return executeProtocol(new DeleteCommandProtocol(namespace, ordered, writeConcern, deletes), sessionContext);
     }
 
     @Override
     public void deleteCommandAsync(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
                                    final List<DeleteRequest> deletes, final SingleResultCallback<BulkWriteResult> callback) {
-        executeProtocolAsync(new DeleteCommandProtocol(namespace, ordered, writeConcern, deletes), callback);
+        deleteCommandAsync(namespace, ordered, writeConcern, deletes, NoOpSessionContext.INSTANCE, callback);
+    }
+
+    @Override
+    public void deleteCommandAsync(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
+                                   final List<DeleteRequest> deletes, final SessionContext sessionContext,
+                                   final SingleResultCallback<BulkWriteResult> callback) {
+        executeProtocolAsync(new DeleteCommandProtocol(namespace, ordered, writeConcern, deletes), sessionContext, callback);
     }
 
     @Override
     public <T> T command(final String database, final BsonDocument command, final boolean slaveOk,
                          final FieldNameValidator fieldNameValidator,
                          final Decoder<T> commandResultDecoder) {
-        return command(database, command, getReadPreferenceFromSlaveOk(slaveOk), fieldNameValidator, commandResultDecoder);
+        return command(database, command, getReadPreferenceFromSlaveOk(slaveOk), fieldNameValidator, commandResultDecoder,
+                NoOpSessionContext.INSTANCE);
     }
 
     @Override
     public <T> T command(final String database, final BsonDocument command, final ReadPreference readPreference,
-                         final FieldNameValidator fieldNameValidator, final Decoder<T> commandResultDecoder) {
-        return executeProtocol(new CommandProtocol<T>(database, command, fieldNameValidator, commandResultDecoder)
-                                       .readPreference(readPreference));
+                         final FieldNameValidator fieldNameValidator, final Decoder<T> commandResultDecoder,
+                         final SessionContext sessionContext) {
+        return executeProtocol(new SimpleCommandProtocol<T>(database, command, fieldNameValidator, commandResultDecoder)
+                                       .readPreference(readPreference), sessionContext);
     }
 
     @Override
     public <T> void commandAsync(final String database, final BsonDocument command, final boolean slaveOk,
                                            final FieldNameValidator fieldNameValidator,
                                            final Decoder<T> commandResultDecoder, final SingleResultCallback<T> callback) {
-        commandAsync(database, command, getReadPreferenceFromSlaveOk(slaveOk), fieldNameValidator, commandResultDecoder, callback);
+        commandAsync(database, command, getReadPreferenceFromSlaveOk(slaveOk), fieldNameValidator, commandResultDecoder,
+                NoOpSessionContext.INSTANCE, callback);
     }
 
     @Override
     public <T> void commandAsync(final String database, final BsonDocument command, final ReadPreference readPreference,
                                  final FieldNameValidator fieldNameValidator, final Decoder<T> commandResultDecoder,
-                                 final SingleResultCallback<T> callback) {
-        executeProtocolAsync(new CommandProtocol<T>(database, command, fieldNameValidator, commandResultDecoder)
+                                 final SessionContext sessionContext, final SingleResultCallback<T> callback) {
+        executeProtocolAsync(new SimpleCommandProtocol<T>(database, command, fieldNameValidator, commandResultDecoder)
                                      .readPreference(readPreference),
-                callback);
+                sessionContext, callback);
     }
 
     @Override
@@ -303,14 +354,28 @@ class DefaultServerConnection extends AbstractReferenceCounted implements Connec
                || (clusterConnectionMode == ClusterConnectionMode.SINGLE && wrapped.getDescription().getServerType() != SHARD_ROUTER);
     }
 
-    private <T> T executeProtocol(final Protocol<T> protocol) {
+    private <T> T executeProtocol(final LegacyProtocol<T> protocol) {
         return protocolExecutor.execute(protocol, this.wrapped);
     }
 
-    private <T> void executeProtocolAsync(final Protocol<T> protocol, final SingleResultCallback<T> callback) {
+    private <T> T executeProtocol(final CommandProtocol<T> protocol, final SessionContext sessionContext) {
+        return protocolExecutor.execute(protocol, this.wrapped, sessionContext);
+    }
+
+    private <T> void executeProtocolAsync(final LegacyProtocol<T> protocol, final SingleResultCallback<T> callback) {
         SingleResultCallback<T> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
         try {
             protocolExecutor.executeAsync(protocol, this.wrapped, errHandlingCallback);
+        } catch (Throwable t) {
+            errHandlingCallback.onResult(null, t);
+        }
+    }
+
+    private <T> void executeProtocolAsync(final CommandProtocol<T> protocol, final SessionContext sessionContext,
+                                          final SingleResultCallback<T> callback) {
+        SingleResultCallback<T> errHandlingCallback = errorHandlingCallback(callback, LOGGER);
+        try {
+            protocolExecutor.executeAsync(protocol, this.wrapped, sessionContext, errHandlingCallback);
         } catch (Throwable t) {
             errHandlingCallback.onResult(null, t);
         }

--- a/driver-core/src/main/com/mongodb/connection/DeleteMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/DeleteMessage.java
@@ -27,7 +27,7 @@ import java.util.List;
  *
  * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-delete OP_DELETE
  */
-class DeleteMessage extends RequestMessage {
+class DeleteMessage extends LegacyMessage {
     private final List<DeleteRequest> deleteRequests;
 
     DeleteMessage(final String collectionName, final List<DeleteRequest> deletes, final MessageSettings settings) {

--- a/driver-core/src/main/com/mongodb/connection/GetMoreMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/GetMoreMessage.java
@@ -23,7 +23,7 @@ import org.bson.io.BsonOutput;
  *
  * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-get-more OP_GET_MORE
  */
-class GetMoreMessage extends RequestMessage {
+class GetMoreMessage extends LegacyMessage {
     private final long cursorId;
     private final int numberToReturn;
 

--- a/driver-core/src/main/com/mongodb/connection/GetMoreProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/GetMoreProtocol.java
@@ -22,6 +22,7 @@ import com.mongodb.async.SingleResultCallback;
 import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
 import com.mongodb.event.CommandListener;
+import com.mongodb.internal.connection.NoOpSessionContext;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonDouble;
@@ -46,7 +47,7 @@ import static java.lang.String.format;
  * @param <T> the type of document to decode query results to
  * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-query OP_QUERY
  */
-class GetMoreProtocol<T> implements Protocol<QueryResult<T>> {
+class GetMoreProtocol<T> implements LegacyProtocol<QueryResult<T>> {
 
     public static final Logger LOGGER = Loggers.getLogger("protocol.getmore");
     private static final String COMMAND_NAME = "getMore";
@@ -160,7 +161,7 @@ class GetMoreProtocol<T> implements Protocol<QueryResult<T>> {
                 sendCommandStartedEvent(message, namespace.getDatabaseName(), COMMAND_NAME, asGetMoreCommandDocument(),
                                         connection.getDescription(), commandListener);
             }
-            message.encode(bsonOutput);
+            message.encode(bsonOutput, NoOpSessionContext.INSTANCE);
             connection.sendMessage(bsonOutput.getByteBuffers(), message.getId());
         } finally {
             bsonOutput.close();

--- a/driver-core/src/main/com/mongodb/connection/InsertMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/InsertMessage.java
@@ -31,7 +31,7 @@ import java.util.List;
  *
  * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-insert OP_INSERT
  */
-class InsertMessage extends RequestMessage {
+class InsertMessage extends LegacyMessage {
 
     private final boolean ordered;
     private final WriteConcern writeConcern;

--- a/driver-core/src/main/com/mongodb/connection/InternalConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/InternalConnection.java
@@ -66,15 +66,19 @@ interface InternalConnection extends BufferProvider {
      * Send a command message to the server.
      *
      * @param message   the command message to send
+     * @param sessionContext the session context
      */
-    <T> T sendAndReceive(CommandMessage message, Decoder<T> decoder);
+    <T> T sendAndReceive(CommandMessage message, Decoder<T> decoder, SessionContext sessionContext);
 
     /**
      * Send a command message to the server.
      *
      * @param message   the command message to send
+     * @param sessionContext the session context
+     * @param callback the callback
      */
-    <T> void sendAndReceiveAsync(CommandMessage message, Decoder<T> decoder, SingleResultCallback<T> callback);
+    <T> void sendAndReceiveAsync(CommandMessage message, Decoder<T> decoder, SessionContext sessionContext,
+                                 SingleResultCallback<T> callback);
 
     /**
      * Send a message to the server. The connection may not make any attempt to validate the integrity of the message.

--- a/driver-core/src/main/com/mongodb/connection/KillCursorProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/KillCursorProtocol.java
@@ -21,6 +21,7 @@ import com.mongodb.async.SingleResultCallback;
 import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
 import com.mongodb.event.CommandListener;
+import com.mongodb.internal.connection.NoOpSessionContext;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonDouble;
@@ -40,7 +41,7 @@ import static java.lang.String.format;
  *
  * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-kill-cursors OP_KILL_CURSOR
  */
-class KillCursorProtocol implements Protocol<Void> {
+class KillCursorProtocol implements LegacyProtocol<Void> {
     public static final Logger LOGGER = Loggers.getLogger("protocol.killcursor");
     private static final String COMMAND_NAME = "killCursors";
 
@@ -68,7 +69,7 @@ class KillCursorProtocol implements Protocol<Void> {
                 sendCommandStartedEvent(message, namespace.getDatabaseName(), COMMAND_NAME, asCommandDocument(),
                                         connection.getDescription(), commandListener);
             }
-            message.encode(bsonOutput);
+            message.encode(bsonOutput, NoOpSessionContext.INSTANCE);
             connection.sendMessage(bsonOutput.getByteBuffers(), message.getId());
             if (commandListener != null && namespace != null) {
                 sendCommandSucceededEvent(message, COMMAND_NAME, asCommandResponseDocument(),
@@ -105,7 +106,7 @@ class KillCursorProtocol implements Protocol<Void> {
                 startEventSent = true;
             }
 
-            message.encode(bsonOutput);
+            message.encode(bsonOutput, NoOpSessionContext.INSTANCE);
             connection.sendMessageAsync(bsonOutput.getByteBuffers(), message.getId(), new SingleResultCallback<Void>() {
                 @Override
                 public void onResult(final Void result, final Throwable t) {

--- a/driver-core/src/main/com/mongodb/connection/KillCursorsMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/KillCursorsMessage.java
@@ -27,7 +27,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-kill-cursors OP_KILL_CURSOR
  */
-class KillCursorsMessage extends RequestMessage {
+class KillCursorsMessage extends LegacyMessage {
     private final List<Long> cursors;
 
     KillCursorsMessage(final List<Long> cursors) {

--- a/driver-core/src/main/com/mongodb/connection/LegacyMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/LegacyMessage.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.connection;
+
+import org.bson.io.BsonOutput;
+
+abstract class LegacyMessage extends RequestMessage {
+    LegacyMessage(final String collectionName, final OpCode opCode, final MessageSettings settings) {
+        super(collectionName, opCode, settings);
+    }
+
+    LegacyMessage(final OpCode opCode, final MessageSettings settings) {
+        super(opCode, settings);
+    }
+
+    abstract EncodingMetadata encodeMessageBodyWithMetadata(BsonOutput bsonOutput, int messageStartPosition);
+
+    protected EncodingMetadata encodeMessageBodyWithMetadata(final BsonOutput bsonOutput, final int messageStartPosition,
+                                                             final SessionContext sessionContext) {
+        return encodeMessageBodyWithMetadata(bsonOutput, messageStartPosition);
+    }
+}

--- a/driver-core/src/main/com/mongodb/connection/LegacyProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/LegacyProtocol.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2015 MongoDB, Inc.
+ * Copyright 2017 MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,6 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package com.mongodb.connection;
@@ -19,26 +20,10 @@ package com.mongodb.connection;
 import com.mongodb.async.SingleResultCallback;
 import com.mongodb.event.CommandListener;
 
-/**
- * An interface for the execution of a MongoDB wire protocol conversation
- *
- * @param <T> the return value of the Protocol response message
- */
-interface Protocol<T> {
-    /**
-     * Execute the protocol.
-     *
-     * @param connection the connection to execute the protocol on
-     * @return the response from execution of the protocol
-     */
+interface LegacyProtocol<T> {
+
     T execute(InternalConnection connection);
 
-    /**
-     * Execute the protocol asynchronously.
-     *
-     * @param connection the connection to execute the protocol on
-     * @param callback   the callback that is passed the result of the execution
-     */
     void executeAsync(InternalConnection connection, SingleResultCallback<T> callback);
 
     void setCommandListener(CommandListener commandListener);

--- a/driver-core/src/main/com/mongodb/connection/ProtocolExecutor.java
+++ b/driver-core/src/main/com/mongodb/connection/ProtocolExecutor.java
@@ -19,7 +19,12 @@ package com.mongodb.connection;
 import com.mongodb.async.SingleResultCallback;
 
 interface ProtocolExecutor {
-    <T> T execute(Protocol<T> protocol, InternalConnection connection);
+    <T> T execute(LegacyProtocol<T> protocol, InternalConnection connection);
 
-    <T> void executeAsync(Protocol<T> protocol, InternalConnection connection, SingleResultCallback<T> callback);
+    <T> void executeAsync(LegacyProtocol<T> protocol, InternalConnection connection, SingleResultCallback<T> callback);
+
+    <T> T execute(CommandProtocol<T> protocol, InternalConnection connection, SessionContext sessionContext);
+
+    <T> void executeAsync(CommandProtocol<T> protocol, InternalConnection connection, SessionContext sessionContext,
+                          SingleResultCallback<T> callback);
 }

--- a/driver-core/src/main/com/mongodb/connection/QueryProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/QueryProtocol.java
@@ -21,6 +21,7 @@ import com.mongodb.async.SingleResultCallback;
 import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
 import com.mongodb.event.CommandListener;
+import com.mongodb.internal.connection.NoOpSessionContext;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
@@ -51,7 +52,7 @@ import static java.lang.String.format;
  * @param <T> the type of document to decode query results to
  * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-query OP_QUERY
  */
-class QueryProtocol<T> implements Protocol<QueryResult<T>> {
+class QueryProtocol<T> implements LegacyProtocol<QueryResult<T>> {
 
     public static final Logger LOGGER = Loggers.getLogger("protocol.query");
     private static final String FIND_COMMAND_NAME = "find";
@@ -268,7 +269,7 @@ class QueryProtocol<T> implements Protocol<QueryResult<T>> {
             ByteBufferBsonOutput bsonOutput = new ByteBufferBsonOutput(connection);
             try {
                 message = createQueryMessage(connection.getDescription());
-                message.encode(bsonOutput);
+                message.encode(bsonOutput, NoOpSessionContext.INSTANCE);
                 isExplain = sendQueryStartedEvent(connection, message, bsonOutput, message.getEncodingMetadata());
                 connection.sendMessage(bsonOutput.getByteBuffers(), message.getId());
             } finally {

--- a/driver-core/src/main/com/mongodb/connection/ReplyMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/ReplyMessage.java
@@ -43,14 +43,18 @@ class ReplyMessage<T> {
         this(responseBuffers.getReplyHeader(), requestId);
 
         if (replyHeader.getNumberReturned() > 0) {
-            BsonInput bsonInput = new ByteBufferBsonInput(responseBuffers.getBodyByteBuffer());
-            while (documents.size() < replyHeader.getNumberReturned()) {
-                BsonBinaryReader reader = new BsonBinaryReader(bsonInput);
-                try {
-                    documents.add(decoder.decode(reader, DecoderContext.builder().build()));
-                } finally {
-                    reader.close();
+            try {
+                BsonInput bsonInput = new ByteBufferBsonInput(responseBuffers.getBodyByteBuffer());
+                while (documents.size() < replyHeader.getNumberReturned()) {
+                    BsonBinaryReader reader = new BsonBinaryReader(bsonInput);
+                    try {
+                        documents.add(decoder.decode(reader, DecoderContext.builder().build()));
+                    } finally {
+                        reader.close();
+                    }
                 }
+            } finally {
+               responseBuffers.reset();
             }
         }
     }

--- a/driver-core/src/main/com/mongodb/connection/RequestMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/RequestMessage.java
@@ -34,6 +34,7 @@ import org.bson.io.BsonOutput;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.mongodb.assertions.Assertions.notNull;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 
 /**
@@ -141,11 +142,13 @@ abstract class RequestMessage {
      * Encoded the message to the given output.
      *
      * @param bsonOutput the output
+     * @param sessionContext the session context
      */
-    public void encode(final BsonOutput bsonOutput) {
+    public void encode(final BsonOutput bsonOutput, final SessionContext sessionContext) {
+        notNull("sessionContext", sessionContext);
         int messageStartPosition = bsonOutput.getPosition();
         writeMessagePrologue(bsonOutput);
-        EncodingMetadata encodingMetadata = encodeMessageBodyWithMetadata(bsonOutput, messageStartPosition);
+        EncodingMetadata encodingMetadata = encodeMessageBodyWithMetadata(bsonOutput, messageStartPosition, sessionContext);
         backpatchMessageLength(messageStartPosition, bsonOutput);
         this.encodingMetadata = encodingMetadata;
     }
@@ -178,7 +181,8 @@ abstract class RequestMessage {
      * @param messageStartPosition the start position of the message
      * @return the encoding metadata
      */
-    protected abstract EncodingMetadata encodeMessageBodyWithMetadata(BsonOutput bsonOutput, int messageStartPosition);
+    protected abstract EncodingMetadata encodeMessageBodyWithMetadata(BsonOutput bsonOutput, int messageStartPosition,
+                                                                      SessionContext sessionContext);
 
     /**
      * Appends a document to the message.

--- a/driver-core/src/main/com/mongodb/connection/SessionContext.java
+++ b/driver-core/src/main/com/mongodb/connection/SessionContext.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.connection;
+
+import org.bson.BsonDocument;
+import org.bson.BsonTimestamp;
+
+/**
+ * The session context.
+ *
+ * @since 3.6
+ */
+public interface SessionContext {
+
+    /**
+     * Returns true if there is a true server session associated with this context.
+     *
+     * @return true if there is a true server session associated with this context.
+     */
+    boolean hasSession();
+
+    /**
+     *
+     * @return the session id
+     */
+    BsonDocument getSessionId();
+
+    /**
+     *
+     * @return the next transaction number for the session
+     */
+    long advanceTransactionNumber();
+
+    /**
+     * @param operationTime the new operation time time
+     */
+    void advanceOperationTime(BsonTimestamp operationTime);
+
+    /**
+     * @return the cluster time
+     */
+    BsonDocument getClusterTime();
+
+    /**
+     * @param clusterTime the new cluster time
+     */
+    void advanceClusterTime(BsonDocument clusterTime);
+}

--- a/driver-core/src/main/com/mongodb/connection/SimpleCommandMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/SimpleCommandMessage.java
@@ -54,7 +54,7 @@ class SimpleCommandMessage extends CommandMessage {
     }
 
     @Override
-    protected EncodingMetadata encodeMessageBodyWithMetadata(final BsonOutput bsonOutput, final int messageStartPosition) {
+    protected EncodingMetadata encodeMessageBodyWithMetadata(final BsonOutput bsonOutput, final SessionContext sessionContext) {
         BsonDocument commandToEncode;
         List<BsonElement> extraElements = null;
         if (useOpMsg()) {
@@ -63,6 +63,12 @@ class SimpleCommandMessage extends CommandMessage {
 
             extraElements = new ArrayList<BsonElement>();
             extraElements.add(new BsonElement("$db", new BsonString(new MongoNamespace(getCollectionName()).getDatabaseName())));
+            if (sessionContext.hasSession()) {
+                if (sessionContext.getClusterTime() != null) {
+                    extraElements.add(new BsonElement("$clusterTime", sessionContext.getClusterTime()));
+                }
+                extraElements.add(new BsonElement("lsid", sessionContext.getSessionId()));
+            }
             if (!isDefaultReadPreference()) {
                 extraElements.add(new BsonElement("$readPreference", readPreference.toDocument()));
             }

--- a/driver-core/src/main/com/mongodb/connection/SimpleCommandProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/SimpleCommandProtocol.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2008-2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.connection;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.ReadPreference;
+import com.mongodb.async.SingleResultCallback;
+import com.mongodb.diagnostics.logging.Logger;
+import com.mongodb.diagnostics.logging.Loggers;
+import org.bson.BsonDocument;
+import org.bson.FieldNameValidator;
+import org.bson.codecs.Decoder;
+
+import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.connection.ProtocolHelper.getMessageSettings;
+import static java.lang.String.format;
+
+/**
+ * A protocol for executing a command against a MongoDB server using the OP_QUERY wire protocol message.
+ *
+ * @param <T> the type returned from execution
+ * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-query OP_QUERY
+ */
+class SimpleCommandProtocol<T> implements CommandProtocol<T> {
+
+    public static final Logger LOGGER = Loggers.getLogger("protocol.command");
+
+    private final MongoNamespace namespace;
+    private final BsonDocument command;
+    private final Decoder<T> commandResultDecoder;
+    private final FieldNameValidator fieldNameValidator;
+    private SessionContext sessionContext;
+    private ReadPreference readPreference;
+
+    SimpleCommandProtocol(final String database, final BsonDocument command, final FieldNameValidator fieldNameValidator,
+                          final Decoder<T> commandResultDecoder) {
+        notNull("database", database);
+        this.namespace = new MongoNamespace(database, MongoNamespace.COMMAND_COLLECTION_NAME);
+        this.command = notNull("command", command);
+        this.commandResultDecoder = notNull("commandResultDecoder", commandResultDecoder);
+        this.fieldNameValidator = notNull("fieldNameValidator", fieldNameValidator);
+    }
+
+    public SimpleCommandProtocol<T> readPreference(final ReadPreference readPreference) {
+        this.readPreference = readPreference;
+        return this;
+    }
+
+    @Override
+    public T execute(final InternalConnection connection) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(format("Sending command {%s : %s} to database %s on connection [%s] to server %s",
+                                getCommandName(), command.values().iterator().next(),
+                                namespace.getDatabaseName(), connection.getDescription().getConnectionId(),
+                                connection.getDescription().getServerAddress()));
+        }
+        SimpleCommandMessage commandMessage = new SimpleCommandMessage(namespace.getFullName(), command, readPreference, fieldNameValidator,
+                                                                              getMessageSettings(connection.getDescription()));
+        T retval = connection.sendAndReceive(commandMessage, commandResultDecoder, sessionContext);
+        LOGGER.debug("Command execution completed");
+        return retval;
+    }
+
+    @Override
+    public void executeAsync(final InternalConnection connection, final SingleResultCallback<T> callback) {
+        final SimpleCommandMessage message = new SimpleCommandMessage(namespace.getFullName(), command, readPreference, fieldNameValidator,
+                                                                             getMessageSettings(connection.getDescription()));
+        try {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug(format("Asynchronously sending command {%s : %s} to database %s on connection [%s] to server %s",
+                                    getCommandName(), command.values().iterator().next(),
+                                    namespace.getDatabaseName(), connection.getDescription().getConnectionId(),
+                                    connection.getDescription().getServerAddress()));
+            }
+            connection.sendAndReceiveAsync(message, commandResultDecoder, sessionContext, new SingleResultCallback<T>() {
+                @Override
+                public void onResult(final T result, final Throwable t) {
+                    if (t != null) {
+                        callback.onResult(null, t);
+                    } else {
+                        callback.onResult(result, null);
+                    }
+                }
+            });
+        } catch (Throwable t) {
+            callback.onResult(null, t);
+        }
+    }
+
+    @Override
+    public SimpleCommandProtocol<T> sessionContext(final SessionContext sessionContext) {
+        this.sessionContext = sessionContext;
+        return this;
+    }
+
+    private String getCommandName() {
+        return command.keySet().iterator().next();
+    }
+}

--- a/driver-core/src/main/com/mongodb/connection/UpdateMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/UpdateMessage.java
@@ -31,7 +31,7 @@ import static com.mongodb.bulk.WriteRequest.Type.REPLACE;
  *
  * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-update OP_UPDATE
  */
-class UpdateMessage extends RequestMessage {
+class UpdateMessage extends LegacyMessage {
     private final List<UpdateRequest> updates;
 
     UpdateMessage(final String collectionName, final List<UpdateRequest> updates, final MessageSettings settings) {

--- a/driver-core/src/main/com/mongodb/connection/UsageTrackingInternalConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/UsageTrackingInternalConnection.java
@@ -93,15 +93,15 @@ class UsageTrackingInternalConnection implements InternalConnection {
     }
 
     @Override
-    public <T> T sendAndReceive(final CommandMessage message, final Decoder<T> decoder) {
-        T result = wrapped.sendAndReceive(message, decoder);
+    public <T> T sendAndReceive(final CommandMessage message, final Decoder<T> decoder, final SessionContext sessionContext) {
+        T result = wrapped.sendAndReceive(message, decoder, sessionContext);
         lastUsedAt = System.currentTimeMillis();
         return result;
     }
 
     @Override
     public <T> void sendAndReceiveAsync(final CommandMessage message, final Decoder<T> decoder,
-                                    final SingleResultCallback<T> callback) {
+                                        final SessionContext sessionContext, final SingleResultCallback<T> callback) {
         SingleResultCallback<T> errHandlingCallback = errorHandlingCallback(new SingleResultCallback<T>() {
             @Override
             public void onResult(final T result, final Throwable t) {
@@ -109,7 +109,7 @@ class UsageTrackingInternalConnection implements InternalConnection {
                 callback.onResult(result, t);
             }
         }, LOGGER);
-        wrapped.sendAndReceiveAsync(message, decoder, errHandlingCallback);
+        wrapped.sendAndReceiveAsync(message, decoder, sessionContext, errHandlingCallback);
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/connection/NoOpSessionContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/NoOpSessionContext.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.internal.connection;
+
+import com.mongodb.connection.SessionContext;
+import org.bson.BsonDocument;
+import org.bson.BsonTimestamp;
+
+/**
+ * A SessionContext implementation that does nothing and reports that it has no session.
+ *
+ * <p>This class should not be considered a part of the public API.</p>
+ */
+public final class NoOpSessionContext implements SessionContext {
+
+    /**
+     * A singleton instance of a NoOpSessionContext
+     */
+    public static final NoOpSessionContext INSTANCE = new NoOpSessionContext();
+
+    @Override
+    public boolean hasSession() {
+        return false;
+    }
+
+    @Override
+    public BsonDocument getSessionId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long advanceTransactionNumber() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void advanceOperationTime(final BsonTimestamp operationTime) {
+    }
+
+    @Override
+    public BsonDocument getClusterTime() {
+        return null;
+    }
+
+    @Override
+    public void advanceClusterTime(final BsonDocument clusterTime) {
+    }
+
+    private NoOpSessionContext() {
+    }
+}

--- a/driver-core/src/main/com/mongodb/operation/AsyncQueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/AsyncQueryBatchCursor.java
@@ -164,7 +164,7 @@ class AsyncQueryBatchCursor<T> implements AsyncBatchCursor<T> {
         if (serverIsAtLeastVersionThreeDotTwo(connection.getDescription())) {
             connection.commandAsync(namespace.getDatabaseName(), asGetMoreCommandDocument(cursor.getId()), ReadPreference.primary(),
                                     new NoOpFieldNameValidator(), CommandResultDocumentCodec.create(decoder, "nextBatch"),
-                                    new CommandResultSingleResultCallback(connection, cursor, callback, tryNext));
+                    connectionSource.getSessionContext(), new CommandResultSingleResultCallback(connection, cursor, callback, tryNext));
 
         } else {
             connection.getMoreAsync(namespace, cursor.getId(), getNumberToReturn(limit, batchSize, count),
@@ -216,7 +216,8 @@ class AsyncQueryBatchCursor<T> implements AsyncBatchCursor<T> {
     private void killCursorAsynchronouslyAndReleaseConnectionAndSource(final AsyncConnection connection, final ServerCursor localCursor) {
         if (serverIsAtLeastVersionThreeDotTwo(connection.getDescription())) {
             connection.commandAsync(namespace.getDatabaseName(), asKillCursorsCommandDocument(localCursor), ReadPreference.primary(),
-                    new NoOpFieldNameValidator(), new BsonDocumentCodec(), new SingleResultCallback<BsonDocument>() {
+                    new NoOpFieldNameValidator(), new BsonDocumentCodec(), connectionSource.getSessionContext(),
+                    new SingleResultCallback<BsonDocument>() {
                         @Override
                         public void onResult(final BsonDocument result, final Throwable t) {
                             connection.release();

--- a/driver-core/src/main/com/mongodb/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/CommandOperationHelper.java
@@ -60,13 +60,6 @@ final class CommandOperationHelper {
         }
     }
 
-    static class VoidTransformer<T> implements CommandTransformer<T, Void> {
-        @Override
-        public Void apply(final T t, final ServerAddress serverAddress) {
-            return null;
-        }
-    }
-
     /* Read Binding Helpers */
 
     static BsonDocument executeWrappedCommandProtocol(final ReadBinding binding, final String database, final BsonDocument command) {

--- a/driver-core/src/main/com/mongodb/operation/DeleteOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DeleteOperation.java
@@ -25,6 +25,7 @@ import com.mongodb.bulk.DeleteRequest;
 import com.mongodb.bulk.WriteRequest;
 import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.Connection;
+import com.mongodb.connection.SessionContext;
 
 import java.util.List;
 
@@ -87,20 +88,21 @@ public class DeleteOperation extends BaseWriteOperation {
     }
 
     @Override
-    protected BulkWriteResult executeCommandProtocol(final Connection connection) {
+    protected BulkWriteResult executeCommandProtocol(final Connection connection, final SessionContext sessionContext) {
         validateWriteRequestCollations(connection, deleteRequests, getWriteConcern());
-        return connection.deleteCommand(getNamespace(), isOrdered(), getWriteConcern(), deleteRequests);
+        return connection.deleteCommand(getNamespace(), isOrdered(), getWriteConcern(), deleteRequests, sessionContext);
     }
 
     @Override
-    protected void executeCommandProtocolAsync(final AsyncConnection connection, final SingleResultCallback<BulkWriteResult> callback) {
+    protected void executeCommandProtocolAsync(final AsyncConnection connection, final SessionContext sessionContext,
+                                               final SingleResultCallback<BulkWriteResult> callback) {
         validateWriteRequestCollations(connection, deleteRequests, getWriteConcern(), new AsyncCallableWithConnection(){
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
                 if (t != null) {
                     callback.onResult(null, t);
                 } else {
-                    connection.deleteCommandAsync(getNamespace(), isOrdered(), getWriteConcern(), deleteRequests, callback);
+                    connection.deleteCommandAsync(getNamespace(), isOrdered(), getWriteConcern(), deleteRequests, sessionContext, callback);
                 }
             }
         });

--- a/driver-core/src/main/com/mongodb/operation/InsertOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/InsertOperation.java
@@ -25,6 +25,7 @@ import com.mongodb.bulk.InsertRequest;
 import com.mongodb.bulk.WriteRequest;
 import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.Connection;
+import com.mongodb.connection.SessionContext;
 
 import java.util.List;
 
@@ -74,14 +75,16 @@ public class InsertOperation extends BaseWriteOperation {
     }
 
     @Override
-    protected BulkWriteResult executeCommandProtocol(final Connection connection) {
-        return connection.insertCommand(getNamespace(), isOrdered(), getWriteConcern(), getBypassDocumentValidation(), insertRequests);
+    protected BulkWriteResult executeCommandProtocol(final Connection connection, final SessionContext sessionContext) {
+        return connection.insertCommand(getNamespace(), isOrdered(), getWriteConcern(), getBypassDocumentValidation(), insertRequests,
+                sessionContext);
     }
 
     @Override
-    protected void executeCommandProtocolAsync(final AsyncConnection connection, final SingleResultCallback<BulkWriteResult> callback) {
+    protected void executeCommandProtocolAsync(final AsyncConnection connection, final SessionContext sessionContext,
+                                               final SingleResultCallback<BulkWriteResult> callback) {
         connection.insertCommandAsync(getNamespace(), isOrdered(), getWriteConcern(), getBypassDocumentValidation(), insertRequests,
-                callback);
+                sessionContext, callback);
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/operation/QueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/QueryBatchCursor.java
@@ -212,7 +212,8 @@ class QueryBatchCursor<T> implements BatchCursor<T> {
                                                              asGetMoreCommandDocument(),
                                                              ReadPreference.primary(),
                                                              new NoOpFieldNameValidator(),
-                                                             CommandResultDocumentCodec.create(decoder, "nextBatch")));
+                                                             CommandResultDocumentCodec.create(decoder, "nextBatch"),
+                                                             connectionSource.getSessionContext()));
                 } catch (MongoCommandException e) {
                     throw translateCommandException(e, serverCursor);
                 }
@@ -277,7 +278,7 @@ class QueryBatchCursor<T> implements BatchCursor<T> {
             notNull("connection", connection);
             if (serverIsAtLeastVersionThreeDotTwo(connection.getDescription())) {
                 connection.command(namespace.getDatabaseName(), asKillCursorsCommandDocument(), ReadPreference.primary(),
-                        new NoOpFieldNameValidator(), new BsonDocumentCodec());
+                        new NoOpFieldNameValidator(), new BsonDocumentCodec(), connectionSource.getSessionContext());
             } else {
                 connection.killCursor(namespace, singletonList(serverCursor.getId()));
             }

--- a/driver-core/src/main/com/mongodb/operation/UpdateOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/UpdateOperation.java
@@ -25,6 +25,7 @@ import com.mongodb.bulk.UpdateRequest;
 import com.mongodb.bulk.WriteRequest;
 import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.Connection;
+import com.mongodb.connection.SessionContext;
 
 import java.util.List;
 
@@ -86,13 +87,15 @@ public class UpdateOperation extends BaseWriteOperation {
     }
 
     @Override
-    protected BulkWriteResult executeCommandProtocol(final Connection connection) {
+    protected BulkWriteResult executeCommandProtocol(final Connection connection, final SessionContext sessionContext) {
         validateWriteRequestCollations(connection, updates, getWriteConcern());
-        return connection.updateCommand(getNamespace(), isOrdered(), getWriteConcern(), getBypassDocumentValidation(), updates);
+        return connection.updateCommand(getNamespace(), isOrdered(), getWriteConcern(), getBypassDocumentValidation(), updates,
+                sessionContext);
     }
 
     @Override
-    protected void executeCommandProtocolAsync(final AsyncConnection connection, final SingleResultCallback<BulkWriteResult> callback) {
+    protected void executeCommandProtocolAsync(final AsyncConnection connection, final SessionContext sessionContext,
+                                               final SingleResultCallback<BulkWriteResult> callback) {
         validateWriteRequestCollations(connection, updates, getWriteConcern(), new AsyncCallableWithConnection(){
             @Override
             public void call(final AsyncConnection connection, final Throwable t) {
@@ -100,7 +103,7 @@ public class UpdateOperation extends BaseWriteOperation {
                     callback.onResult(null, t);
                 } else {
                     connection.updateCommandAsync(getNamespace(), isOrdered(), getWriteConcern(), getBypassDocumentValidation(), updates,
-                            callback);
+                            sessionContext, callback);
                 }
             }
         });

--- a/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
@@ -195,9 +195,9 @@ class OperationFunctionalSpecification extends Specification {
         }
 
         if (checkCommand) {
-            1 * connection.command(_, expectedCommand, _, _, _) >> { result }
+            1 * connection.command(_, expectedCommand, _, _, _, _) >> { result }
         } else if (checkSlaveOk) {
-            1 * connection.command(_, _, readPreference, _, _) >> { result }
+            1 * connection.command(_, _, readPreference, _, _, _) >> { result }
         }
 
         0 * connection.command(_, _, _, _, _) >> {
@@ -236,9 +236,9 @@ class OperationFunctionalSpecification extends Specification {
         def callback = new FutureResultCallback()
 
         if (checkCommand) {
-            1 * connection.commandAsync(_, expectedCommand, _, _, _, _) >> { it[5].onResult(result, null) }
+            1 * connection.commandAsync(_, expectedCommand, _, _, _, _, _) >> { it[6].onResult(result, null) }
         } else if (checkSlaveOk) {
-            1 * connection.commandAsync(_, _, readPreference, _, _, _) >> { it[5].onResult(result, null) }
+            1 * connection.commandAsync(_, _, readPreference, _, _, _, _) >> { it[6].onResult(result, null) }
         }
 
         0 * connection.commandAsync(_, _, _, _, _, _) >> {

--- a/driver-core/src/test/functional/com/mongodb/binding/AsyncSingleConnectionBinding.java
+++ b/driver-core/src/test/functional/com/mongodb/binding/AsyncSingleConnectionBinding.java
@@ -24,6 +24,8 @@ import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.Cluster;
 import com.mongodb.connection.Server;
 import com.mongodb.connection.ServerDescription;
+import com.mongodb.connection.SessionContext;
+import com.mongodb.internal.connection.NoOpSessionContext;
 import com.mongodb.selector.ReadPreferenceServerSelector;
 import com.mongodb.selector.WritableServerSelector;
 
@@ -149,6 +151,11 @@ public class AsyncSingleConnectionBinding extends AbstractReferenceCounted imple
     }
 
     @Override
+    public SessionContext getSessionContext() {
+        return NoOpSessionContext.INSTANCE;
+    }
+
+    @Override
     public void getReadConnectionSource(final SingleResultCallback<AsyncConnectionSource> callback) {
         isTrue("open", getCount() > 0);
         if (readPreference == primary()) {
@@ -186,6 +193,11 @@ public class AsyncSingleConnectionBinding extends AbstractReferenceCounted imple
         @Override
         public ServerDescription getServerDescription() {
             return server.getDescription();
+        }
+
+        @Override
+        public SessionContext getSessionContext() {
+            return NoOpSessionContext.INSTANCE;
         }
 
         @Override

--- a/driver-core/src/test/functional/com/mongodb/binding/SingleConnectionBinding.java
+++ b/driver-core/src/test/functional/com/mongodb/binding/SingleConnectionBinding.java
@@ -21,6 +21,8 @@ import com.mongodb.connection.Cluster;
 import com.mongodb.connection.Connection;
 import com.mongodb.connection.Server;
 import com.mongodb.connection.ServerDescription;
+import com.mongodb.connection.SessionContext;
+import com.mongodb.internal.connection.NoOpSessionContext;
 import com.mongodb.selector.ReadPreferenceServerSelector;
 import com.mongodb.selector.WritableServerSelector;
 
@@ -103,6 +105,11 @@ public class SingleConnectionBinding implements ReadWriteBinding {
     }
 
     @Override
+    public SessionContext getSessionContext() {
+        return NoOpSessionContext.INSTANCE;
+    }
+
+    @Override
     public ConnectionSource getWriteConnectionSource() {
         isTrue("open", getCount() > 0);
         return new SingleConnectionSource(writeServer, writeConnection);
@@ -122,6 +129,11 @@ public class SingleConnectionBinding implements ReadWriteBinding {
         @Override
         public ServerDescription getServerDescription() {
             return server.getDescription();
+        }
+
+        @Override
+        public SessionContext getSessionContext() {
+            return NoOpSessionContext.INSTANCE;
         }
 
         @Override

--- a/driver-core/src/test/functional/com/mongodb/connection/ProtocolTestHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/connection/ProtocolTestHelper.java
@@ -22,7 +22,19 @@ import com.mongodb.async.FutureResultCallback;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 final class ProtocolTestHelper {
-    public static <T> T execute(final Protocol<T> protocol, final InternalConnection connection, final boolean async) throws Throwable{
+    public static <T> T execute(final LegacyProtocol<T> protocol, final InternalConnection connection, final boolean async)
+            throws Throwable{
+        if (async) {
+            final FutureResultCallback<T> futureResultCallback = new FutureResultCallback<T>();
+            protocol.executeAsync(connection, futureResultCallback);
+            return futureResultCallback.get(ClusterFixture.TIMEOUT, SECONDS);
+        } else {
+            return protocol.execute(connection);
+        }
+    }
+
+    public static <T> T execute(final CommandProtocol<T> protocol, final InternalConnection connection, final boolean async)
+            throws Throwable{
         if (async) {
             final FutureResultCallback<T> futureResultCallback = new FutureResultCallback<T>();
             protocol.executeAsync(connection, futureResultCallback);

--- a/driver-core/src/test/functional/com/mongodb/connection/WriteProtocolCommandEventSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/WriteProtocolCommandEventSpecification.groovy
@@ -26,6 +26,7 @@ import com.mongodb.bulk.UpdateRequest
 import com.mongodb.connection.netty.NettyStreamFactory
 import com.mongodb.event.CommandStartedEvent
 import com.mongodb.event.CommandSucceededEvent
+import com.mongodb.internal.connection.NoOpSessionContext
 import com.mongodb.internal.validator.NoOpFieldNameValidator
 import org.bson.BsonArray
 import org.bson.BsonBinary
@@ -89,9 +90,10 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
 
         cleanup:
         // force acknowledgement
-        new CommandProtocol(getDatabaseName(), new BsonDocument('drop', new BsonString(getCollectionName())),
+        new SimpleCommandProtocol(getDatabaseName(), new BsonDocument('drop', new BsonString(getCollectionName())),
                             new NoOpFieldNameValidator(), new BsonDocumentCodec())
                 .readPreference(ReadPreference.primary())
+                .sessionContext(NoOpSessionContext.INSTANCE)
                 .execute(connection)
 
         where:
@@ -139,9 +141,10 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
 
         cleanup:
         // force acknowledgement
-        new CommandProtocol(getDatabaseName(), new BsonDocument('drop', new BsonString(getCollectionName())),
+        new SimpleCommandProtocol(getDatabaseName(), new BsonDocument('drop', new BsonString(getCollectionName())),
                             new NoOpFieldNameValidator(), new BsonDocumentCodec())
                 .readPreference(ReadPreference.primary())
+                .sessionContext(NoOpSessionContext.INSTANCE)
                 .execute(connection)
 
         where:
@@ -176,9 +179,10 @@ class WriteProtocolCommandEventSpecification extends OperationFunctionalSpecific
 
         cleanup:
         // force acknowledgement
-        new CommandProtocol(getDatabaseName(), new BsonDocument('drop', new BsonString(getCollectionName())),
+        new SimpleCommandProtocol(getDatabaseName(), new BsonDocument('drop', new BsonString(getCollectionName())),
                             new NoOpFieldNameValidator(), new BsonDocumentCodec())
                 .readPreference(ReadPreference.primary())
+                .sessionContext(NoOpSessionContext.INSTANCE)
                 .execute(connection)
 
         where:

--- a/driver-core/src/test/functional/com/mongodb/connection/WriteProtocolSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/connection/WriteProtocolSpecification.groovy
@@ -22,6 +22,7 @@ import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.ReadPreference
 import com.mongodb.bulk.InsertRequest
 import com.mongodb.connection.netty.NettyStreamFactory
+import com.mongodb.internal.connection.NoOpSessionContext
 import com.mongodb.internal.validator.NoOpFieldNameValidator
 import org.bson.BsonBinary
 import org.bson.BsonDocument
@@ -74,9 +75,10 @@ class WriteProtocolSpecification extends OperationFunctionalSpecification {
 
         cleanup:
         // force acknowledgement
-        new CommandProtocol(getDatabaseName(), new BsonDocument('drop', new BsonString(getCollectionName())),
+        new SimpleCommandProtocol(getDatabaseName(), new BsonDocument('drop', new BsonString(getCollectionName())),
                             new NoOpFieldNameValidator(), new BsonDocumentCodec())
                 .readPreference(ReadPreference.primary())
+                .sessionContext(NoOpSessionContext.INSTANCE)
                 .execute(connection)
 
         where:
@@ -100,9 +102,10 @@ class WriteProtocolSpecification extends OperationFunctionalSpecification {
         when:
         execute(protocol, connection, async)
         // force acknowledgement
-        new CommandProtocol(getDatabaseName(), new BsonDocument('ping', new BsonInt32(1)),
+        new SimpleCommandProtocol(getDatabaseName(), new BsonDocument('ping', new BsonInt32(1)),
                 new NoOpFieldNameValidator(), new BsonDocumentCodec())
                 .readPreference(ReadPreference.primary())
+                .sessionContext(NoOpSessionContext.INSTANCE)
                 .execute(connection)
 
         then:
@@ -130,9 +133,10 @@ class WriteProtocolSpecification extends OperationFunctionalSpecification {
         when:
         execute(protocol, connection, async)
         // force acknowledgement
-        new CommandProtocol(getDatabaseName(), new BsonDocument('ping', new BsonInt32(1)),
+        new SimpleCommandProtocol(getDatabaseName(), new BsonDocument('ping', new BsonInt32(1)),
                 new NoOpFieldNameValidator(), new BsonDocumentCodec())
                 .readPreference(ReadPreference.primary())
+                .sessionContext(NoOpSessionContext.INSTANCE)
                 .execute(connection)
 
         then:
@@ -160,9 +164,10 @@ class WriteProtocolSpecification extends OperationFunctionalSpecification {
         when:
         execute(protocol, connection, async)
         // force acknowledgement
-        new CommandProtocol(getDatabaseName(), new BsonDocument('ping', new BsonInt32(1)),
+        new SimpleCommandProtocol(getDatabaseName(), new BsonDocument('ping', new BsonInt32(1)),
                 new NoOpFieldNameValidator(), new BsonDocumentCodec())
                 .readPreference(ReadPreference.primary())
+                .sessionContext(NoOpSessionContext.INSTANCE)
                 .execute(connection)
 
         then:

--- a/driver-core/src/test/functional/com/mongodb/operation/AsyncQueryBatchCursorFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/AsyncQueryBatchCursorFunctionalSpecification.groovy
@@ -367,8 +367,9 @@ class AsyncQueryBatchCursorFunctionalSpecification extends OperationFunctionalSp
 
             def futureResultCallback = new FutureResultCallback<BsonDocument>();
             connection.commandAsync(getDatabaseName(), findCommand,
-                                    ReadPreference.secondaryPreferred(), new NoOpFieldNameValidator(),
-                                    CommandResultDocumentCodec.create(new DocumentCodec(), 'firstBatch'), futureResultCallback)
+                    ReadPreference.secondaryPreferred(), new NoOpFieldNameValidator(),
+                    CommandResultDocumentCodec.create(new DocumentCodec(), 'firstBatch'), binding.sessionContext,
+                    futureResultCallback)
             def response = futureResultCallback.get(60, SECONDS)
             cursorDocumentToQueryResult(response.getDocument('cursor'), connection.getDescription().getServerAddress())
         } else {

--- a/driver-core/src/test/functional/com/mongodb/operation/ListCollectionsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ListCollectionsOperationSpecification.groovy
@@ -405,7 +405,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
         then:
         _ * connection.getDescription() >> helper.threeZeroConnectionDescription
-        1 * connection.command(_, _, readPreference, _, _) >> helper.commandResult
+        1 * connection.command(_, _, readPreference, _, _, _) >> helper.commandResult
         1 * connection.release()
 
         where:
@@ -437,7 +437,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
 
         then:
         _ * connection.getDescription() >> helper.threeZeroConnectionDescription
-        1 * connection.commandAsync(helper.dbName, _, readPreference, _, _, _) >> { it[6].onResult(helper.commandResult, _) }
+        1 * connection.commandAsync(helper.dbName, _, readPreference, _, _, _, _) >> { it[6].onResult(helper.commandResult, _) }
 
         where:
         readPreference << [ReadPreference.primary(), ReadPreference.secondary()]

--- a/driver-core/src/test/functional/com/mongodb/operation/ListDatabasesOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ListDatabasesOperationSpecification.groovy
@@ -129,7 +129,7 @@ class ListDatabasesOperationSpecification extends OperationFunctionalSpecificati
 
         then:
         _ * connection.getDescription() >> helper.connectionDescription
-        1 * connection.command(_, _, readPreference, _, _) >> helper.commandResult
+        1 * connection.command(_, _, readPreference, _, _, _) >> helper.commandResult
         1 * connection.release()
 
         where:
@@ -153,7 +153,7 @@ class ListDatabasesOperationSpecification extends OperationFunctionalSpecificati
 
         then:
         _ * connection.getDescription() >> helper.connectionDescription
-        1 * connection.commandAsync(_, _, readPreference, _, _, _) >> { it[5].onResult(helper.commandResult, null) }
+        1 * connection.commandAsync(_, _, readPreference, _, _, _, _) >> { it[6].onResult(helper.commandResult, null) }
         1 * connection.release()
 
         where:

--- a/driver-core/src/test/functional/com/mongodb/operation/ListIndexesOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ListIndexesOperationSpecification.groovy
@@ -272,7 +272,7 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
 
         then:
         _ * connection.getDescription() >> helper.threeZeroConnectionDescription
-        1 * connection.command(_, _, readPreference, _, _) >> helper.commandResult
+        1 * connection.command(_, _, readPreference, _, _, _) >> helper.commandResult
         1 * connection.release()
 
         where:
@@ -304,7 +304,7 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
 
         then:
         _ * connection.getDescription() >> helper.threeZeroConnectionDescription
-        1 * connection.commandAsync(helper.dbName, _, readPreference, _, _, _) >> { it[6].onResult(helper.commandResult, _) }
+        1 * connection.commandAsync(helper.dbName, _, readPreference, _, _, _, _) >> { it[6].onResult(helper.commandResult, _) }
 
         where:
         readPreference << [ReadPreference.primary(), ReadPreference.secondary()]

--- a/driver-core/src/test/functional/com/mongodb/operation/ParallelCollectionScanOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ParallelCollectionScanOperationSpecification.groovy
@@ -138,7 +138,7 @@ class ParallelCollectionScanOperationSpecification extends OperationFunctionalSp
 
         then:
         _ * connection.getDescription() >> helper.connectionDescription
-        1 * connection.command(helper.dbName, _, readPreference, _, _) >> helper.commandResult
+        1 * connection.command(helper.dbName, _, readPreference, _, _, _) >> helper.commandResult
         1 * connection.release()
 
         where:
@@ -162,8 +162,8 @@ class ParallelCollectionScanOperationSpecification extends OperationFunctionalSp
 
         then:
         _ * connection.getDescription() >> helper.connectionDescription
-        1 * connection.commandAsync(helper.dbName, _, readPreference, _, _, _) >> {
-            it[5].onResult(helper.commandResult, null) }
+        1 * connection.commandAsync(helper.dbName, _, readPreference, _, _, _, _) >> {
+            it[6].onResult(helper.commandResult, null) }
         1 * connection.release()
 
         where:
@@ -192,7 +192,7 @@ class ParallelCollectionScanOperationSpecification extends OperationFunctionalSp
         operation.execute(readBinding)
 
         then:
-        1 * connection.command(helper.dbName, expectedCommand, _, _, _) >> { helper.commandResult }
+        1 * connection.command(helper.dbName, expectedCommand, _, _, _, _) >> { helper.commandResult }
         1 * connection.release()
 
         when:
@@ -202,7 +202,7 @@ class ParallelCollectionScanOperationSpecification extends OperationFunctionalSp
         operation.execute(readBinding)
 
         then:
-        1 * connection.command(helper.dbName, expectedCommand, _, _, _) >> { helper.commandResult }
+        1 * connection.command(helper.dbName, expectedCommand, _, _, _, _) >> { helper.commandResult }
         1 * connection.release()
     }
 
@@ -227,7 +227,7 @@ class ParallelCollectionScanOperationSpecification extends OperationFunctionalSp
         operation.executeAsync(readBinding, Stub(SingleResultCallback))
 
         then:
-        1 * connection.commandAsync(helper.dbName, expectedCommand, _, _, _, _) >> { it[5].onResult(helper.commandResult, null) }
+        1 * connection.commandAsync(helper.dbName, expectedCommand, _, _, _, _, _) >> { it[6].onResult(helper.commandResult, null) }
         1 * connection.release()
 
         when:
@@ -237,7 +237,7 @@ class ParallelCollectionScanOperationSpecification extends OperationFunctionalSp
         operation.executeAsync(readBinding, Stub(SingleResultCallback))
 
         then:
-        1 * connection.commandAsync(helper.dbName, expectedCommand, _, _, _, _) >> { it[5].onResult(helper.commandResult, null) }
+        1 * connection.commandAsync(helper.dbName, expectedCommand, _, _, _, _, _) >> { it[6].onResult(helper.commandResult, null) }
         1 * connection.release()
     }
 

--- a/driver-core/src/test/functional/com/mongodb/operation/UserOperationsSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/UserOperationsSpecification.groovy
@@ -367,7 +367,7 @@ class UserOperationsSpecification extends OperationFunctionalSpecification {
 
         then:
         _ * connection.getDescription() >> helper.twoSixConnectionDescription
-        1 * connection.command(helper.dbName, _, readPreference, _, _) >> helper.cursorResult
+        1 * connection.command(helper.dbName, _, readPreference, _, _, _) >> helper.cursorResult
 
         where:
         readPreference << [ReadPreference.primary(), ReadPreference.secondary()]
@@ -390,8 +390,8 @@ class UserOperationsSpecification extends OperationFunctionalSpecification {
 
         then:
         _ * connection.getDescription() >> helper.twoSixConnectionDescription
-        1 * connection.commandAsync(helper.dbName, _, readPreference, _, _, _) >> {
-            it[5].onResult(helper.cursorResult, null) }
+        1 * connection.commandAsync(helper.dbName, _, readPreference, _, _, _, _) >> {
+            it[6].onResult(helper.cursorResult, null) }
 
         where:
         readPreference << [ReadPreference.primary(), ReadPreference.secondary()]

--- a/driver-core/src/test/unit/com/mongodb/connection/ClusterClockSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/ClusterClockSpecification.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.connection
+
+import org.bson.BsonDocument
+import org.bson.BsonTimestamp
+import spock.lang.Specification
+
+
+class ClusterClockSpecification extends Specification {
+    def 'should advance cluster time'() {
+        given:
+        def firstClusterTime = new BsonDocument('clusterTime', new BsonTimestamp(42, 1))
+        def secondClusterTime = new BsonDocument('clusterTime', new BsonTimestamp(52, 1))
+        def olderClusterTime = new BsonDocument('clusterTime', new BsonTimestamp(22, 1))
+
+        when:
+        def clock = new ClusterClock()
+
+        then:
+        clock.getCurrent() == null
+
+        when:
+        clock.advance(null)
+
+        then:
+        clock.getCurrent() == null
+        clock.greaterOf(firstClusterTime) == firstClusterTime
+
+        when:
+        clock.advance(firstClusterTime)
+
+        then:
+        clock.getCurrent() == firstClusterTime
+        clock.greaterOf(secondClusterTime) == secondClusterTime
+
+        when:
+        clock.advance(secondClusterTime)
+
+        then:
+        clock.getCurrent() == secondClusterTime
+        clock.greaterOf(olderClusterTime) == secondClusterTime
+
+        when:
+        clock.advance(olderClusterTime)
+
+        then:
+        clock.getCurrent() == secondClusterTime
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/connection/CommandEventOnConnectionFailureSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/CommandEventOnConnectionFailureSpecification.groovy
@@ -44,7 +44,7 @@ class CommandEventOnConnectionFailureSpecification extends Specification {
 
     def 'should publish failed command event when sendMessage throws exception'() {
         String commandName = protocolInfo[0]
-        Protocol protocol = protocolInfo[1]
+        LegacyProtocol protocol = protocolInfo[1]
 
         def commandListener = new TestCommandListener()
         protocol.commandListener = commandListener
@@ -75,7 +75,7 @@ class CommandEventOnConnectionFailureSpecification extends Specification {
 
     def 'should publish failed command event when receiveMessage throws exception'() {
         String commandName = protocolInfo[0]
-        Protocol protocol = protocolInfo[1]
+        LegacyProtocol protocol = protocolInfo[1]
 
         def commandListener = new TestCommandListener()
         protocol.commandListener = commandListener

--- a/driver-core/src/test/unit/com/mongodb/connection/DefaultServerMonitorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/DefaultServerMonitorSpecification.groovy
@@ -123,7 +123,7 @@ class DefaultServerMonitorSpecification extends Specification {
 
                     sendMessage(_, _) >> { }
 
-                    sendAndReceive(_, _) >> {
+                    sendAndReceive(_, _, _) >> {
                         BsonDocument.parse(isMasterResponse)
                     }
                 }
@@ -196,7 +196,7 @@ class DefaultServerMonitorSpecification extends Specification {
                         connectionDescription
                     }
 
-                    sendAndReceive(_, _) >> {
+                    sendAndReceive(_, _, _) >> {
                         throw exception
                     }
                 }

--- a/driver-core/src/test/unit/com/mongodb/connection/DefaultTestClusterableServerFactory.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/DefaultTestClusterableServerFactory.java
@@ -41,14 +41,15 @@ public class DefaultTestClusterableServerFactory implements ClusterableServerFac
     }
 
     @Override
-    public ClusterableServer create(final ServerAddress serverAddress, final ServerListener serverListener) {
+    public ClusterableServer create(final ServerAddress serverAddress, final ServerListener serverListener,
+                                    final ClusterClock clusterClock) {
         TestServerMonitorFactory serverMonitorFactory = new TestServerMonitorFactory(new ServerId(clusterId, serverAddress));
         serverAddressToServerMonitorFactoryMap.put(serverAddress, serverMonitorFactory);
 
         return new DefaultServer(new ServerId(clusterId, serverAddress), clusterConnectionMode, new TestConnectionPool(),
                 new TestConnectionFactory(), serverMonitorFactory,
                 createServerListener(ServerSettings.builder().addServerListener(serverListener).build(),
-                        serverListenerFactory.create(serverAddress)), null);
+                        serverListenerFactory.create(serverAddress)), null, clusterClock);
     }
 
     @Override

--- a/driver-core/src/test/unit/com/mongodb/connection/MaxDocumentSizeTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/MaxDocumentSizeTest.java
@@ -17,6 +17,7 @@
 package com.mongodb.connection;
 
 import com.mongodb.bulk.InsertRequest;
+import com.mongodb.internal.connection.NoOpSessionContext;
 import org.bson.BsonBinary;
 import org.bson.BsonDocument;
 import org.bson.BsonSerializationException;
@@ -47,6 +48,6 @@ public class MaxDocumentSizeTest {
 
     @Test(expected = BsonSerializationException.class)
     public void testMaxDocumentSize() {
-        message.encode(buffer);
+        message.encode(buffer, NoOpSessionContext.INSTANCE);
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/connection/MaxMessageSizeTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/MaxMessageSizeTest.java
@@ -17,6 +17,7 @@
 package com.mongodb.connection;
 
 import com.mongodb.bulk.InsertRequest;
+import com.mongodb.internal.connection.NoOpSessionContext;
 import org.bson.BsonBinary;
 import org.bson.BsonDocument;
 import org.junit.After;
@@ -52,10 +53,10 @@ public class MaxMessageSizeTest {
 
     @Test
     public void testMaxDocumentSize() {
-        message.encode(buffer);
+        message.encode(buffer, NoOpSessionContext.INSTANCE);
         RequestMessage next = message.getEncodingMetadata().getNextMessage();
         assertNotNull(next);
-        next.encode(buffer);
+        next.encode(buffer, NoOpSessionContext.INSTANCE);
         assertNull(next.getEncodingMetadata().getNextMessage());
     }
 

--- a/driver-core/src/test/unit/com/mongodb/connection/SimpleCommandMessageSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/SimpleCommandMessageSpecification.groovy
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.connection
+
+import com.mongodb.ReadPreference
+import org.bson.BsonBinary
+import org.bson.BsonDocument
+import org.bson.BsonString
+import org.bson.BsonTimestamp
+import org.bson.ByteBufNIO
+import org.bson.codecs.BsonDocumentCodec
+import org.bson.io.BasicOutputBuffer
+import spock.lang.Specification
+
+import java.nio.ByteBuffer
+
+class SimpleCommandMessageSpecification extends Specification {
+    def 'should encode command message with OP_MSG'() {
+        given:
+        def message = new SimpleCommandMessage('db.test', new BsonDocument('count', new BsonString('test')),
+                readPreference,
+                MessageSettings.builder()
+                        .serverVersion(new ServerVersion(3, 6))
+                        .build())
+        def output = new BasicOutputBuffer()
+
+        when:
+        message.encode(output, sessionContext)
+
+        then:
+        def byteBuf = new ByteBufNIO(ByteBuffer.wrap(output.toByteArray()))
+        def messageHeader = new MessageHeader(byteBuf, 512)
+        messageHeader.opCode == OpCode.OP_MSG.value
+        messageHeader.requestId == RequestMessage.currentGlobalId - 1
+        messageHeader.responseTo == 0
+
+        def expectedCommandDocument = new BsonDocument()
+                .append('count', new BsonString('test'))
+                .append('$db', new BsonString('db'))
+
+        if (sessionContext.hasSession()) {
+            if (sessionContext.clusterTime != null) {
+                expectedCommandDocument.append('$clusterTime', sessionContext.clusterTime)
+            }
+            expectedCommandDocument.append('lsid', sessionContext.sessionId)
+        }
+
+        if (readPreference != ReadPreference.primary()) {
+            expectedCommandDocument.append('$readPreference', readPreference.toDocument())
+        }
+        getCommandDocument(byteBuf, messageHeader) == expectedCommandDocument
+
+        where:
+        [readPreference, sessionContext] << [
+                [ReadPreference.primary(), ReadPreference.secondary()],
+                [
+                        Stub(SessionContext) {
+                            hasSession() >> false
+                        },
+                        Stub(SessionContext) {
+                            hasSession() >> true
+                            getClusterTime() >> null
+                            getSessionId() >> new BsonDocument('id', new BsonBinary([1, 2, 3] as byte[]))
+                        },
+                        Stub(SessionContext) {
+                            hasSession() >> true
+                            getClusterTime() >> new BsonDocument('clusterTime', new BsonTimestamp(42, 1))
+                            getSessionId() >> new BsonDocument('id', new BsonBinary([1, 2, 3] as byte[]))
+                        }
+                ]
+        ].combinations()
+    }
+
+
+    private static BsonDocument getCommandDocument(ByteBufNIO byteBuf, MessageHeader messageHeader) {
+        new ReplyMessage<BsonDocument>(new ResponseBuffers(new ReplyHeader(byteBuf, messageHeader), byteBuf),
+                new BsonDocumentCodec(), 0).documents.get(0)
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/connection/StreamHelper.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/StreamHelper.groovy
@@ -20,6 +20,7 @@ package com.mongodb.connection
 import com.mongodb.MongoNamespace
 import com.mongodb.ReadPreference
 import com.mongodb.async.FutureResultCallback
+import com.mongodb.internal.connection.NoOpSessionContext
 import org.bson.BsonBinaryWriter
 import org.bson.BsonDocument
 import org.bson.BsonInt32
@@ -166,7 +167,7 @@ class StreamHelper {
                 new BsonDocument('ismaster', new BsonInt32(1)),
                 ReadPreference.primary(), MessageSettings.builder().serverVersion(new ServerVersion(0, 0)).build())
         OutputBuffer outputBuffer = new BasicOutputBuffer()
-        command.encode(outputBuffer)
+        command.encode(outputBuffer, NoOpSessionContext.INSTANCE)
         nextMessageId++
         [outputBuffer.byteBuffers, nextMessageId]
     }

--- a/driver-core/src/test/unit/com/mongodb/connection/TestClusterableServerFactory.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/TestClusterableServerFactory.java
@@ -33,7 +33,8 @@ public class TestClusterableServerFactory implements ClusterableServerFactory {
     private final Map<ServerAddress, TestServer> addressToServerMap = new HashMap<ServerAddress, TestServer>();
 
     @Override
-    public ClusterableServer create(final ServerAddress serverAddress, final ServerListener serverListener) {
+    public ClusterableServer create(final ServerAddress serverAddress, final ServerListener serverListener,
+                                    final ClusterClock clusterClock) {
         addressToServerMap.put(serverAddress, new TestServer(serverAddress, serverListener));
         return addressToServerMap.get(serverAddress);
     }

--- a/driver-core/src/test/unit/com/mongodb/connection/TestConnection.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/TestConnection.java
@@ -35,7 +35,8 @@ import java.util.List;
 class TestConnection implements Connection, AsyncConnection {
     private final InternalConnection internalConnection;
     private final ProtocolExecutor executor;
-    private Protocol enqueuedProtocol;
+    private LegacyProtocol enqueuedLegacyProtocol;
+    private CommandProtocol enqueuedCommandProtocol;
 
     TestConnection(final InternalConnection internalConnection, final ProtocolExecutor executor) {
         this.internalConnection = internalConnection;
@@ -65,38 +66,38 @@ class TestConnection implements Connection, AsyncConnection {
     @Override
     public WriteConcernResult insert(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
                                      final List<InsertRequest> inserts) {
-        return executeEnqueuedProtocol();
+        return executeEnqueuedLegacyProtocol();
     }
 
     @Override
     public void insertAsync(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
                             final List<InsertRequest> inserts, final SingleResultCallback<WriteConcernResult> callback) {
-        executeEnqueuedProtocolAsync(callback);
+        executeEnqueuedLegacyProtocolAsync(callback);
     }
 
     @Override
     public WriteConcernResult update(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
                                      final List<UpdateRequest> updates) {
-        return executeEnqueuedProtocol();
+        return executeEnqueuedLegacyProtocol();
     }
 
     @Override
     public void updateAsync(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
                             final List<UpdateRequest> updates, final SingleResultCallback<WriteConcernResult> callback) {
-        executeEnqueuedProtocolAsync(callback);
+        executeEnqueuedLegacyProtocolAsync(callback);
     }
 
     @Override
     public WriteConcernResult delete(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
                                      final List<DeleteRequest> deletes) {
-        return executeEnqueuedProtocol();
+        return executeEnqueuedLegacyProtocol();
     }
 
     @Override
     public void deleteAsync(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
                             final List<DeleteRequest> deletes,
                             final SingleResultCallback<WriteConcernResult> callback) {
-        executeEnqueuedProtocolAsync(callback);
+        executeEnqueuedLegacyProtocolAsync(callback);
     }
 
     @Override
@@ -108,7 +109,14 @@ class TestConnection implements Connection, AsyncConnection {
     @Override
     public BulkWriteResult insertCommand(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
                                          final Boolean bypassDocumentValidation, final List<InsertRequest> inserts) {
-        return executeEnqueuedProtocol();
+        throw new UnsupportedOperationException("Deprecated method called directly - this should have been updated");
+    }
+
+    @Override
+    public BulkWriteResult insertCommand(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
+                                         final Boolean bypassDocumentValidation, final List<InsertRequest> inserts,
+                                         final SessionContext sessionContext) {
+        return executeEnqueuedCommandBasedProtocol(sessionContext);
     }
 
     @Override
@@ -121,7 +129,14 @@ class TestConnection implements Connection, AsyncConnection {
     public void insertCommandAsync(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
                                    final Boolean bypassDocumentValidation, final List<InsertRequest> inserts,
                                    final SingleResultCallback<BulkWriteResult> callback) {
-        executeEnqueuedProtocolAsync(callback);
+        throw new UnsupportedOperationException("Deprecated method called directly - this should have been updated");
+    }
+
+    @Override
+    public void insertCommandAsync(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
+                                   final Boolean bypassDocumentValidation, final List<InsertRequest> inserts,
+                                   final SessionContext sessionContext, final SingleResultCallback<BulkWriteResult> callback) {
+        executeEnqueuedCommandBasedProtocolAsync(null, callback);
     }
 
     @Override
@@ -133,7 +148,14 @@ class TestConnection implements Connection, AsyncConnection {
     @Override
     public BulkWriteResult updateCommand(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
                                          final Boolean bypassDocumentValidation, final List<UpdateRequest> updates) {
-        return executeEnqueuedProtocol();
+        throw new UnsupportedOperationException("Deprecated method called directly - this should have been updated");
+    }
+
+    @Override
+    public BulkWriteResult updateCommand(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
+                                         final Boolean bypassDocumentValidation, final List<UpdateRequest> updates,
+                                         final SessionContext sessionContext) {
+        return executeEnqueuedCommandBasedProtocol(sessionContext);
     }
 
     @Override
@@ -146,47 +168,68 @@ class TestConnection implements Connection, AsyncConnection {
     public void updateCommandAsync(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
                                    final Boolean bypassDocumentValidation, final List<UpdateRequest> updates,
                                    final SingleResultCallback<BulkWriteResult> callback) {
-        executeEnqueuedProtocolAsync(callback);
+        throw new UnsupportedOperationException("Deprecated method called directly - this should have been updated");
+    }
+
+    @Override
+    public void updateCommandAsync(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
+                                   final Boolean bypassDocumentValidation, final List<UpdateRequest> updates,
+                                   final SessionContext sessionContext, final SingleResultCallback<BulkWriteResult> callback) {
+        executeEnqueuedCommandBasedProtocolAsync(null, callback);
     }
 
     @Override
     public BulkWriteResult deleteCommand(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
                                          final List<DeleteRequest> deletes) {
-        return executeEnqueuedProtocol();
+        throw new UnsupportedOperationException("Deprecated method called directly - this should have been updated");
+    }
+
+    @Override
+    public BulkWriteResult deleteCommand(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
+                                         final List<DeleteRequest> deletes, final SessionContext sessionContext) {
+        return executeEnqueuedCommandBasedProtocol(sessionContext);
     }
 
     @Override
     public void deleteCommandAsync(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
                                    final List<DeleteRequest> deletes,
                                    final SingleResultCallback<BulkWriteResult> callback) {
-        executeEnqueuedProtocolAsync(callback);
+        throw new UnsupportedOperationException("Deprecated method called directly - this should have been updated");
+    }
+
+    @Override
+    public void deleteCommandAsync(final MongoNamespace namespace, final boolean ordered, final WriteConcern writeConcern,
+                                   final List<DeleteRequest> deletes, final SessionContext sessionContext,
+                                   final SingleResultCallback<BulkWriteResult> callback) {
+        executeEnqueuedCommandBasedProtocolAsync(null, callback);
     }
 
     @Override
     public <T> T command(final String database, final BsonDocument command, final boolean slaveOk,
                          final FieldNameValidator fieldNameValidator,
                          final Decoder<T> commandResultDecoder) {
-        return executeEnqueuedProtocol();
+        return executeEnqueuedCommandBasedProtocol(null);
     }
 
     @Override
-    public <T> T command(final String database, final BsonDocument command, final ReadPreference readPreference,
-                         final FieldNameValidator fieldNameValidator, final Decoder<T> commandResultDecoder) {
-        return executeEnqueuedProtocol();
+    public <T> T command(final String database, final BsonDocument command,
+                         final ReadPreference readPreference, final FieldNameValidator fieldNameValidator,
+                         final Decoder<T> commandResultDecoder, final SessionContext sessionContext) {
+        return executeEnqueuedCommandBasedProtocol(sessionContext);
     }
 
     @Override
     public <T> void commandAsync(final String database, final BsonDocument command, final boolean slaveOk,
                                  final FieldNameValidator fieldNameValidator,
                                  final Decoder<T> commandResultDecoder, final SingleResultCallback<T> callback) {
-        executeEnqueuedProtocolAsync(callback);
+        executeEnqueuedCommandBasedProtocolAsync(null, callback);
     }
 
     @Override
     public <T> void commandAsync(final String database, final BsonDocument command, final ReadPreference readPreference,
                                  final FieldNameValidator fieldNameValidator, final Decoder<T> commandResultDecoder,
-                                 final SingleResultCallback<T> callback) {
-        executeEnqueuedProtocolAsync(callback);
+                                 final SessionContext sessionContext, final SingleResultCallback<T> callback) {
+        executeEnqueuedCommandBasedProtocolAsync(sessionContext, callback);
     }
 
     @Override
@@ -195,7 +238,7 @@ class TestConnection implements Connection, AsyncConnection {
                                     final boolean slaveOk, final boolean tailableCursor, final boolean awaitData,
                                     final boolean noCursorTimeout,
                                     final boolean partial, final boolean oplogReplay, final Decoder<T> resultDecoder) {
-        return executeEnqueuedProtocol();
+        return executeEnqueuedLegacyProtocol();
     }
 
     @Override
@@ -204,7 +247,7 @@ class TestConnection implements Connection, AsyncConnection {
                                     final int batchSize, final boolean slaveOk, final boolean tailableCursor, final boolean awaitData,
                                     final boolean noCursorTimeout,
                                     final boolean partial, final boolean oplogReplay, final Decoder<T> resultDecoder) {
-        return executeEnqueuedProtocol();
+        return executeEnqueuedLegacyProtocol();
     }
 
     @Override
@@ -214,7 +257,7 @@ class TestConnection implements Connection, AsyncConnection {
                                final boolean partial,
                                final boolean oplogReplay, final Decoder<T> resultDecoder,
                                final SingleResultCallback<QueryResult<T>> callback) {
-        executeEnqueuedProtocolAsync(callback);
+        executeEnqueuedLegacyProtocolAsync(callback);
     }
 
     @Override
@@ -224,53 +267,67 @@ class TestConnection implements Connection, AsyncConnection {
                                final boolean noCursorTimeout,
                                final boolean partial, final boolean oplogReplay, final Decoder<T> resultDecoder,
                                final SingleResultCallback<QueryResult<T>> callback) {
-        executeEnqueuedProtocolAsync(callback);
+        executeEnqueuedLegacyProtocolAsync(callback);
     }
 
     @Override
     public <T> QueryResult<T> getMore(final MongoNamespace namespace, final long cursorId, final int numberToReturn,
                                       final Decoder<T> resultDecoder) {
-        return executeEnqueuedProtocol();
+        return executeEnqueuedLegacyProtocol();
     }
 
     @Override
     public <T> void getMoreAsync(final MongoNamespace namespace, final long cursorId, final int numberToReturn,
                                  final Decoder<T> resultDecoder,
                                  final SingleResultCallback<QueryResult<T>> callback) {
-        executeEnqueuedProtocolAsync(callback);
+        executeEnqueuedLegacyProtocolAsync(callback);
     }
 
     @Override
     public void killCursor(final List<Long> cursors) {
-        executeEnqueuedProtocol();
+        executeEnqueuedLegacyProtocol();
     }
 
     @Override
     public void killCursor(final MongoNamespace namespace, final List<Long> cursors) {
-        executeEnqueuedProtocol();
+        executeEnqueuedLegacyProtocol();
     }
 
     @Override
     public void killCursorAsync(final List<Long> cursors, final SingleResultCallback<Void> callback) {
-        executeEnqueuedProtocolAsync(callback);
+        executeEnqueuedLegacyProtocolAsync(callback);
     }
 
     @Override
     public void killCursorAsync(final MongoNamespace namespace, final List<Long> cursors, final SingleResultCallback<Void> callback) {
-        executeEnqueuedProtocolAsync(callback);
+        executeEnqueuedLegacyProtocolAsync(callback);
     }
 
     @SuppressWarnings("unchecked")
-    private <T> T executeEnqueuedProtocol() {
-        return (T) executor.execute(enqueuedProtocol, internalConnection);
+    private <T> T executeEnqueuedLegacyProtocol() {
+        return (T) executor.execute(enqueuedLegacyProtocol, internalConnection);
     }
 
     @SuppressWarnings("unchecked")
-    private <T> void executeEnqueuedProtocolAsync(final SingleResultCallback<T> callback) {
-        executor.executeAsync(enqueuedProtocol, internalConnection, callback);
+    private <T> void executeEnqueuedLegacyProtocolAsync(final SingleResultCallback<T> callback) {
+        executor.executeAsync(enqueuedLegacyProtocol, internalConnection, callback);
     }
 
-    void enqueueProtocol(final Protocol protocol) {
-        enqueuedProtocol = protocol;
+    @SuppressWarnings("unchecked")
+    private <T> T executeEnqueuedCommandBasedProtocol(final SessionContext sessionContext) {
+        return (T) executor.execute(enqueuedCommandProtocol, internalConnection, sessionContext);
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> void executeEnqueuedCommandBasedProtocolAsync(final SessionContext sessionContext, final SingleResultCallback<T> callback) {
+        executor.executeAsync(enqueuedCommandProtocol, internalConnection, sessionContext, callback);
+    }
+
+    void enqueueProtocol(final LegacyProtocol protocol) {
+        enqueuedLegacyProtocol = protocol;
+    }
+
+    void enqueueProtocol(final CommandProtocol protocol) {
+        enqueuedCommandProtocol = protocol;
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/connection/TestConnectionPool.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/TestConnectionPool.java
@@ -50,13 +50,13 @@ public class TestConnectionPool implements ConnectionPool {
             }
 
             @Override
-            public <T> T sendAndReceive(final CommandMessage message, final Decoder<T> decoder) {
+            public <T> T sendAndReceive(final CommandMessage message, final Decoder<T> decoder, final SessionContext sessionContext) {
                 throw new UnsupportedOperationException("Not implemented yet!");
             }
 
             @Override
             public <T> void sendAndReceiveAsync(final CommandMessage message, final Decoder<T> decoder,
-                                            final SingleResultCallback<T> callback) {
+                                                final SessionContext sessionContext, final SingleResultCallback<T> callback) {
                 throw new UnsupportedOperationException("Not implemented yet!");
             }
 

--- a/driver-core/src/test/unit/com/mongodb/connection/TestInternalConnection.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/TestInternalConnection.java
@@ -140,10 +140,10 @@ class TestInternalConnection implements InternalConnection {
     }
 
     @Override
-    public <T> T sendAndReceive(final CommandMessage message, final Decoder<T> decoder) {
+    public <T> T sendAndReceive(final CommandMessage message, final Decoder<T> decoder, final SessionContext sessionContext) {
         ByteBufferBsonOutput bsonOutput = new ByteBufferBsonOutput(this);
         try {
-            message.encode(bsonOutput);
+            message.encode(bsonOutput, sessionContext);
             sendMessage(bsonOutput.getByteBuffers(), message.getId());
         } finally {
             bsonOutput.close();
@@ -171,9 +171,9 @@ class TestInternalConnection implements InternalConnection {
 
     @Override
     public <T> void sendAndReceiveAsync(final CommandMessage message, final Decoder<T> decoder,
-                                        final SingleResultCallback<T> callback) {
+                                        final SessionContext sessionContext, final SingleResultCallback<T> callback) {
         try {
-            T result = sendAndReceive(message, decoder);
+            T result = sendAndReceive(message, decoder, sessionContext);
             callback.onResult(result, null);
         } catch (MongoException ex) {
             callback.onResult(null, ex);

--- a/driver-core/src/test/unit/com/mongodb/connection/TestInternalConnectionFactory.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/TestInternalConnectionFactory.java
@@ -85,13 +85,13 @@ class TestInternalConnectionFactory implements InternalConnectionFactory {
         }
 
         @Override
-        public <T> T sendAndReceive(final CommandMessage message, final Decoder<T> decoder) {
+        public <T> T sendAndReceive(final CommandMessage message, final Decoder<T> decoder, final SessionContext sessionContext) {
             return null;
         }
 
         @Override
         public <T> void sendAndReceiveAsync(final CommandMessage message, final Decoder<T> decoder,
-                                        final SingleResultCallback<T> callback) {
+                                            final SessionContext sessionContext, final SingleResultCallback<T> callback) {
             callback.onResult(null, null);
         }
 

--- a/driver-core/src/test/unit/com/mongodb/connection/TestSessionContext.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/TestSessionContext.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.connection;
+
+import org.bson.BsonDocument;
+import org.bson.BsonTimestamp;
+
+class TestSessionContext implements SessionContext {
+
+    private BsonDocument clusterTime;
+    private BsonTimestamp operationTime;
+
+    TestSessionContext(final BsonDocument initialClusterTime) {
+        this.clusterTime = initialClusterTime;
+    }
+
+    public BsonTimestamp getOperationTime() {
+        return operationTime;
+    }
+
+    @Override
+    public boolean hasSession() {
+        return false;
+    }
+
+    @Override
+    public BsonDocument getSessionId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long advanceTransactionNumber() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void advanceOperationTime(final BsonTimestamp operationTime) {
+        this.operationTime = operationTime;
+    }
+
+    @Override
+    public BsonDocument getClusterTime() {
+        return clusterTime;
+    }
+
+    @Override
+    public void advanceClusterTime(final BsonDocument clusterTime) {
+        this.clusterTime = clusterTime;
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/connection/UsageTrackingConnectionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/UsageTrackingConnectionSpecification.groovy
@@ -19,6 +19,7 @@ package com.mongodb.connection
 import category.Async
 import com.mongodb.ServerAddress
 import com.mongodb.async.FutureResultCallback
+import com.mongodb.internal.connection.NoOpSessionContext
 import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.codecs.BsonDocumentCodec
@@ -173,7 +174,8 @@ class UsageTrackingConnectionSpecification extends Specification {
 
         when:
         connection.sendAndReceive(new SimpleCommandMessage('test', new BsonDocument('ping', new BsonInt32(1)), primary(),
-                MessageSettings.builder().serverVersion(new ServerVersion(0, 0)).build()), new BsonDocumentCodec())
+                MessageSettings.builder().serverVersion(new ServerVersion(0, 0)).build()),
+                new BsonDocumentCodec(), NoOpSessionContext.INSTANCE)
 
         then:
         connection.lastUsedAt >= openedLastUsedAt
@@ -190,7 +192,7 @@ class UsageTrackingConnectionSpecification extends Specification {
         when:
         connection.sendAndReceiveAsync(new SimpleCommandMessage('test', new BsonDocument('ping', new BsonInt32(1)), primary(),
                 MessageSettings.builder().serverVersion(new ServerVersion(0, 0)).build()),
-                new BsonDocumentCodec(), futureResultCallback)
+                new BsonDocumentCodec(), NoOpSessionContext.INSTANCE, futureResultCallback)
         futureResultCallback.get(60, SECONDS)
 
         then:

--- a/driver-core/src/test/unit/com/mongodb/connection/WriteCommandLimitsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/WriteCommandLimitsSpecification.groovy
@@ -22,6 +22,7 @@ import com.mongodb.WriteConcern
 import com.mongodb.bulk.DeleteRequest
 import com.mongodb.bulk.InsertRequest
 import com.mongodb.bulk.UpdateRequest
+import com.mongodb.internal.connection.NoOpSessionContext
 import org.bson.BsonDocument
 import org.bson.BsonInt32
 import spock.lang.Specification
@@ -44,7 +45,7 @@ class WriteCommandLimitsSpecification extends Specification {
                 inserts);
 
         when:
-        message.encode(buffer)
+        message.encode(buffer, NoOpSessionContext.INSTANCE)
         def nextMessage = (InsertCommandMessage) message.getEncodingMetadata().nextMessage
 
         then:
@@ -67,7 +68,7 @@ class WriteCommandLimitsSpecification extends Specification {
                 inserts);
 
         when:
-        message.encode(buffer)
+        message.encode(buffer, NoOpSessionContext.INSTANCE)
         def nextMessage = (InsertCommandMessage) message.getEncodingMetadata().nextMessage
 
         then:
@@ -90,7 +91,7 @@ class WriteCommandLimitsSpecification extends Specification {
                 deletes);
 
         when:
-        message.encode(buffer)
+        message.encode(buffer, NoOpSessionContext.INSTANCE)
         def nextMessage = (DeleteCommandMessage) message.getEncodingMetadata().nextMessage
 
         then:
@@ -113,7 +114,7 @@ class WriteCommandLimitsSpecification extends Specification {
                 deletes);
 
         when:
-        message.encode(buffer)
+        message.encode(buffer, NoOpSessionContext.INSTANCE)
         def nextMessage = (DeleteCommandMessage) message.getEncodingMetadata().nextMessage
 
         then:
@@ -136,7 +137,7 @@ class WriteCommandLimitsSpecification extends Specification {
                 replaces);
 
         when:
-        message.encode(buffer)
+        message.encode(buffer, NoOpSessionContext.INSTANCE)
         def nextMessage = (UpdateCommandMessage) message.getEncodingMetadata().nextMessage
 
         then:
@@ -159,7 +160,7 @@ class WriteCommandLimitsSpecification extends Specification {
                 replaces);
 
         when:
-        message.encode(buffer)
+        message.encode(buffer, NoOpSessionContext.INSTANCE)
         def nextMessage = (UpdateCommandMessage) message.getEncodingMetadata().nextMessage
 
         then:

--- a/driver-core/src/test/unit/com/mongodb/connection/WriteCommandMessageSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/WriteCommandMessageSpecification.groovy
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.connection
+
+import com.mongodb.MongoNamespace
+import com.mongodb.WriteConcern
+import com.mongodb.bulk.InsertRequest
+import org.bson.BsonArray
+import org.bson.BsonBinary
+import org.bson.BsonBoolean
+import org.bson.BsonDocument
+import org.bson.BsonInt32
+import org.bson.BsonString
+import org.bson.BsonTimestamp
+import org.bson.ByteBufNIO
+import org.bson.codecs.BsonDocumentCodec
+import org.bson.io.BasicOutputBuffer
+import spock.lang.Specification
+
+import java.nio.ByteBuffer
+
+class WriteCommandMessageSpecification extends Specification {
+    def 'should encode write command message with OP_MSG'() {
+        given:
+        def message = new InsertCommandMessage(new MongoNamespace('db.test'), ordered, writeConcern, bypassDocumentValidation,
+                MessageSettings.builder()
+                        .serverVersion(new ServerVersion(3, 6))
+                        .build(),
+                [new InsertRequest(new BsonDocument('_id', new BsonInt32(1)))])
+        def output = new BasicOutputBuffer()
+
+        when:
+        message.encode(output, sessionContext)
+
+        then:
+        def byteBuf = new ByteBufNIO(ByteBuffer.wrap(output.toByteArray()))
+        def messageHeader = new MessageHeader(byteBuf, 512)
+        messageHeader.opCode == OpCode.OP_MSG.value
+        messageHeader.requestId == RequestMessage.currentGlobalId - 1
+        messageHeader.responseTo == 0
+
+        def expectedCommandDocument = new BsonDocument()
+                .append('insert', new BsonString('test'))
+                .append('ordered', new BsonBoolean(ordered))
+
+        if (!writeConcern.isServerDefault()) {
+            expectedCommandDocument.append('writeConcern', writeConcern.asDocument())
+        }
+        if (bypassDocumentValidation != null) {
+            expectedCommandDocument.append('bypassDocumentValidation', new BsonBoolean(bypassDocumentValidation))
+        }
+        expectedCommandDocument
+                .append('documents', new BsonArray([new BsonDocument('_id', new BsonInt32(1))]))
+                .append('$db', new BsonString('db'))
+
+        if (sessionContext.hasSession()) {
+            if (sessionContext.clusterTime != null) {
+                expectedCommandDocument.append('$clusterTime', sessionContext.clusterTime)
+            }
+            expectedCommandDocument.append('lsid', sessionContext.sessionId)
+        }
+
+        getCommandDocument(byteBuf, messageHeader) == expectedCommandDocument
+
+        where:
+        [ordered, writeConcern, bypassDocumentValidation, sessionContext] << [
+                [true, false],
+                [WriteConcern.ACKNOWLEDGED, WriteConcern.MAJORITY],
+                [true, false, null],
+                [
+                        Stub(SessionContext) {
+                            hasSession() >> false
+                        },
+                        Stub(SessionContext) {
+                            hasSession() >> true
+                            getClusterTime() >> null
+                            getSessionId() >> new BsonDocument('id', new BsonBinary([1, 2, 3] as byte[]))
+                        },
+                        Stub(SessionContext) {
+                            hasSession() >> true
+                            getClusterTime() >> new BsonDocument('clusterTime', new BsonTimestamp(42, 1))
+                            getSessionId() >> new BsonDocument('id', new BsonBinary([1, 2, 3] as byte[]))
+                        }
+                ]
+        ].combinations()
+    }
+
+
+    private static BsonDocument getCommandDocument(ByteBufNIO byteBuf, MessageHeader messageHeader) {
+        new ReplyMessage<BsonDocument>(new ResponseBuffers(new ReplyHeader(byteBuf, messageHeader), byteBuf),
+                new BsonDocumentCodec(), 0).documents.get(0)
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/NoOpSessionContextSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/NoOpSessionContextSpecification.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.internal.connection
+
+import org.bson.BsonDocument
+import org.bson.BsonTimestamp
+import spock.lang.Specification
+
+class NoOpSessionContextSpecification extends Specification {
+    def 'should be a no-op'() {
+        given:
+        def sessionContext = NoOpSessionContext.INSTANCE
+
+        expect:
+        !sessionContext.hasSession()
+        sessionContext.getClusterTime() == null
+
+        when:
+        sessionContext.advanceOperationTime(new BsonTimestamp(42, 1))
+
+        then:
+        true
+
+        when:
+        sessionContext.advanceClusterTime(new BsonDocument())
+
+        then:
+        true
+
+        when:
+        sessionContext.getSessionId()
+
+        then:
+        thrown(UnsupportedOperationException)
+
+        when:
+        sessionContext.advanceTransactionNumber()
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/operation/AsyncQueryBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/AsyncQueryBatchCursorSpecification.groovy
@@ -64,8 +64,8 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         def batch = nextBatch(cursor)
 
         then:
-        1 * connection.commandAsync(NAMESPACE.getDatabaseName(), expectedCommand, _, _, _, _) >> {
-            it[5].onResult(reply, null)
+        1 * connection.commandAsync(NAMESPACE.getDatabaseName(), expectedCommand, _, _, _, _, _) >> {
+            it[6].onResult(reply, null)
         }
         batch == null
 
@@ -98,8 +98,9 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         then:
         if (firstBatch.getCursor() != null) {
             if (serverVersion.compareTo(new ServerVersion(3, 2)) >= 0) {
-                1 * connection.commandAsync(NAMESPACE.databaseName, createKillCursorsDocument(firstBatch.cursor), primary(), _, _, _) >> {
-                    it[5].onResult(null, null)
+                1 * connection.commandAsync(NAMESPACE.databaseName, createKillCursorsDocument(firstBatch.cursor), primary(),
+                        _, _, _, _) >> {
+                    it[6].onResult(null, null)
                 }
             } else {
                 1 * connection.killCursorAsync(NAMESPACE, [42], _) >> {
@@ -170,7 +171,7 @@ class AsyncQueryBatchCursorSpecification extends Specification {
 
         then:
         if (commandAsync) {
-            1 * connectionA.commandAsync(_, _, _, _, _, _) >> { it[5].onResult(documentResponse(secondBatch), null) }
+            1 * connectionA.commandAsync(_, _, _, _, _, _, _) >> { it[6].onResult(documentResponse(secondBatch), null) }
         } else {
             1 * connectionA.getMoreAsync(_, _, _, _, _) >> { it[4].onResult(queryResult(secondBatch), null) }
         }
@@ -185,10 +186,10 @@ class AsyncQueryBatchCursorSpecification extends Specification {
 
         then:
         if (commandAsync) {
-            1 * connectionB.commandAsync(_, _, _, _, _, _) >> {
+            1 * connectionB.commandAsync(_, _, _, _, _, _, _) >> {
                 connectionB.getCount() == 1
                 connectionSource.getCount() == 1
-                it[5].onResult(documentResponse(thirdBatch, 0), null)
+                it[6].onResult(documentResponse(thirdBatch, 0), null)
             }
         } else {
             1 * connectionB.getMoreAsync(_, _, _, _, _) >> {
@@ -239,7 +240,7 @@ class AsyncQueryBatchCursorSpecification extends Specification {
 
         then:
         if (commandAsync) {
-            1 * connectionA.commandAsync(_, _, _, _, _, _) >> { it[5].onResult(documentResponse(secondBatch), null) }
+            1 * connectionA.commandAsync(_, _, _, _, _, _, _) >> { it[6].onResult(documentResponse(secondBatch), null) }
         } else {
             1 * connectionA.getMoreAsync(_, _, _, _, _) >> { it[4].onResult(queryResult(secondBatch), null) }
         }
@@ -254,10 +255,10 @@ class AsyncQueryBatchCursorSpecification extends Specification {
 
         then:
         if (commandAsync) {
-            1 * connectionB.commandAsync(_, _, _, _, _, _) >> {
+            1 * connectionB.commandAsync(_, _, _, _, _, _, _) >> {
                 connectionB.getCount() == 1
                 connectionSource.getCount() == 1
-                it[5].onResult(documentResponse(thirdBatch, 0), null)
+                it[6].onResult(documentResponse(thirdBatch, 0), null)
             }
         } else {
             1 * connectionB.getMoreAsync(_, _, _, _, _) >> {
@@ -298,8 +299,8 @@ class AsyncQueryBatchCursorSpecification extends Specification {
 
         then:
         if (serverVersion.compareTo(new ServerVersion(3, 2)) >= 0) {
-            1 * connection.commandAsync(NAMESPACE.databaseName, createKillCursorsDocument(queryResult.cursor), primary(), _, _, _) >> {
-                it[5].onResult(null, null)
+            1 * connection.commandAsync(NAMESPACE.databaseName, createKillCursorsDocument(queryResult.cursor), primary(), _, _, _, _) >> {
+                it[6].onResult(null, null)
             }
         } else {
             1 * connection.killCursorAsync(NAMESPACE, [42], _) >> {
@@ -332,16 +333,16 @@ class AsyncQueryBatchCursorSpecification extends Specification {
 
         then:
         if (commandAsync) {
-            1 * connection.commandAsync(_, _, _, _, _, _) >> {
+            1 * connection.commandAsync(_, _, _, _, _, _, _) >> {
                 connection.getCount() == 1
                 connectionSource.getCount() == 1
-                it[5].onResult(response, null)
+                it[6].onResult(response, null)
             }
 
-            1 * connection.commandAsync(_, _, _, _, _, _) >> {
+            1 * connection.commandAsync(_, _, _, _, _, _, _) >> {
                 connection.getCount() == 1
                 connectionSource.getCount() == 1
-                it[5].onResult(response2, null)
+                it[6].onResult(response2, null)
             }
         } else {
             1 * connection.getMoreAsync(_, _, _, _, _) >> {
@@ -396,11 +397,11 @@ class AsyncQueryBatchCursorSpecification extends Specification {
 
         then:
         if (commandAsync) {
-            1 * connection.commandAsync(_, _, _, _, _, _) >> {
-                it[5].onResult(response, null)
+            1 * connection.commandAsync(_, _, _, _, _, _, _) >> {
+                it[6].onResult(response, null)
             }
-            1 * connection.commandAsync(NAMESPACE.databaseName, createKillCursorsDocument(initialResult.cursor), primary(), _, _, _) >> {
-                it[5].onResult(null, null)
+            1 * connection.commandAsync(NAMESPACE.databaseName, createKillCursorsDocument(initialResult.cursor), primary(), _, _, _, _) >> {
+                it[6].onResult(null, null)
             }
         } else {
             1 * connection.getMoreAsync(_, _, _, _, _) >> {
@@ -447,13 +448,14 @@ class AsyncQueryBatchCursorSpecification extends Specification {
 
         then:
         if (commandAsync) {
-            1 * connectionA.commandAsync(_, _, _, _, _, _) >> {
+            1 * connectionA.commandAsync(_, _, _, _, _, _, _) >> {
                 // Simulate the user calling close while the getMore is in flight
                 cursor.close()
-                it[5].onResult(response, null)
+                it[6].onResult(response, null)
             }
-            1 * connectionB.commandAsync(NAMESPACE.databaseName, createKillCursorsDocument(initialResult.cursor), primary(), _, _, _) >> {
-                it[5].onResult(null, null)
+            1 * connectionB.commandAsync(NAMESPACE.databaseName, createKillCursorsDocument(initialResult.cursor), primary(),
+                    _, _, _, _) >> {
+                it[6].onResult(null, null)
             }
         } else {
             1 * connectionA.getMoreAsync(_, _, _, _, _) >> {
@@ -542,10 +544,10 @@ class AsyncQueryBatchCursorSpecification extends Specification {
 
         then:
         if (commandAsync) {
-            1 * connectionA.commandAsync(_, _, _, _, _, _) >> {
+            1 * connectionA.commandAsync(_, _, _, _, _, _, _) >> {
                 connectionA.getCount() == 1
                 connectionSource.getCount() == 1
-                it[5].onResult(null, exception)
+                it[6].onResult(null, exception)
             }
         } else {
             1 * connectionA.getMoreAsync(_, _, _, _, _) >> {

--- a/driver-core/src/test/unit/com/mongodb/operation/CommandOperationHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/CommandOperationHelperSpecification.groovy
@@ -125,7 +125,7 @@ class CommandOperationHelperSpecification extends Specification {
 
         then:
         _ * connection.getDescription() >> connectionDescription
-        1 * connection.command(dbName, command, primary(), _, decoder)
+        1 * connection.command(dbName, command, primary(), _, decoder, _)
         1 * connection.release()
     }
 
@@ -150,7 +150,7 @@ class CommandOperationHelperSpecification extends Specification {
 
         then:
         _ * connection.getDescription() >> connectionDescription
-        1 * connection.command(dbName, command, readPreference, _, decoder)
+        1 * connection.command(dbName, command, readPreference, _, decoder, _)
         1 * connection.release()
 
         where:
@@ -178,7 +178,7 @@ class CommandOperationHelperSpecification extends Specification {
 
         then:
         _ * connection.getDescription() >> connectionDescription
-        1 * connection.commandAsync(dbName, command, primary(), _, decoder, _) >> { it[5].onResult(1, null) }
+        1 * connection.commandAsync(dbName, command, primary(), _, decoder, _, _) >> { it[6].onResult(1, null) }
         1 * connection.release()
     }
 
@@ -204,7 +204,7 @@ class CommandOperationHelperSpecification extends Specification {
 
         then:
         _ * connection.getDescription() >> connectionDescription
-        1 * connection.commandAsync(dbName, command, readPreference, _, decoder, _) >> { it[5].onResult(1, null) }
+        1 * connection.commandAsync(dbName, command, readPreference, _, decoder, _, _) >> { it[6].onResult(1, null) }
         1 * connection.release()
 
         where:

--- a/driver-core/src/test/unit/com/mongodb/operation/FindOperationUnitSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/FindOperationUnitSpecification.groovy
@@ -127,9 +127,10 @@ class FindOperationUnitSpecification extends OperationUnitSpecification {
         1 * connection.release()
     }
 
+
     def 'should find with correct command'() {
         when:
-        def operation = new FindOperation<BsonDocument>(namespace, new DocumentCodec())
+        def operation = new FindOperation<BsonDocument>(namespace, new BsonDocumentCodec())
         def expectedCommand = new BsonDocument('find', new BsonString(namespace.getCollectionName()))
 
         then:

--- a/driver-core/src/test/unit/com/mongodb/operation/QueryBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/QueryBatchCursorSpecification.groovy
@@ -72,7 +72,7 @@ class QueryBatchCursorSpecification extends Specification {
         cursor.hasNext()
 
         then:
-        1 * connection.command(database, expectedCommand, _, _, _) >> {
+        1 * connection.command(database, expectedCommand, _, _, _, _) >> {
             reply
         }
         1 * connection.release()

--- a/driver/src/test/functional/com/mongodb/client/CommandMonitoringTest.java
+++ b/driver/src/test/functional/com/mongodb/client/CommandMonitoringTest.java
@@ -282,6 +282,7 @@ public class CommandMonitoringTest {
         } else if (actual.getCommandName().equals("killCursors")) {
             command.getArray("cursors").set(0, new BsonInt64(42));
         }
+        command.remove("$clusterTime");
 
         return new CommandStartedEvent(actual.getRequestId(), actual.getConnectionDescription(), actual.getDatabaseName(),
                 actual.getCommandName(), command);


### PR DESCRIPTION
This patch implements support for sessions in the core driver.  The high-level API will come in a subsequent patch.  There are four three things happening here:

* A new SessionContext is passed around, starting in the read and write bindings, and down through all the connection methods that execute commands
* The SessionContext is used to encode the cluster time and session id into the commands
* The SessionContext is updated from the responses from the server with the new cluster id and operation time

Lots of files had to change but I'll point out the spots where the rubber hits the road, so to speak.

Patch build: https://evergreen.mongodb.com/version/59afff6de3c331477100025a