### PR TITLE
JAVA-2564: ClientSession in sync driver

### DIFF
--- a/driver-core/src/main/com/mongodb/operation/OperationExecutor.java
+++ b/driver-core/src/main/com/mongodb/operation/OperationExecutor.java
@@ -22,6 +22,7 @@ import com.mongodb.ReadPreference;
  * An interface describing the execution of a read or a write operation.
  *
  * @since 3.0
+ * @deprecated there is no replacement for this interface
  */
 @Deprecated
 public interface OperationExecutor {

--- a/driver/src/main/com/mongodb/AggregateIterableImpl.java
+++ b/driver/src/main/com/mongodb/AggregateIterableImpl.java
@@ -24,7 +24,6 @@ import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.FindOptions;
 import com.mongodb.operation.AggregateOperation;
 import com.mongodb.operation.AggregateToCollectionOperation;
-import com.mongodb.operation.OperationExecutor;
 import org.bson.BsonDocument;
 import org.bson.BsonValue;
 import org.bson.codecs.configuration.CodecRegistry;

--- a/driver/src/main/com/mongodb/ChangeStreamIterableImpl.java
+++ b/driver/src/main/com/mongodb/ChangeStreamIterableImpl.java
@@ -22,7 +22,6 @@ import com.mongodb.client.MongoIterable;
 import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.FullDocument;
 import com.mongodb.operation.ChangeStreamOperation;
-import com.mongodb.operation.OperationExecutor;
 import org.bson.BsonDocument;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;

--- a/driver/src/main/com/mongodb/ClientSession.java
+++ b/driver/src/main/com/mongodb/ClientSession.java
@@ -26,6 +26,7 @@ import java.io.Closeable;
 /**
  * A client session.
  *
+ * @mongodb.server.release 3.6
  * @since 3.6
  */
 @NotThreadSafe

--- a/driver/src/main/com/mongodb/ClientSession.java
+++ b/driver/src/main/com/mongodb/ClientSession.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb;
+
+import com.mongodb.annotations.NotThreadSafe;
+import org.bson.BsonDocument;
+import org.bson.BsonTimestamp;
+
+import java.io.Closeable;
+
+/**
+ * A client session.
+ *
+ * @since 3.6
+ */
+@NotThreadSafe
+public interface ClientSession extends Closeable {
+
+    /**
+     * Get the options for this session.
+     *
+     * @return the options, which may not be null
+     */
+    ClientSessionOptions getOptions();
+
+    /**
+     * Returns true if operations in this session must be causally consistent
+     *
+     * @return whether operations in this session must be causally consistent.
+     */
+    boolean isCausallyConsistent();
+
+    /**
+     * Gets the MongoClient on which this is a session.
+     *
+     * <p>
+     * Important so that the MongoClient can check that the session is from the same MongoClient instance to which it's passed
+     * </p>
+     *
+     * @return the MongoClient on which this is a session
+     */
+    MongoClient getMongoClient();
+
+    /**
+     *
+     * @return the server session
+     */
+    ServerSession getServerSession();
+
+    /**
+     * Gets the operation time of the last operation executed in this session.
+     *
+     * @return the operation time
+     */
+    BsonTimestamp getOperationTime();
+
+    /**
+     * Set the operation time of the last operation executed in this session.
+     *
+     * @param operationTime the operation time
+     */
+    void advanceOperationTime(BsonTimestamp operationTime);
+
+    /**
+     * @param clusterTime the cluster time to advance to
+     */
+    void advanceClusterTime(BsonDocument clusterTime);
+
+    /**
+     * @return the latest cluster time seen by this session
+     */
+    BsonDocument getClusterTime();
+
+    @Override
+    void close();
+}

--- a/driver/src/main/com/mongodb/ClientSessionBinding.java
+++ b/driver/src/main/com/mongodb/ClientSessionBinding.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb;
+
+import com.mongodb.binding.ConnectionSource;
+import com.mongodb.binding.ReadWriteBinding;
+import com.mongodb.connection.Connection;
+import com.mongodb.connection.ServerDescription;
+import com.mongodb.connection.SessionContext;
+
+import static org.bson.assertions.Assertions.notNull;
+
+class ClientSessionBinding implements ReadWriteBinding {
+    private final ReadWriteBinding wrapped;
+    private final ClientSession session;
+    private final boolean ownsSession;
+    private final ClientSessionContext sessionContext;
+
+    ClientSessionBinding(final ClientSession session, final boolean ownsSession, final ReadWriteBinding wrapped) {
+        this.wrapped = notNull("wrapped", wrapped);
+        this.ownsSession = ownsSession;
+        this.session = notNull("session", session);
+        this.sessionContext = new ClientSessionContext(session);
+    }
+
+    @Override
+    public ReadPreference getReadPreference() {
+        return wrapped.getReadPreference();
+    }
+
+    @Override
+    public int getCount() {
+        return wrapped.getCount();
+    }
+
+    @Override
+    public ReadWriteBinding retain() {
+        wrapped.retain();
+        return this;
+    }
+
+    @Override
+    public void release() {
+        wrapped.release();
+        closeSessionIfCountIsZero();
+    }
+
+    private void closeSessionIfCountIsZero() {
+        if (getCount() == 0 && ownsSession) {
+            session.close();
+        }
+    }
+
+    @Override
+    public ConnectionSource getReadConnectionSource() {
+        return new SessionBindingConnectionSource(wrapped.getReadConnectionSource());
+    }
+
+    @Override
+    public SessionContext getSessionContext() {
+        return sessionContext;
+    }
+
+    @Override
+    public ConnectionSource getWriteConnectionSource() {
+        return new SessionBindingConnectionSource(wrapped.getWriteConnectionSource());
+    }
+
+    private class SessionBindingConnectionSource implements ConnectionSource {
+        private ConnectionSource wrapped;
+
+        SessionBindingConnectionSource(final ConnectionSource wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public ServerDescription getServerDescription() {
+            return wrapped.getServerDescription();
+        }
+
+        @Override
+        public SessionContext getSessionContext() {
+            return sessionContext;
+        }
+
+        @Override
+        public Connection getConnection() {
+            return wrapped.getConnection();
+        }
+
+        @Override
+        @SuppressWarnings("checkstyle:methodlength")
+        public ConnectionSource retain() {
+            wrapped = wrapped.retain();
+            return this;
+        }
+
+        @Override
+        public int getCount() {
+            return wrapped.getCount();
+        }
+
+        @Override
+        public void release() {
+            wrapped.release();
+            closeSessionIfCountIsZero();
+        }
+    }
+
+}

--- a/driver/src/main/com/mongodb/ClientSessionContext.java
+++ b/driver/src/main/com/mongodb/ClientSessionContext.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb;
+
+import com.mongodb.connection.SessionContext;
+import org.bson.BsonDocument;
+import org.bson.BsonTimestamp;
+
+import static com.mongodb.assertions.Assertions.notNull;
+
+class ClientSessionContext implements SessionContext {
+
+    private ClientSession clientSession;
+
+    ClientSessionContext(final ClientSession clientSession) {
+        this.clientSession = notNull("clientSession", clientSession);
+    }
+
+    ClientSession getClientSession() {
+        return clientSession;
+    }
+
+    @Override
+    public boolean hasSession() {
+        return true;
+    }
+
+    @Override
+    public BsonDocument getSessionId() {
+        return clientSession.getServerSession().getIdentifier();
+    }
+
+    @Override
+    public long advanceTransactionNumber() {
+        return clientSession.getServerSession().advanceTransactionNumber();
+    }
+
+    @Override
+    public void advanceOperationTime(final BsonTimestamp operationTime) {
+        clientSession.advanceOperationTime(operationTime);
+    }
+
+    @Override
+    public BsonDocument getClusterTime() {
+        return clientSession.getClusterTime();
+    }
+
+    @Override
+    public void advanceClusterTime(final BsonDocument clusterTime) {
+        clientSession.advanceClusterTime(clusterTime);
+    }
+}

--- a/driver/src/main/com/mongodb/ClientSessionOptions.java
+++ b/driver/src/main/com/mongodb/ClientSessionOptions.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb;
+
+import com.mongodb.annotations.Immutable;
+import com.mongodb.annotations.NotThreadSafe;
+import org.bson.BsonDocument;
+import org.bson.BsonTimestamp;
+
+/**
+ * The options to apply to a {@code ClientSession}.
+ *
+ * @mongodb.server.release 3.6
+ * @since 3.6
+ * @see ClientSession
+ * @see MongoClient#startSession(ClientSessionOptions)
+ */
+@Immutable
+public final class ClientSessionOptions {
+
+    private final Boolean causallyConsistent;
+    private final BsonDocument initialClusterTime;
+    private final BsonTimestamp initialOperationTime;
+
+    /**
+     * Whether operations using the session should causally consistent with each other.
+     *
+     * @return whether operations using the session should be causally consistent.  A null value indicates to use the the global default,
+     * which is currently false.
+     */
+    public Boolean isCausallyConsistent() {
+        return causallyConsistent;
+    }
+
+    /**
+     * Gets the initial cluster time to apply to the client session
+     *
+     * @return the initial cluster time, which may be null
+     */
+    public BsonDocument getInitialClusterTime() {
+        return initialClusterTime;
+    }
+
+    /**
+     * Gets the initial operation time to apply to the client session
+     * @return the initial operation time, which may be null
+     */
+    public BsonTimestamp getInitialOperationTime() {
+        return initialOperationTime;
+    }
+
+    /**
+     * Gets an instance of a builder
+     *
+     * @return a builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder for instances of {@code ClientSession}
+     */
+    @NotThreadSafe
+    public static final class Builder {
+        private Boolean causallyConsistent;
+        private BsonDocument initialClusterTime;
+        private BsonTimestamp initialOperationTime;
+
+        /**
+         * Sets whether operations using the session should causally consistent with each other.
+         *
+         * @param causallyConsistent whether operations using the session should be causally consistent
+         * @return this
+         */
+        public Builder causallyConsistent(final boolean causallyConsistent) {
+            this.causallyConsistent = causallyConsistent;
+            return this;
+        }
+
+        /**
+         * Sets the initial cluster time to apply to the client session
+         *
+         * @param initialClusterTime the initial cluster time, which may be null
+         * @return this
+         */
+        public Builder initialClusterTime(final BsonDocument initialClusterTime) {
+            this.initialClusterTime = initialClusterTime;
+            return this;
+        }
+
+        /**
+         * Gets the initial operation time to apply to the client session
+         *
+         * @param initialOperationTime the initial operation time, which may be null
+         * @return this
+         */
+        public Builder initialOperationTime(final BsonTimestamp initialOperationTime) {
+            this.initialOperationTime = initialOperationTime;
+            return this;
+        }
+        /**
+         * Build the session options instance.
+         *
+         * @return The {@code ClientSessionOptions}
+         */
+        public ClientSessionOptions build() {
+            return new ClientSessionOptions(this);
+        }
+
+        private Builder() {
+        }
+    }
+
+    private ClientSessionOptions(final Builder builder) {
+        this.causallyConsistent = builder.causallyConsistent;
+        this.initialClusterTime = builder.initialClusterTime;
+        this.initialOperationTime = builder.initialOperationTime;
+    }
+}

--- a/driver/src/main/com/mongodb/DB.java
+++ b/driver/src/main/com/mongodb/DB.java
@@ -30,7 +30,6 @@ import com.mongodb.operation.CreateViewOperation;
 import com.mongodb.operation.DropDatabaseOperation;
 import com.mongodb.operation.DropUserOperation;
 import com.mongodb.operation.ListCollectionsOperation;
-import com.mongodb.operation.OperationExecutor;
 import com.mongodb.operation.UpdateUserOperation;
 import com.mongodb.operation.UserExistsOperation;
 import org.bson.BsonDocument;

--- a/driver/src/main/com/mongodb/DBCollection.java
+++ b/driver/src/main/com/mongodb/DBCollection.java
@@ -49,7 +49,6 @@ import com.mongodb.operation.MapReduceStatistics;
 import com.mongodb.operation.MapReduceToCollectionOperation;
 import com.mongodb.operation.MapReduceWithInlineResultsOperation;
 import com.mongodb.operation.MixedBulkWriteOperation;
-import com.mongodb.operation.OperationExecutor;
 import com.mongodb.operation.ParallelCollectionScanOperation;
 import com.mongodb.operation.RenameCollectionOperation;
 import com.mongodb.operation.UpdateOperation;

--- a/driver/src/main/com/mongodb/DBCursor.java
+++ b/driver/src/main/com/mongodb/DBCursor.java
@@ -22,7 +22,6 @@ import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.DBCollectionCountOptions;
 import com.mongodb.client.model.DBCollectionFindOptions;
 import com.mongodb.operation.FindOperation;
-import com.mongodb.operation.OperationExecutor;
 import org.bson.codecs.Decoder;
 
 import java.util.ArrayList;

--- a/driver/src/main/com/mongodb/DistinctIterableImpl.java
+++ b/driver/src/main/com/mongodb/DistinctIterableImpl.java
@@ -21,7 +21,6 @@ import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoIterable;
 import com.mongodb.client.model.Collation;
 import com.mongodb.operation.DistinctOperation;
-import com.mongodb.operation.OperationExecutor;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 

--- a/driver/src/main/com/mongodb/FindIterableImpl.java
+++ b/driver/src/main/com/mongodb/FindIterableImpl.java
@@ -23,7 +23,6 @@ import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.FindOptions;
 import com.mongodb.operation.BatchCursor;
 import com.mongodb.operation.FindOperation;
-import com.mongodb.operation.OperationExecutor;
 import org.bson.BsonDocument;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;

--- a/driver/src/main/com/mongodb/ListCollectionsIterableImpl.java
+++ b/driver/src/main/com/mongodb/ListCollectionsIterableImpl.java
@@ -20,7 +20,6 @@ import com.mongodb.client.ListCollectionsIterable;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoIterable;
 import com.mongodb.operation.ListCollectionsOperation;
-import com.mongodb.operation.OperationExecutor;
 import org.bson.BsonDocument;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;

--- a/driver/src/main/com/mongodb/ListDatabasesIterableImpl.java
+++ b/driver/src/main/com/mongodb/ListDatabasesIterableImpl.java
@@ -19,7 +19,6 @@ import com.mongodb.client.ListDatabasesIterable;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoIterable;
 import com.mongodb.operation.ListDatabasesOperation;
-import com.mongodb.operation.OperationExecutor;
 import org.bson.codecs.configuration.CodecRegistry;
 
 import java.util.Collection;

--- a/driver/src/main/com/mongodb/ListIndexesIterableImpl.java
+++ b/driver/src/main/com/mongodb/ListIndexesIterableImpl.java
@@ -20,7 +20,6 @@ import com.mongodb.client.ListIndexesIterable;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoIterable;
 import com.mongodb.operation.ListIndexesOperation;
-import com.mongodb.operation.OperationExecutor;
 import org.bson.codecs.configuration.CodecRegistry;
 
 import java.util.Collection;

--- a/driver/src/main/com/mongodb/MapReduceIterableImpl.java
+++ b/driver/src/main/com/mongodb/MapReduceIterableImpl.java
@@ -24,7 +24,6 @@ import com.mongodb.client.model.FindOptions;
 import com.mongodb.client.model.MapReduceAction;
 import com.mongodb.operation.MapReduceToCollectionOperation;
 import com.mongodb.operation.MapReduceWithInlineResultsOperation;
-import com.mongodb.operation.OperationExecutor;
 import org.bson.BsonDocument;
 import org.bson.BsonJavaScript;
 import org.bson.codecs.configuration.CodecRegistry;

--- a/driver/src/main/com/mongodb/Mongo.java
+++ b/driver/src/main/com/mongodb/Mongo.java
@@ -39,7 +39,6 @@ import com.mongodb.internal.thread.DaemonThreadFactory;
 import com.mongodb.operation.CurrentOpOperation;
 import com.mongodb.operation.FsyncUnlockOperation;
 import com.mongodb.operation.ListDatabasesOperation;
-import com.mongodb.operation.OperationExecutor;
 import com.mongodb.operation.ReadOperation;
 import com.mongodb.operation.WriteOperation;
 import com.mongodb.selector.LatencyMinimizingServerSelector;

--- a/driver/src/main/com/mongodb/Mongo.java
+++ b/driver/src/main/com/mongodb/Mongo.java
@@ -34,6 +34,7 @@ import com.mongodb.connection.DefaultClusterFactory;
 import com.mongodb.connection.ServerDescription;
 import com.mongodb.connection.SocketStreamFactory;
 import com.mongodb.event.ClusterListener;
+import com.mongodb.internal.connection.ConcurrentPool;
 import com.mongodb.internal.connection.PowerOfTwoBufferPool;
 import com.mongodb.internal.thread.DaemonThreadFactory;
 import com.mongodb.operation.CurrentOpOperation;
@@ -42,12 +43,20 @@ import com.mongodb.operation.ListDatabasesOperation;
 import com.mongodb.operation.ReadOperation;
 import com.mongodb.operation.WriteOperation;
 import com.mongodb.selector.LatencyMinimizingServerSelector;
+import org.bson.BsonBinary;
 import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentWriter;
+import org.bson.BsonTimestamp;
+import org.bson.UuidRepresentation;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.UuidCodec;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
@@ -56,6 +65,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static com.mongodb.ReadPreference.primary;
+import static com.mongodb.assertions.Assertions.isTrue;
 import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE;
 import static com.mongodb.connection.ClusterType.REPLICA_SET;
 import static com.mongodb.internal.event.EventListenerHelper.getCommandListener;
@@ -637,7 +647,7 @@ public class Mongo {
      * @mongodb.driver.manual reference/command/fsync/ fsync command
      */
     public DBObject unlock() {
-        return DBObjects.toDBObject(execute(new FsyncUnlockOperation(), readPreference));
+        return DBObjects.toDBObject(createOperationExecutor().execute(new FsyncUnlockOperation(), readPreference));
     }
 
     /**
@@ -648,8 +658,8 @@ public class Mongo {
      * @mongodb.driver.manual reference/command/fsync/ fsync command
      */
     public boolean isLocked() {
-        return execute(new CurrentOpOperation(), ReadPreference.primary())
-               .getBoolean("fsyncLock", BsonBoolean.FALSE).getValue();
+        return createOperationExecutor().execute(new CurrentOpOperation(), ReadPreference.primary())
+                       .getBoolean("fsyncLock", BsonBoolean.FALSE).getValue();
     }
 
     @Override
@@ -774,18 +784,6 @@ public class Mongo {
         return credentialsList;
     }
 
-    WriteBinding getWriteBinding() {
-        return getReadWriteBinding(primary());
-    }
-
-    ReadBinding getReadBinding(final ReadPreference readPreference) {
-        return getReadWriteBinding(readPreference);
-    }
-
-    private ReadWriteBinding getReadWriteBinding(final ReadPreference readPreference) {
-        return new ClusterBinding(getCluster(), readPreference);
-    }
-
     void addOrphanedCursor(final ServerCursor serverCursor, final MongoNamespace namespace) {
         orphanedCursors.add(new ServerCursorAndNamespace(serverCursor, namespace));
     }
@@ -794,31 +792,162 @@ public class Mongo {
         return new OperationExecutor() {
             @Override
             public <T> T execute(final ReadOperation<T> operation, final ReadPreference readPreference) {
-                return Mongo.this.execute(operation, readPreference);
+                return execute(operation, readPreference, null);
             }
 
             @Override
             public <T> T execute(final WriteOperation<T> operation) {
-                return Mongo.this.execute(operation);
+                return execute(operation, null);
+            }
+
+            @Override
+            public <T> T execute(final ReadOperation<T> operation, final ReadPreference readPreference, final ClientSession session) {
+                ClientSession actualClientSession = getClientSession(session);
+                ReadBinding binding = getReadBinding(readPreference, actualClientSession, session == null && actualClientSession != null);
+                try {
+                    return operation.execute(binding);
+                } finally {
+                    binding.release();
+                }
+            }
+
+            @Override
+            public <T> T execute(final WriteOperation<T> operation, final ClientSession session) {
+                ClientSession actualClientSession = getClientSession(session);
+                WriteBinding binding = getWriteBinding(actualClientSession, session == null && actualClientSession != null);
+                try {
+                    return operation.execute(binding);
+                } finally {
+                    binding.release();
+                }
+            }
+
+            WriteBinding getWriteBinding(final ClientSession session, final boolean ownsSession) {
+                return getReadWriteBinding(primary(), session, ownsSession);
+            }
+
+            ReadBinding getReadBinding(final ReadPreference readPreference, final ClientSession session, final boolean ownsSession) {
+                return getReadWriteBinding(readPreference, session, ownsSession);
+            }
+
+            ReadWriteBinding getReadWriteBinding(final ReadPreference readPreference, final ClientSession session,
+                                                         final boolean ownsSession) {
+                ReadWriteBinding readWriteBinding = new ClusterBinding(getCluster(), readPreference);
+                if (session != null) {
+                    readWriteBinding = new ClientSessionBinding(session, ownsSession, readWriteBinding);
+                }
+                return readWriteBinding;
+            }
+
+            ClientSession getClientSession(final ClientSession clientSessionFromOperation) {
+                ClientSession session;
+                if (clientSessionFromOperation != null) {
+                    isTrue("ClientSession from same MongoClient", clientSessionFromOperation.getMongoClient() == Mongo.this);
+                    session = clientSessionFromOperation;
+                } else {
+                    session = createClientSession(ClientSessionOptions.builder().build());
+                }
+                return session;
             }
         };
     }
 
-    <T> T execute(final ReadOperation<T> operation, final ReadPreference readPreference) {
-        ReadBinding binding = getReadBinding(readPreference);
-        try {
-            return operation.execute(binding);
-        } finally {
-            binding.release();
+    ClientSession createClientSession(final ClientSessionOptions options) {
+        if (cluster.getDescription().getLogicalSessionTimeoutMinutes() != null) {
+            return new ClientSessionImpl(this, options);
+        } else {
+            return null;
         }
     }
 
-    <T> T execute(final WriteOperation<T> operation) {
-        WriteBinding binding = getWriteBinding();
-        try {
-            return operation.execute(binding);
-        } finally {
-            binding.release();
+    static class ClientSessionImpl implements ClientSession {
+        private static final String CLUSTER_TIME_KEY = "clusterTime";
+
+        private final Mongo mongo;
+        private final ServerSession serverSession;
+        private final ClientSessionOptions options;
+        private BsonDocument clusterTime;
+        private BsonTimestamp operationTime;
+
+        ClientSessionImpl(final Mongo mongo, final ClientSessionOptions options) {
+            this.mongo = mongo;
+            this.serverSession = mongo.serverSessionPool.get();
+            this.options = options;
+            clusterTime = options.getInitialClusterTime();
+            operationTime = options.getInitialOperationTime();
+        }
+
+        @Override
+        public ClientSessionOptions getOptions() {
+            return options;
+        }
+
+        @Override
+        public boolean isCausallyConsistent() {
+            return options.isCausallyConsistent() == null ? false : options.isCausallyConsistent();
+        }
+
+        @Override
+        public MongoClient getMongoClient() {
+            if (mongo instanceof MongoClient) {
+                return (MongoClient) mongo;
+            }
+            return null;
+        }
+
+        @Override
+        public ServerSession getServerSession() {
+            return serverSession;
+        }
+
+        @Override
+        public BsonTimestamp getOperationTime() {
+            return operationTime;
+        }
+
+        @Override
+        public void advanceOperationTime(final BsonTimestamp operationTime) {
+            this.operationTime = operationTime; // TODO: ensure it's advancing
+        }
+
+        @Override
+        public BsonDocument getClusterTime() {
+            return clusterTime;
+        }
+
+        @Override
+        public void advanceClusterTime(final BsonDocument clusterTime) {
+            if (this.clusterTime == null
+                        || clusterTime.getTimestamp(CLUSTER_TIME_KEY).compareTo(this.clusterTime.getTimestamp(CLUSTER_TIME_KEY)) > 0) {
+                this.clusterTime = clusterTime;
+            }
+        }
+
+        @Override
+        public void close() {
+            mongo.serverSessionPool.release(serverSession);
+        }
+    }
+
+    private final ConcurrentPool<ServerSession> serverSessionPool =
+            new ConcurrentPool<ServerSession>(Integer.MAX_VALUE, new ServerSessionItemFactory());
+
+    private static class ServerSessionImpl implements ServerSession {
+        private final BsonDocument identifier;
+        private int transactionNumber;
+
+        ServerSessionImpl(final BsonBinary identifier) {
+            this.identifier = new BsonDocument("id", identifier);
+        }
+
+        @Override
+        public BsonDocument getIdentifier() {
+            return identifier;
+        }
+
+        @Override
+        public long advanceTransactionNumber() {
+            return transactionNumber++;
         }
     }
 
@@ -870,6 +999,35 @@ public class Mongo {
         ServerCursorAndNamespace(final ServerCursor serverCursor, final MongoNamespace namespace) {
             this.serverCursor = serverCursor;
             this.namespace = namespace;
+        }
+    }
+
+
+    private static final class ServerSessionItemFactory implements ConcurrentPool.ItemFactory<ServerSession> {
+        @Override
+        public ServerSession create(final boolean initialize) {
+            return new ServerSessionImpl(createNewServerSessionIdentifier());
+        }
+
+        @Override
+        public void close(final ServerSession serverSession) {
+            // TODO: pruning
+        }
+
+        @Override
+        public boolean shouldPrune(final ServerSession serverSession) {
+            return false;
+        }
+
+        private BsonBinary createNewServerSessionIdentifier() {
+            UuidCodec uuidCodec = new UuidCodec(UuidRepresentation.STANDARD);
+            BsonDocument holder = new BsonDocument();
+            BsonDocumentWriter bsonDocumentWriter = new BsonDocumentWriter(holder);
+            bsonDocumentWriter.writeStartDocument();
+            bsonDocumentWriter.writeName("id");
+            uuidCodec.encode(bsonDocumentWriter, UUID.randomUUID(), EncoderContext.builder().build());
+            bsonDocumentWriter.writeEndDocument();
+            return holder.getBinary("id");
         }
     }
 

--- a/driver/src/main/com/mongodb/MongoClient.java
+++ b/driver/src/main/com/mongodb/MongoClient.java
@@ -412,6 +412,23 @@ public class MongoClient extends Mongo implements Closeable {
                 clientOptions.getWriteConcern(), clientOptions.getReadConcern(), createOperationExecutor());
     }
 
+    /**
+     * Creates a client session.
+     *
+     * @param options the options for the client session
+     * @return the client session
+     * @throws MongoClientException if the MongoDB cluster to which this client is connected does not support sessions
+     * @mongodb.server.release 3.6
+     * @since 3.6
+     */
+    public ClientSession startSession(final ClientSessionOptions options) {
+        ClientSession clientSession = createClientSession(options);
+        if (clientSession == null) {
+            throw new MongoClientException("Sessions are not supported by the MongoDB cluster to which this client is connected");
+        }
+        return clientSession;
+    }
+
     static DBObjectCodec getCommandCodec() {
         return new DBObjectCodec(getDefaultCodecRegistry());
     }

--- a/driver/src/main/com/mongodb/MongoCollectionImpl.java
+++ b/driver/src/main/com/mongodb/MongoCollectionImpl.java
@@ -60,7 +60,6 @@ import com.mongodb.operation.FindAndDeleteOperation;
 import com.mongodb.operation.FindAndReplaceOperation;
 import com.mongodb.operation.FindAndUpdateOperation;
 import com.mongodb.operation.MixedBulkWriteOperation;
-import com.mongodb.operation.OperationExecutor;
 import com.mongodb.operation.RenameCollectionOperation;
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentWrapper;

--- a/driver/src/main/com/mongodb/MongoDatabaseImpl.java
+++ b/driver/src/main/com/mongodb/MongoDatabaseImpl.java
@@ -28,7 +28,6 @@ import com.mongodb.operation.CommandReadOperation;
 import com.mongodb.operation.CreateCollectionOperation;
 import com.mongodb.operation.CreateViewOperation;
 import com.mongodb.operation.DropDatabaseOperation;
-import com.mongodb.operation.OperationExecutor;
 import org.bson.BsonDocument;
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;

--- a/driver/src/main/com/mongodb/OperationExecutor.java
+++ b/driver/src/main/com/mongodb/OperationExecutor.java
@@ -41,4 +41,25 @@ interface OperationExecutor {
      * @return the result of executing the operation.
      */
     <T> T execute(WriteOperation<T> operation);
+
+    /**
+     * Execute the read operation with the given read preference.
+     *
+     * @param <T> the operations result type.
+     * @param operation the read operation.
+     * @param readPreference the read preference.
+     * @param session the session to associate this operation with
+     * @return the result of executing the operation.
+     */
+    <T> T execute(ReadOperation<T> operation, ReadPreference readPreference, ClientSession session);
+
+    /**
+     * Execute the write operation.
+     *
+     * @param operation the write operation.
+     * @param session the session to associate this operation with
+     * @param <T> the operations result type.
+     * @return the result of executing the operation.
+     */
+    <T> T execute(WriteOperation<T> operation, ClientSession session);
 }

--- a/driver/src/main/com/mongodb/OperationExecutor.java
+++ b/driver/src/main/com/mongodb/OperationExecutor.java
@@ -14,23 +14,21 @@
  * limitations under the License.
  */
 
-package com.mongodb.operation;
+package com.mongodb;
 
-import com.mongodb.ReadPreference;
+import com.mongodb.operation.ReadOperation;
+import com.mongodb.operation.WriteOperation;
 
 /**
  * An interface describing the execution of a read or a write operation.
- *
- * @since 3.0
  */
-@Deprecated
-public interface OperationExecutor {
+interface OperationExecutor {
     /**
      * Execute the read operation with the given read preference.
      *
+     * @param <T> the operations result type.
      * @param operation the read operation.
      * @param readPreference the read preference.
-     * @param <T> the operations result type.
      * @return the result of executing the operation.
      */
     <T> T execute(ReadOperation<T> operation, ReadPreference readPreference);

--- a/driver/src/main/com/mongodb/OperationIterable.java
+++ b/driver/src/main/com/mongodb/OperationIterable.java
@@ -19,7 +19,6 @@ package com.mongodb;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoIterable;
 import com.mongodb.operation.BatchCursor;
-import com.mongodb.operation.OperationExecutor;
 import com.mongodb.operation.ReadOperation;
 
 import java.util.Collection;

--- a/driver/src/main/com/mongodb/ServerSession.java
+++ b/driver/src/main/com/mongodb/ServerSession.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb;
+
+import org.bson.BsonDocument;
+
+/**
+ * A MongoDB server session.
+ *
+ * @mongodb.server.release 3.6
+ * @since 3.6
+ */
+public interface ServerSession {
+
+    /**
+     * @return the server session identifier
+     */
+    BsonDocument getIdentifier();
+
+    /**
+     * Return the next available transaction number.
+     *
+     * @return the next transaction number
+     */
+    long advanceTransactionNumber();
+}

--- a/driver/src/test/functional/com/mongodb/DBFunctionalSpecification.groovy
+++ b/driver/src/test/functional/com/mongodb/DBFunctionalSpecification.groovy
@@ -16,7 +16,6 @@
 
 package com.mongodb
 
-import com.mongodb.operation.OperationExecutor
 import org.bson.BsonDocument
 import org.bson.BsonDouble
 import org.bson.BsonInt32

--- a/driver/src/test/functional/com/mongodb/MongoClientListenerRegistrationSpecification.groovy
+++ b/driver/src/test/functional/com/mongodb/MongoClientListenerRegistrationSpecification.groovy
@@ -26,6 +26,7 @@ import org.bson.Document
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
+import static com.mongodb.Fixture.getMongoClientURI
 import static com.mongodb.Fixture.mongoClientURI
 
 class MongoClientListenerRegistrationSpecification extends FunctionalSpecification {
@@ -49,14 +50,13 @@ class MongoClientListenerRegistrationSpecification extends FunctionalSpecificati
         }
 
         when:
-        def options = MongoClientOptions.builder(mongoClientURI.options)
+        def optionBuilder = MongoClientOptions.builder(mongoClientURI.options)
                 .addClusterListener(clusterListener)
                 .addCommandListener(commandListener)
                 .addConnectionPoolListener(connectionPoolListener)
                 .addServerListener(serverListener)
                 .addServerMonitorListener(serverMonitorListener)
-                .build()
-        def client = new MongoClient(mongoClientURI.getHosts().collect { new ServerAddress(it) }, options)
+        def client = new MongoClient(getMongoClientURI(optionBuilder))
 
         then:
         client.getDatabase('admin').runCommand(new Document('ping', 1))
@@ -65,10 +65,9 @@ class MongoClientListenerRegistrationSpecification extends FunctionalSpecificati
     def 'should register single command listener'() {
         given:
         def first = Mock(CommandListener)
-        def client = new MongoClient(mongoClientURI.getHosts().collect { new ServerAddress(it) },
-                MongoClientOptions.builder(mongoClientURI.options)
-                                                       .addCommandListener(first)
-                                                       .build())
+        def optionsBuilder = MongoClientOptions.builder(mongoClientURI.options)
+                .addCommandListener(first)
+        def client = new MongoClient(getMongoClientURI(optionsBuilder))
 
         when:
         client.getDatabase('admin').runCommand(new Document('ping', 1))
@@ -82,10 +81,10 @@ class MongoClientListenerRegistrationSpecification extends FunctionalSpecificati
         given:
         def first = Mock(CommandListener)
         def second = Mock(CommandListener)
-        def client = new MongoClient(mongoClientURI.getHosts().collect { new ServerAddress(it) },
-                                     MongoClientOptions.builder(mongoClientURI.options)
-                                                       .addCommandListener(first)
-                                                       .addCommandListener(second).build());
+        def optionsBuilder = MongoClientOptions.builder(mongoClientURI.options)
+                .addCommandListener(first)
+                .addCommandListener(second)
+        def client = new MongoClient(getMongoClientURI(optionsBuilder));
 
         when:
         client.getDatabase('admin').runCommand(new Document('ping', 1))
@@ -114,12 +113,11 @@ class MongoClientListenerRegistrationSpecification extends FunctionalSpecificati
             }
         }
 
-        def client = new MongoClient(mongoClientURI.getHosts().collect { new ServerAddress(it) },
-                MongoClientOptions.builder(mongoClientURI.options)
-                        .addClusterListener(clusterListener)
-                        .addServerListener(serverListener)
-                        .addServerMonitorListener(serverMonitorListener)
-                        .build());
+        def optionsBuilder = MongoClientOptions.builder(mongoClientURI.options)
+                .addClusterListener(clusterListener)
+                .addServerListener(serverListener)
+                .addServerMonitorListener(serverMonitorListener)
+        def client = new MongoClient(getMongoClientURI(optionsBuilder));
 
         when:
         def finished = latch.await(5, TimeUnit.SECONDS)
@@ -161,15 +159,14 @@ class MongoClientListenerRegistrationSpecification extends FunctionalSpecificati
             }
         }
 
-        def client = new MongoClient(mongoClientURI.getHosts().collect { new ServerAddress(it) },
-                MongoClientOptions.builder(mongoClientURI.options)
-                        .addClusterListener(clusterListener)
-                        .addServerListener(serverListener)
-                        .addServerMonitorListener(serverMonitorListener)
-                        .addClusterListener(clusterListenerTwo)
-                        .addServerListener(serverListenerTwo)
-                        .addServerMonitorListener(serverMonitorListenerTwo)
-                        .build());
+        def optionsBuilder = MongoClientOptions.builder(mongoClientURI.options)
+                .addClusterListener(clusterListener)
+                .addServerListener(serverListener)
+                .addServerMonitorListener(serverMonitorListener)
+                .addClusterListener(clusterListenerTwo)
+                .addServerListener(serverListenerTwo)
+                .addServerMonitorListener(serverMonitorListenerTwo)
+        def client = new MongoClient(getMongoClientURI(optionsBuilder));
 
         when:
         def finished = latch.await(5, TimeUnit.SECONDS)

--- a/driver/src/test/functional/com/mongodb/MongoClientSessionSpecification.groovy
+++ b/driver/src/test/functional/com/mongodb/MongoClientSessionSpecification.groovy
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb
+
+import com.mongodb.connection.TestCommandListener
+import com.mongodb.event.CommandStartedEvent
+import org.bson.BsonBinarySubType
+import org.bson.BsonDocument
+import org.bson.BsonInt32
+import org.bson.BsonTimestamp
+import spock.lang.IgnoreIf
+
+import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.Fixture.getMongoClientURI
+
+class MongoClientSessionSpecification extends FunctionalSpecification {
+
+    @IgnoreIf({ serverVersionAtLeast(3, 5) })
+    def 'should throw MongoClientException starting a session when sessions are not supported'() {
+        when:
+        Fixture.getMongoClient().startSession(ClientSessionOptions.builder().build())
+
+        then:
+        thrown(MongoClientException)
+    }
+
+    @IgnoreIf({ !serverVersionAtLeast(3, 5) })
+    def 'should create session with correct defaults'() {
+        when:
+        def options = ClientSessionOptions.builder().build()
+        def clientSession = Fixture.getMongoClient().startSession(options)
+
+        then:
+        clientSession != null
+        clientSession.getMongoClient() == Fixture.getMongoClient()
+        !clientSession.isCausallyConsistent()
+        clientSession.getOptions() == options
+        clientSession.getClusterTime() == null
+        clientSession.getOperationTime() == null
+        clientSession.getServerSession() != null
+    }
+
+    @IgnoreIf({ !serverVersionAtLeast(3, 5) })
+    def 'should apply causally consistent session option to client session'() {
+        when:
+        def clientSession = Fixture.getMongoClient().startSession(ClientSessionOptions.builder()
+                .causallyConsistent(causallyConsistent)
+                .initialClusterTime(initialClusterTime)
+                .initialOperationTime(initialOperationTime)
+                .build())
+
+        then:
+        clientSession != null
+        clientSession.isCausallyConsistent() == causallyConsistent
+        clientSession.getClusterTime() == initialClusterTime
+        clientSession.getOperationTime() == initialOperationTime
+
+        where:
+        [causallyConsistent, initialClusterTime, initialOperationTime] << [
+                [true, false],
+                [null, new BsonDocument('x', new BsonInt32(1))],
+                [null, new BsonTimestamp(42, 1)]
+        ].combinations()
+    }
+
+    @IgnoreIf({ !serverVersionAtLeast(3, 5) })
+    def 'client session should have server session with valid identifier'() {
+        given:
+        def clientSession = Fixture.getMongoClient().startSession(ClientSessionOptions.builder().build())
+
+        when:
+        def identifier = clientSession.getServerSession().identifier
+
+        then:
+        identifier.size() == 1
+        identifier.containsKey('id')
+        identifier.get('id').isBinary()
+        identifier.getBinary('id').getType() == BsonBinarySubType.UUID_STANDARD.value
+        identifier.getBinary('id').data.length == 16
+    }
+
+    @IgnoreIf({ !serverVersionAtLeast(3, 5) })
+    def 'should use a default session'() {
+        given:
+        def commandListener = new TestCommandListener()
+        def optionsBuilder = MongoClientOptions.builder()
+                .addCommandListener(commandListener)
+        def client = new MongoClient(getMongoClientURI(optionsBuilder))
+
+        when:
+        client.getDatabase('admin').runCommand(new BsonDocument('ping', new BsonInt32(1)))
+
+        then:
+        def pingCommandStartedEvent = commandListener.events.get(0)
+        (pingCommandStartedEvent as CommandStartedEvent).command.containsKey('lsid')
+    }
+
+    @IgnoreIf({ serverVersionAtLeast(3, 5) })
+    def 'should not use a default session when sessions are not supported'() {
+        given:
+        def commandListener = new TestCommandListener()
+        def optionsBuilder = MongoClientOptions.builder()
+                .addCommandListener(commandListener)
+        def client = new MongoClient(getMongoClientURI(optionsBuilder))
+
+        when:
+        client.getDatabase('admin').runCommand(new BsonDocument('ping', new BsonInt32(1)))
+
+        then:
+        def pingCommandStartedEvent = commandListener.events.get(0)
+        !(pingCommandStartedEvent as CommandStartedEvent).command.containsKey('lsid')
+    }
+}

--- a/driver/src/test/functional/com/mongodb/MongoClientsSpecification.groovy
+++ b/driver/src/test/functional/com/mongodb/MongoClientsSpecification.groovy
@@ -52,5 +52,4 @@ class MongoClientsSpecification extends FunctionalSpecification {
         profileCollection?.drop()
         client?.close()
     }
-
 }

--- a/driver/src/test/functional/com/mongodb/client/CommandMonitoringTest.java
+++ b/driver/src/test/functional/com/mongodb/client/CommandMonitoringTest.java
@@ -283,6 +283,7 @@ public class CommandMonitoringTest {
             command.getArray("cursors").set(0, new BsonInt64(42));
         }
         command.remove("$clusterTime");
+        command.remove("lsid");
 
         return new CommandStartedEvent(actual.getRequestId(), actual.getConnectionDescription(), actual.getDatabaseName(),
                 actual.getCommandName(), command);

--- a/driver/src/test/unit/com/mongodb/ClientSessionBindingSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/ClientSessionBindingSpecification.groovy
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb
+
+import com.mongodb.binding.ClusterBinding
+import com.mongodb.binding.ConnectionSource
+import com.mongodb.binding.ReadWriteBinding
+import com.mongodb.connection.Cluster
+import spock.lang.Specification
+
+class ClientSessionBindingSpecification extends Specification {
+    def 'should return the session context from the binding'() {
+        given:
+        def session = Stub(ClientSession)
+        def wrappedBinding = Stub(ReadWriteBinding)
+        def binding = new ClientSessionBinding(session, false, wrappedBinding)
+
+        when:
+        def context = binding.getSessionContext()
+
+        then:
+        (context as ClientSessionContext).getClientSession() == session
+    }
+
+    def 'should return the session context from the connection source'() {
+        given:
+        def session = Stub(ClientSession)
+        def wrappedBinding = Mock(ReadWriteBinding)
+        def binding = new ClientSessionBinding(session, false, wrappedBinding)
+
+        when:
+        def readConnectionSource = binding.getReadConnectionSource()
+        def context = readConnectionSource.getSessionContext()
+
+        then:
+        (context as ClientSessionContext).getClientSession() == session
+        1 * wrappedBinding.getReadConnectionSource() >> {
+            Stub(ConnectionSource)
+        }
+
+        when:
+        def writeConnectionSource = binding.getWriteConnectionSource()
+        context = writeConnectionSource.getSessionContext()
+
+        then:
+        (context as ClientSessionContext).getClientSession() == session
+        1 * wrappedBinding.getWriteConnectionSource() >> {
+            Stub(ConnectionSource)
+        }
+    }
+
+    def 'should close client session when binding reference count drops to zero if it is owned by the binding'() {
+        given:
+        def session = Mock(ClientSession)
+        def wrappedBinding = createStubBinding()
+        def binding = new ClientSessionBinding(session, true, wrappedBinding)
+        binding.retain()
+
+        when:
+        binding.release()
+
+        then:
+        0 * session.close()
+
+        when:
+        binding.release()
+
+        then:
+        1 * session.close()
+    }
+
+    def 'should close client session when binding reference count drops to zero due to connection source if it is owned by the binding'() {
+        given:
+        def session = Mock(ClientSession)
+        def wrappedBinding = createStubBinding()
+        def binding = new ClientSessionBinding(session, true, wrappedBinding)
+        def readConnectionSource = binding.getReadConnectionSource()
+        def writeConnectionSource = binding.getWriteConnectionSource()
+
+        when:
+        binding.release()
+
+        then:
+        0 * session.close()
+
+        when:
+        writeConnectionSource.release()
+
+        then:
+        0 * session.close()
+
+        when:
+        readConnectionSource.release()
+
+        then:
+        1 * session.close()
+    }
+
+    def 'should not close client session when binding reference count drops to zero if it is not owned by the binding'() {
+        given:
+        def session = Mock(ClientSession)
+        def wrappedBinding = createStubBinding()
+        def binding = new ClientSessionBinding(session, false, wrappedBinding)
+        binding.retain()
+
+        when:
+        binding.release()
+
+        then:
+        0 * session.close()
+
+        when:
+        binding.release()
+
+        then:
+        0 * session.close()
+    }
+
+    private ReadWriteBinding createStubBinding() {
+        def cluster = Stub(Cluster)
+        new ClusterBinding(cluster, ReadPreference.primary())
+    }
+}

--- a/driver/src/test/unit/com/mongodb/ClientSessionContextSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/ClientSessionContextSpecification.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb
+
+import org.bson.BsonBoolean
+import org.bson.BsonDocument
+import org.bson.BsonInt32
+import org.bson.BsonTimestamp
+import spock.lang.Specification
+
+class ClientSessionContextSpecification extends Specification {
+
+    def 'should have session'() {
+        given:
+        def clientSession = Mock(ClientSession)
+        def context = new ClientSessionContext(clientSession)
+
+        expect:
+        context.hasSession()
+    }
+
+    def 'should forward all methods to wrapped session'() {
+        given:
+        def expectedSessionId = new BsonDocument('id', new BsonInt32(1))
+        def expectedClusterTime = new BsonDocument('x', BsonBoolean.TRUE)
+        def expectedOperationTime = new BsonTimestamp(42, 1)
+
+        def serverSession = Mock(ServerSession)
+        def clientSession = Mock(ClientSession) {
+            _ * getServerSession() >> {
+                serverSession
+            }
+        }
+        def context = new ClientSessionContext(clientSession)
+
+        when:
+        def sessionId = context.getSessionId()
+
+        then:
+        sessionId == expectedSessionId
+        1 * serverSession.getIdentifier() >> {
+            expectedSessionId
+        }
+
+        when:
+        context.advanceClusterTime(expectedClusterTime)
+
+        then:
+        1 * clientSession.advanceClusterTime(expectedClusterTime)
+
+        when:
+        context.advanceOperationTime(expectedOperationTime)
+
+        then:
+        1 * clientSession.advanceOperationTime(expectedOperationTime)
+
+        when:
+        context.advanceTransactionNumber()
+
+        then:
+        1 * serverSession.advanceTransactionNumber()
+
+        when:
+        def clusterTime = context.getClusterTime()
+
+        then:
+        clusterTime == expectedClusterTime
+        1 * clientSession.getClusterTime() >> {
+            expectedClusterTime
+        }
+    }
+}

--- a/driver/src/test/unit/com/mongodb/ClientSessionOptionsSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/ClientSessionOptionsSpecification.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb
+
+import org.bson.BsonDocument
+import org.bson.BsonInt32
+import org.bson.BsonTimestamp
+import spock.lang.Specification
+
+class ClientSessionOptionsSpecification extends Specification {
+
+    def 'should have correct defaults'() {
+        when:
+        def options = ClientSessionOptions.builder().build()
+
+        then:
+        options.isCausallyConsistent() == null
+        options.getInitialClusterTime() == null
+        options.getInitialOperationTime() == null
+    }
+
+    def 'should apply options set in builder'() {
+        when:
+        def options = ClientSessionOptions.builder()
+                .causallyConsistent(causallyConsistent)
+                .initialClusterTime(initialClusterTime)
+                .initialOperationTime(initialOperationTime)
+                .build()
+
+        then:
+        options.isCausallyConsistent() == causallyConsistent
+        options.getInitialClusterTime() == initialClusterTime
+        options.getInitialOperationTime() == initialOperationTime
+
+        where:
+        [causallyConsistent, initialClusterTime, initialOperationTime] << [
+                [true, false],
+                [null, new BsonDocument('x', new BsonInt32(1))],
+                [null, new BsonTimestamp(42, 1)]
+        ].combinations()
+    }
+}

--- a/driver/src/test/unit/com/mongodb/MongoCollectionSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/MongoCollectionSpecification.groovy
@@ -54,7 +54,6 @@ import com.mongodb.operation.FindAndReplaceOperation
 import com.mongodb.operation.FindAndUpdateOperation
 import com.mongodb.operation.ListIndexesOperation
 import com.mongodb.operation.MixedBulkWriteOperation
-import com.mongodb.operation.OperationExecutor
 import com.mongodb.operation.RenameCollectionOperation
 import org.bson.BsonDocument
 import org.bson.BsonInt32

--- a/driver/src/test/unit/com/mongodb/MongoDatabaseSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/MongoDatabaseSpecification.groovy
@@ -27,7 +27,6 @@ import com.mongodb.operation.CommandReadOperation
 import com.mongodb.operation.CreateCollectionOperation
 import com.mongodb.operation.CreateViewOperation
 import com.mongodb.operation.DropDatabaseOperation
-import com.mongodb.operation.OperationExecutor
 import org.bson.BsonBoolean
 import org.bson.BsonDocument
 import org.bson.BsonInt32

--- a/driver/src/test/unit/com/mongodb/TestOperationExecutor.java
+++ b/driver/src/test/unit/com/mongodb/TestOperationExecutor.java
@@ -37,24 +37,35 @@ class TestOperationExecutor implements OperationExecutor {
     @Override
     @SuppressWarnings("unchecked")
     public <T> T execute(final ReadOperation<T> operation, final ReadPreference readPreference) {
-        readOperations.add(operation);
-        readPreferences.add(readPreference);
-        return (T) getResponse();
+        return execute(operation, readPreference, null);
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public <T> T execute(final WriteOperation<T> operation) {
-        writeOperations.add(operation);
-        return (T) getResponse();
+        return execute(operation, null);
     }
 
-    private Object getResponse() {
+    @Override
+    public <T> T execute(final ReadOperation<T> operation, final ReadPreference readPreference, final ClientSession session) {
+        readOperations.add(operation);
+        readPreferences.add(readPreference);
+        return getResponse();
+    }
+
+    @Override
+    public <T> T execute(final WriteOperation<T> operation, final ClientSession session) {
+        writeOperations.add(operation);
+        return getResponse();
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T getResponse() {
         Object response = responses.remove(0);
         if (response instanceof RuntimeException) {
             throw (RuntimeException) response;
         }
-        return response;
+        return (T) response;
     }
 
     ReadOperation getReadOperation() {

--- a/driver/src/test/unit/com/mongodb/TestOperationExecutor.java
+++ b/driver/src/test/unit/com/mongodb/TestOperationExecutor.java
@@ -16,7 +16,6 @@
 
 package com.mongodb;
 
-import com.mongodb.operation.OperationExecutor;
 import com.mongodb.operation.ReadOperation;
 import com.mongodb.operation.WriteOperation;
 

--- a/driver/src/test/unit/com/mongodb/client/gridfs/GridFSBucketSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/client/gridfs/GridFSBucketSpecification.groovy
@@ -33,7 +33,7 @@ import com.mongodb.client.result.DeleteResult
 import com.mongodb.client.result.UpdateResult
 import com.mongodb.operation.BatchCursor
 import com.mongodb.operation.FindOperation
-import com.mongodb.operation.OperationExecutor
+import com.mongodb.OperationExecutor
 import org.bson.BsonDocument
 import org.bson.BsonObjectId
 import org.bson.BsonString

--- a/driver/src/test/unit/com/mongodb/client/gridfs/GridFSBucketsSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/client/gridfs/GridFSBucketsSpecification.groovy
@@ -20,7 +20,7 @@ import com.mongodb.MongoDatabaseImpl
 import com.mongodb.ReadConcern
 import com.mongodb.ReadPreference
 import com.mongodb.WriteConcern
-import com.mongodb.operation.OperationExecutor
+import com.mongodb.OperationExecutor
 import org.bson.codecs.configuration.CodecRegistry
 import spock.lang.Specification
 


### PR DESCRIPTION
* Add ClientSession and ServerSession
* Add MongoClient#startSession
* Add default ClientSession if none specified

The first commit is a refactoring, probably easiest to look at it separately.

Next step is to overload all MongoCollection methods to add a ClientSession 

Patch build: https://evergreen.mongodb.com/version/59b97815e3c3316a9e004a1d