### PR TITLE
JAVA-2564: Overload all MongoCollection methods to take a ClientSession

### DIFF
--- a/driver/src/main/com/mongodb/AggregateIterableImpl.java
+++ b/driver/src/main/com/mongodb/AggregateIterableImpl.java
@@ -50,10 +50,11 @@ class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
     private Boolean bypassDocumentValidation;
     private Collation collation;
 
-    AggregateIterableImpl(final MongoNamespace namespace, final Class<TDocument> documentClass, final Class<TResult> resultClass,
-                          final CodecRegistry codecRegistry, final ReadPreference readPreference, final ReadConcern readConcern,
-                          final WriteConcern writeConcern, final OperationExecutor executor, final List<? extends Bson> pipeline) {
-        super(executor, readConcern, readPreference);
+    AggregateIterableImpl(final ClientSession clientSession, final MongoNamespace namespace, final Class<TDocument> documentClass,
+                          final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
+                          final ReadConcern readConcern, final WriteConcern writeConcern, final OperationExecutor executor,
+                          final List<? extends Bson> pipeline) {
+        super(clientSession, executor, readConcern, readPreference);
         this.namespace = notNull("namespace", namespace);
         this.documentClass = notNull("documentClass", documentClass);
         this.resultClass = notNull("resultClass", resultClass);
@@ -70,7 +71,7 @@ class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
             throw new IllegalStateException("The last stage of the aggregation pipeline must be $out");
         }
 
-        getExecutor().execute(createAggregateToCollectionOperation(aggregateList));
+        getExecutor().execute(createAggregateToCollectionOperation(aggregateList), getClientSession());
     }
 
     @Override
@@ -126,7 +127,7 @@ class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
         BsonValue outCollection = getOutCollection(aggregateList);
 
         if (outCollection != null) {
-            getExecutor().execute(createAggregateToCollectionOperation(aggregateList));
+            getExecutor().execute(createAggregateToCollectionOperation(aggregateList), getClientSession());
             FindOperation<TResult> findOperation =
                     new FindOperation<TResult>(new MongoNamespace(namespace.getDatabaseName(), outCollection.asString().getValue()),
                                                       codecRegistry.get(resultClass))

--- a/driver/src/main/com/mongodb/ChangeStreamIterableImpl.java
+++ b/driver/src/main/com/mongodb/ChangeStreamIterableImpl.java
@@ -49,10 +49,10 @@ final class ChangeStreamIterableImpl<TResult> extends MongoIterableImpl<ChangeSt
     private Collation collation;
 
 
-    ChangeStreamIterableImpl(final MongoNamespace namespace, final CodecRegistry codecRegistry, final ReadPreference readPreference,
-                             final ReadConcern readConcern, final OperationExecutor executor, final List<? extends Bson> pipeline,
-                             final Class<TResult> resultClass) {
-        super(executor, readConcern, readPreference);
+    ChangeStreamIterableImpl(final ClientSession clientSession, final MongoNamespace namespace, final CodecRegistry codecRegistry,
+                             final ReadPreference readPreference, final ReadConcern readConcern, final OperationExecutor executor,
+                             final List<? extends Bson> pipeline, final Class<TResult> resultClass) {
+        super(clientSession, executor, readConcern, readPreference);
         this.namespace = notNull("namespace", namespace);
         this.codecRegistry = notNull("codecRegistry", codecRegistry);
         this.pipeline = notNull("pipeline", pipeline);
@@ -92,7 +92,7 @@ final class ChangeStreamIterableImpl<TResult> extends MongoIterableImpl<ChangeSt
 
     @Override
     public <TDocument> MongoIterable<TDocument> withDocumentClass(final Class<TDocument> clazz) {
-        return new MongoIterableImpl<TDocument>(getExecutor(), getReadConcern(), getReadPreference()) {
+        return new MongoIterableImpl<TDocument>(getClientSession(), getExecutor(), getReadConcern(), getReadPreference()) {
             private ReadOperation<BatchCursor<TDocument>> operation = createChangeStreamOperation(codecRegistry.get(clazz));
 
             @Override

--- a/driver/src/main/com/mongodb/DB.java
+++ b/driver/src/main/com/mongodb/DB.java
@@ -258,7 +258,7 @@ public class DB {
      */
     public Set<String> getCollectionNames() {
         List<String> collectionNames =
-                new MongoIterableImpl<DBObject>(executor, ReadConcern.DEFAULT, primary()) {
+                new MongoIterableImpl<DBObject>(null, executor, ReadConcern.DEFAULT, primary()) {
                     @Override
                     ReadOperation<BatchCursor<DBObject>> asReadOperation() {
                         return new ListCollectionsOperation<DBObject>(name, commandCodec);

--- a/driver/src/main/com/mongodb/DBCollection.java
+++ b/driver/src/main/com/mongodb/DBCollection.java
@@ -1171,7 +1171,8 @@ public class DBCollection {
     @SuppressWarnings("unchecked")
     public List distinct(final String fieldName, final DBCollectionDistinctOptions options) {
         notNull("fieldName", fieldName);
-        return new MongoIterableImpl<BsonValue>(executor, options.getReadConcern() != null ? options.getReadConcern() : getReadConcern(),
+        return new MongoIterableImpl<BsonValue>(null, executor,
+                                                  options.getReadConcern() != null ? options.getReadConcern() : getReadConcern(),
                                                   options.getReadPreference() != null ? options.getReadPreference() : getReadPreference()) {
             @Override
             ReadOperation<BatchCursor<BsonValue>> asReadOperation() {
@@ -2143,7 +2144,7 @@ public class DBCollection {
      * @mongodb.driver.manual core/indexes/ Indexes
      */
     public List<DBObject> getIndexInfo() {
-        return new MongoIterableImpl<DBObject>(executor, ReadConcern.DEFAULT, primary()) {
+        return new MongoIterableImpl<DBObject>(null, executor, ReadConcern.DEFAULT, primary()) {
             @Override
             ReadOperation<BatchCursor<DBObject>> asReadOperation() {
                 return new ListIndexesOperation<DBObject>(getNamespace(), getDefaultDBObjectCodec());

--- a/driver/src/main/com/mongodb/DistinctIterableImpl.java
+++ b/driver/src/main/com/mongodb/DistinctIterableImpl.java
@@ -41,10 +41,10 @@ class DistinctIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult
     private Collation collation;
 
 
-    DistinctIterableImpl(final MongoNamespace namespace, final Class<TDocument> documentClass, final Class<TResult> resultClass,
-                         final CodecRegistry codecRegistry, final ReadPreference readPreference, final ReadConcern readConcern,
-                         final OperationExecutor executor, final String fieldName, final Bson filter) {
-        super(executor, readConcern, readPreference);
+    DistinctIterableImpl(final ClientSession clientSession, final MongoNamespace namespace, final Class<TDocument> documentClass,
+                         final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
+                         final ReadConcern readConcern, final OperationExecutor executor, final String fieldName, final Bson filter) {
+        super(clientSession, executor, readConcern, readPreference);
         this.namespace = notNull("namespace", namespace);
         this.documentClass = notNull("documentClass", documentClass);
         this.resultClass = notNull("resultClass", resultClass);

--- a/driver/src/main/com/mongodb/ListIndexesIterableImpl.java
+++ b/driver/src/main/com/mongodb/ListIndexesIterableImpl.java
@@ -35,7 +35,7 @@ final class ListIndexesIterableImpl<TResult> extends MongoIterableImpl<TResult> 
 
     ListIndexesIterableImpl(final ClientSession clientSession, final MongoNamespace namespace, final Class<TResult> resultClass,
                             final CodecRegistry codecRegistry, final ReadPreference readPreference, final OperationExecutor executor) {
-        super(clientSession, executor, ReadConcern.DEFAULT, readPreference); // TODO: ReadConcern?
+        super(clientSession, executor, ReadConcern.DEFAULT, readPreference);
         this.namespace = notNull("namespace", namespace);
         this.resultClass = notNull("resultClass", resultClass);
         this.codecRegistry = notNull("codecRegistry", codecRegistry);

--- a/driver/src/main/com/mongodb/ListIndexesIterableImpl.java
+++ b/driver/src/main/com/mongodb/ListIndexesIterableImpl.java
@@ -33,9 +33,9 @@ final class ListIndexesIterableImpl<TResult> extends MongoIterableImpl<TResult> 
     private final CodecRegistry codecRegistry;
     private long maxTimeMS;
 
-    ListIndexesIterableImpl(final MongoNamespace namespace, final Class<TResult> resultClass, final CodecRegistry codecRegistry,
-                            final ReadPreference readPreference, final OperationExecutor executor) {
-        super(executor, ReadConcern.DEFAULT, readPreference); // TODO: ReadConcern?
+    ListIndexesIterableImpl(final ClientSession clientSession, final MongoNamespace namespace, final Class<TResult> resultClass,
+                            final CodecRegistry codecRegistry, final ReadPreference readPreference, final OperationExecutor executor) {
+        super(clientSession, executor, ReadConcern.DEFAULT, readPreference); // TODO: ReadConcern?
         this.namespace = notNull("namespace", namespace);
         this.resultClass = notNull("resultClass", resultClass);
         this.codecRegistry = notNull("codecRegistry", codecRegistry);

--- a/driver/src/main/com/mongodb/MapReduceIterableImpl.java
+++ b/driver/src/main/com/mongodb/MapReduceIterableImpl.java
@@ -63,11 +63,11 @@ class MapReduceIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
     private Boolean bypassDocumentValidation;
     private Collation collation;
 
-    MapReduceIterableImpl(final MongoNamespace namespace, final Class<TDocument> documentClass, final Class<TResult> resultClass,
-                          final CodecRegistry codecRegistry, final ReadPreference readPreference, final ReadConcern readConcern,
-                          final WriteConcern writeConcern, final OperationExecutor executor, final String mapFunction,
-                          final String reduceFunction) {
-        super(executor, readConcern, readPreference);
+    MapReduceIterableImpl(final ClientSession clientSession, final MongoNamespace namespace, final Class<TDocument> documentClass,
+                          final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
+                          final ReadConcern readConcern, final WriteConcern writeConcern, final OperationExecutor executor,
+                          final String mapFunction, final String reduceFunction) {
+        super(clientSession, executor, readConcern, readPreference);
         this.namespace = notNull("namespace", namespace);
         this.documentClass = notNull("documentClass", documentClass);
         this.resultClass = notNull("resultClass", resultClass);
@@ -83,7 +83,7 @@ class MapReduceIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
             throw new IllegalStateException("The options must specify a non-inline result");
         }
 
-        getExecutor().execute(createMapReduceToCollectionOperation());
+        getExecutor().execute(createMapReduceToCollectionOperation(), getClientSession());
     }
 
     @Override
@@ -215,7 +215,7 @@ class MapReduceIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
             }
             return new WrappedMapReduceReadOperation<TResult>(operation);
         } else {
-            getExecutor().execute(createMapReduceToCollectionOperation());
+            getExecutor().execute(createMapReduceToCollectionOperation(), getClientSession());
 
             String dbName = databaseName != null ? databaseName : namespace.getDatabaseName();
             return new FindOperation<TResult>(new MongoNamespace(dbName, collectionName), codecRegistry.get(resultClass))

--- a/driver/src/main/com/mongodb/Mongo.java
+++ b/driver/src/main/com/mongodb/Mongo.java
@@ -467,7 +467,7 @@ public class Mongo {
      */
     @Deprecated
     public List<String> getDatabaseNames() {
-        return new MongoIterableImpl<DBObject>(createOperationExecutor(), ReadConcern.DEFAULT, primary()) {
+        return new MongoIterableImpl<DBObject>(null, createOperationExecutor(), ReadConcern.DEFAULT, primary()) {
             @Override
             ReadOperation<BatchCursor<DBObject>> asReadOperation() {
                 return new ListDatabasesOperation<DBObject>(MongoClient.getCommandCodec());

--- a/driver/src/main/com/mongodb/MongoCollectionImpl.java
+++ b/driver/src/main/com/mongodb/MongoCollectionImpl.java
@@ -229,6 +229,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     @Override
     public <TResult> DistinctIterable<TResult> distinct(final ClientSession clientSession, final String fieldName, final Bson filter,
                                                         final Class<TResult> resultClass) {
+        notNull("clientSession", clientSession);
         return executeDistinct(clientSession, fieldName, filter, resultClass);
     }
 
@@ -402,7 +403,6 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public BulkWriteResult bulkWrite(final List<? extends WriteModel<? extends TDocument>> requests, final BulkWriteOptions options) {
         return executeBulkWrite(null, requests, options);
     }
@@ -805,6 +805,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public List<String> createIndexes(final ClientSession clientSession, final List<IndexModel> indexes) {
+        notNull("clientSession", clientSession);
         return executeCreateIndexes(clientSession, indexes);
     }
 
@@ -879,11 +880,13 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public void dropIndex(final ClientSession clientSession, final String indexName) {
+        notNull("clientSession", clientSession);
         executeDropIndex(clientSession, indexName);
     }
 
     @Override
     public void dropIndex(final ClientSession clientSession, final Bson keys) {
+        notNull("clientSession", clientSession);
         executeDropIndex(clientSession, keys);
     }
 
@@ -894,6 +897,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public void dropIndexes(final ClientSession clientSession) {
+        notNull("clientSession", clientSession);
         executeDropIndex(clientSession, "*");
     }
 

--- a/driver/src/main/com/mongodb/MongoCollectionImpl.java
+++ b/driver/src/main/com/mongodb/MongoCollectionImpl.java
@@ -175,19 +175,40 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public long count(final Bson filter, final CountOptions options) {
+        return executeCount(null, filter, options);
+    }
+
+    @Override
+    public long count(final ClientSession clientSession) {
+        return count(clientSession, new BsonDocument());
+    }
+
+    @Override
+    public long count(final ClientSession clientSession, final Bson filter) {
+        return count(clientSession, filter, new CountOptions());
+    }
+
+    @Override
+    public long count(final ClientSession clientSession, final Bson filter, final CountOptions options) {
+        notNull("clientSession", clientSession);
+        return executeCount(clientSession, filter, options);
+    }
+
+    private long executeCount(final ClientSession clientSession, final Bson filter, final CountOptions options) {
         CountOperation operation = new CountOperation(namespace)
-                                       .filter(toBsonDocument(filter))
-                                       .skip(options.getSkip())
-                                       .limit(options.getLimit())
-                                       .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
-                                       .collation(options.getCollation());
+                                           .filter(toBsonDocument(filter))
+                                           .skip(options.getSkip())
+                                           .limit(options.getLimit())
+                                           .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
+                                           .collation(options.getCollation());
         if (options.getHint() != null) {
             operation.hint(toBsonDocument(options.getHint()));
         } else if (options.getHintString() != null) {
             operation.hint(new BsonString(options.getHintString()));
         }
-        return executor.execute(operation, readPreference);
+        return executor.execute(operation, readPreference, clientSession);
     }
+
 
     @Override
     public <TResult> DistinctIterable<TResult> distinct(final String fieldName, final Class<TResult> resultClass) {
@@ -196,8 +217,25 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public <TResult> DistinctIterable<TResult> distinct(final String fieldName, final Bson filter, final Class<TResult> resultClass) {
-        return new DistinctIterableImpl<TDocument, TResult>(namespace, documentClass, resultClass, codecRegistry, readPreference,
-                readConcern, executor, fieldName, filter);
+        return executeDistinct(null, fieldName, filter, resultClass);
+    }
+
+    @Override
+    public <TResult> DistinctIterable<TResult> distinct(final ClientSession clientSession, final String fieldName,
+                                                        final Class<TResult> resultClass) {
+        return distinct(clientSession, fieldName, new BsonDocument(), resultClass);
+    }
+
+    @Override
+    public <TResult> DistinctIterable<TResult> distinct(final ClientSession clientSession, final String fieldName, final Bson filter,
+                                                        final Class<TResult> resultClass) {
+        return executeDistinct(clientSession, fieldName, filter, resultClass);
+    }
+
+    private <TResult> DistinctIterable<TResult> executeDistinct(final ClientSession clientSession, final String fieldName,
+                                                                final Bson filter, final Class<TResult> resultClass) {
+        return new DistinctIterableImpl<TDocument, TResult>(clientSession, namespace, documentClass, resultClass, codecRegistry,
+                                                                   readPreference, readConcern, executor, fieldName, filter);
     }
 
     @Override
@@ -258,8 +296,25 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public <TResult> AggregateIterable<TResult> aggregate(final List<? extends Bson> pipeline, final Class<TResult> resultClass) {
-        return new AggregateIterableImpl<TDocument, TResult>(namespace, documentClass, resultClass, codecRegistry, readPreference,
-                readConcern, writeConcern, executor, pipeline);
+        return executeAggregate(null, pipeline, resultClass);
+    }
+
+    @Override
+    public AggregateIterable<TDocument> aggregate(final ClientSession clientSession, final List<? extends Bson> pipeline) {
+        return aggregate(clientSession, pipeline, documentClass);
+    }
+
+    @Override
+    public <TResult> AggregateIterable<TResult> aggregate(final ClientSession clientSession, final List<? extends Bson> pipeline,
+                                                          final Class<TResult> resultClass) {
+        notNull("clientSession", clientSession);
+        return executeAggregate(clientSession, pipeline, resultClass);
+    }
+
+    private <TResult> AggregateIterable<TResult> executeAggregate(final ClientSession clientSession, final List<? extends Bson> pipeline,
+                                                                  final Class<TResult> resultClass) {
+        return new AggregateIterableImpl<TDocument, TResult>(clientSession, namespace, documentClass, resultClass, codecRegistry,
+                                                                    readPreference, readConcern, writeConcern, executor, pipeline);
     }
 
     @Override
@@ -279,8 +334,35 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public <TResult> ChangeStreamIterable<TResult> watch(final List<? extends Bson> pipeline, final Class<TResult> resultClass) {
-        return new ChangeStreamIterableImpl<TResult>(namespace, codecRegistry, readPreference, readConcern, executor, pipeline,
-                resultClass);
+        return executeWatch(null, pipeline, resultClass);
+    }
+
+    @Override
+    public ChangeStreamIterable<TDocument> watch(final ClientSession clientSession) {
+        return watch(clientSession, Collections.<Bson>emptyList(), documentClass);
+    }
+
+    @Override
+    public <TResult> ChangeStreamIterable<TResult> watch(final ClientSession clientSession, final Class<TResult> resultClass) {
+        return watch(clientSession, Collections.<Bson>emptyList(), resultClass);
+    }
+
+    @Override
+    public ChangeStreamIterable<TDocument> watch(final ClientSession clientSession, final List<? extends Bson> pipeline) {
+        return watch(clientSession, pipeline, documentClass);
+    }
+
+    @Override
+    public <TResult> ChangeStreamIterable<TResult> watch(final ClientSession clientSession, final List<? extends Bson> pipeline,
+                                                         final Class<TResult> resultClass) {
+        notNull("clientSession", clientSession);
+        return executeWatch(clientSession, pipeline, resultClass);
+    }
+
+    private <TResult> ChangeStreamIterable<TResult> executeWatch(final ClientSession clientSession, final List<? extends Bson> pipeline,
+                                                                 final Class<TResult> resultClass) {
+        return new ChangeStreamIterableImpl<TResult>(clientSession, namespace, codecRegistry, readPreference, readConcern, executor,
+                                                            pipeline, resultClass);
     }
 
     @Override
@@ -291,8 +373,27 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     @Override
     public <TResult> MapReduceIterable<TResult> mapReduce(final String mapFunction, final String reduceFunction,
                                                           final Class<TResult> resultClass) {
-        return new MapReduceIterableImpl<TDocument, TResult>(namespace, documentClass, resultClass, codecRegistry, readPreference,
-                readConcern, writeConcern, executor, mapFunction, reduceFunction);
+        return executeMapReduce(null, mapFunction, reduceFunction, resultClass);
+    }
+
+    @Override
+    public MapReduceIterable<TDocument> mapReduce(final ClientSession clientSession, final String mapFunction,
+                                                  final String reduceFunction) {
+        return mapReduce(clientSession, mapFunction, reduceFunction, documentClass);
+    }
+
+    @Override
+    public <TResult> MapReduceIterable<TResult> mapReduce(final ClientSession clientSession, final String mapFunction,
+                                                          final String reduceFunction, final Class<TResult> resultClass) {
+        notNull("clientSession", clientSession);
+        return executeMapReduce(clientSession, mapFunction, reduceFunction, resultClass);
+    }
+
+    private <TResult> MapReduceIterable<TResult> executeMapReduce(final ClientSession clientSession, final String mapFunction,
+                                                                  final String reduceFunction, final Class<TResult> resultClass) {
+        return new MapReduceIterableImpl<TDocument, TResult>(clientSession, namespace, documentClass, resultClass, codecRegistry,
+                                                                    readPreference, readConcern, writeConcern, executor, mapFunction,
+                                                                    reduceFunction);
     }
 
     @Override
@@ -303,6 +404,25 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     @Override
     @SuppressWarnings("unchecked")
     public BulkWriteResult bulkWrite(final List<? extends WriteModel<? extends TDocument>> requests, final BulkWriteOptions options) {
+        return executeBulkWrite(null, requests, options);
+    }
+
+    @Override
+    public BulkWriteResult bulkWrite(final ClientSession clientSession, final List<? extends WriteModel<? extends TDocument>> requests) {
+        return bulkWrite(clientSession, requests, new BulkWriteOptions());
+    }
+
+    @Override
+    public BulkWriteResult bulkWrite(final ClientSession clientSession, final List<? extends WriteModel<? extends TDocument>> requests,
+                                     final BulkWriteOptions options) {
+        notNull("clientSession", clientSession);
+        return executeBulkWrite(clientSession, requests, options);
+    }
+
+    @SuppressWarnings("unchecked")
+    private BulkWriteResult executeBulkWrite(final ClientSession clientSession,
+                                             final List<? extends WriteModel<? extends TDocument>> requests,
+                                             final BulkWriteOptions options) {
         notNull("requests", requests);
         List<WriteRequest> writeRequests = new ArrayList<WriteRequest>(requests.size());
         for (WriteModel<? extends TDocument> writeModel : requests) {
@@ -319,31 +439,31 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
                 ReplaceOneModel<TDocument> replaceOneModel = (ReplaceOneModel<TDocument>) writeModel;
                 writeRequest = new UpdateRequest(toBsonDocument(replaceOneModel.getFilter()), documentToBsonDocument(replaceOneModel
                                                                                                                      .getReplacement()),
-                                                 WriteRequest.Type.REPLACE)
-                                   .upsert(replaceOneModel.getOptions().isUpsert())
-                                   .collation(replaceOneModel.getOptions().getCollation());
+                                                        WriteRequest.Type.REPLACE)
+                                       .upsert(replaceOneModel.getOptions().isUpsert())
+                                       .collation(replaceOneModel.getOptions().getCollation());
             } else if (writeModel instanceof UpdateOneModel) {
                 UpdateOneModel<TDocument> updateOneModel = (UpdateOneModel<TDocument>) writeModel;
                 writeRequest = new UpdateRequest(toBsonDocument(updateOneModel.getFilter()), toBsonDocument(updateOneModel.getUpdate()),
-                                                 WriteRequest.Type.UPDATE)
-                                   .multi(false)
-                                   .upsert(updateOneModel.getOptions().isUpsert())
-                                   .collation(updateOneModel.getOptions().getCollation());
+                                                        WriteRequest.Type.UPDATE)
+                                       .multi(false)
+                                       .upsert(updateOneModel.getOptions().isUpsert())
+                                       .collation(updateOneModel.getOptions().getCollation());
             } else if (writeModel instanceof UpdateManyModel) {
                 UpdateManyModel<TDocument> updateManyModel = (UpdateManyModel<TDocument>) writeModel;
                 writeRequest = new UpdateRequest(toBsonDocument(updateManyModel.getFilter()), toBsonDocument(updateManyModel.getUpdate()),
-                                                 WriteRequest.Type.UPDATE)
-                                   .multi(true)
-                                   .upsert(updateManyModel.getOptions().isUpsert())
-                                   .collation(updateManyModel.getOptions().getCollation());
+                                                        WriteRequest.Type.UPDATE)
+                                       .multi(true)
+                                       .upsert(updateManyModel.getOptions().isUpsert())
+                                       .collation(updateManyModel.getOptions().getCollation());
             } else if (writeModel instanceof DeleteOneModel) {
                 DeleteOneModel<TDocument> deleteOneModel = (DeleteOneModel<TDocument>) writeModel;
                 writeRequest = new DeleteRequest(toBsonDocument(deleteOneModel.getFilter())).multi(false)
-                        .collation(deleteOneModel.getOptions().getCollation());
+                                       .collation(deleteOneModel.getOptions().getCollation());
             } else if (writeModel instanceof DeleteManyModel) {
                 DeleteManyModel<TDocument> deleteManyModel = (DeleteManyModel<TDocument>) writeModel;
                 writeRequest = new DeleteRequest(toBsonDocument(deleteManyModel.getFilter())).multi(true)
-                        .collation(deleteManyModel.getOptions().getCollation());
+                                       .collation(deleteManyModel.getOptions().getCollation());
             } else {
                 throw new UnsupportedOperationException(format("WriteModel of type %s is not supported", writeModel.getClass()));
             }
@@ -351,7 +471,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
         }
 
         return executor.execute(new MixedBulkWriteOperation(namespace, writeRequests, options.isOrdered(), writeConcern)
-                .bypassDocumentValidation(options.getBypassDocumentValidation()));
+                                        .bypassDocumentValidation(options.getBypassDocumentValidation()), clientSession);
     }
 
     @Override
@@ -393,6 +513,22 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public void insertMany(final List<? extends TDocument> documents, final InsertManyOptions options) {
+        executeInsertMany(null, documents, options);
+    }
+
+    @Override
+    public void insertMany(final ClientSession clientSession, final List<? extends TDocument> documents) {
+        insertMany(clientSession, documents, new InsertManyOptions());
+    }
+
+    @Override
+    public void insertMany(final ClientSession clientSession, final List<? extends TDocument> documents, final InsertManyOptions options) {
+        notNull("clientSession", clientSession);
+        executeInsertMany(clientSession, documents, options);
+    }
+
+    private void executeInsertMany(final ClientSession clientSession, final List<? extends TDocument> documents,
+                                   final InsertManyOptions options) {
         notNull("documents", documents);
         List<InsertRequest> requests = new ArrayList<InsertRequest>(documents.size());
         for (TDocument document : documents) {
@@ -405,7 +541,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
             requests.add(new InsertRequest(documentToBsonDocument(document)));
         }
         executor.execute(new MixedBulkWriteOperation(namespace, requests, options.isOrdered(), writeConcern)
-                .bypassDocumentValidation(options.getBypassDocumentValidation()));
+                                 .bypassDocumentValidation(options.getBypassDocumentValidation()), clientSession);
     }
 
     @Override
@@ -415,7 +551,18 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public DeleteResult deleteOne(final Bson filter, final DeleteOptions options) {
-        return delete(filter, options, false);
+        return executeDelete(null, filter, options, false);
+    }
+
+    @Override
+    public DeleteResult deleteOne(final ClientSession clientSession, final Bson filter) {
+        return deleteOne(clientSession, filter, new DeleteOptions());
+    }
+
+    @Override
+    public DeleteResult deleteOne(final ClientSession clientSession, final Bson filter, final DeleteOptions options) {
+        notNull("clientSession", clientSession);
+        return executeDelete(clientSession, filter, options, false);
     }
 
     @Override
@@ -425,7 +572,18 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public DeleteResult deleteMany(final Bson filter, final DeleteOptions options) {
-        return delete(filter, options, true);
+        return executeDelete(null, filter, options, true);
+    }
+
+    @Override
+    public DeleteResult deleteMany(final ClientSession clientSession, final Bson filter) {
+        return deleteMany(clientSession, filter, new DeleteOptions());
+    }
+
+    @Override
+    public DeleteResult deleteMany(final ClientSession clientSession, final Bson filter, final DeleteOptions options) {
+        notNull("clientSession", clientSession);
+        return executeDelete(clientSession, filter, options, true);
     }
 
     @Override
@@ -435,8 +593,26 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public UpdateResult replaceOne(final Bson filter, final TDocument replacement, final UpdateOptions updateOptions) {
-        return toUpdateResult(executeSingleWriteRequest(null, new UpdateRequest(toBsonDocument(filter), documentToBsonDocument(replacement),
-                WriteRequest.Type.REPLACE).upsert(updateOptions.isUpsert()).collation(updateOptions.getCollation()),
+        return executeReplaceOne(null, filter, replacement, updateOptions);
+    }
+
+    @Override
+    public UpdateResult replaceOne(final ClientSession clientSession, final Bson filter, final TDocument replacement) {
+        return replaceOne(clientSession, filter, replacement, new UpdateOptions());
+    }
+
+    @Override
+    public UpdateResult replaceOne(final ClientSession clientSession, final Bson filter, final TDocument replacement,
+                                   final UpdateOptions updateOptions) {
+        notNull("clientSession", clientSession);
+        return executeReplaceOne(clientSession, filter, replacement, updateOptions);
+    }
+
+    private UpdateResult executeReplaceOne(final ClientSession clientSession, final Bson filter, final TDocument replacement,
+                                           final UpdateOptions updateOptions) {
+        return toUpdateResult(executeSingleWriteRequest(clientSession,
+                new UpdateRequest(toBsonDocument(filter), documentToBsonDocument(replacement), WriteRequest.Type.REPLACE)
+                        .upsert(updateOptions.isUpsert()).collation(updateOptions.getCollation()),
                 updateOptions.getBypassDocumentValidation()));
     }
 
@@ -447,7 +623,20 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public UpdateResult updateOne(final Bson filter, final Bson update, final UpdateOptions updateOptions) {
-        return update(filter, update, updateOptions, false);
+        return executeUpdate(null, filter, update, updateOptions, false);
+    }
+
+    @Override
+    public UpdateResult updateOne(final ClientSession clientSession, final Bson filter, final Bson update) {
+        return updateOne(clientSession, filter, update, new UpdateOptions());
+    }
+
+    @Override
+    public UpdateResult updateOne(final ClientSession clientSession, final Bson filter, final Bson update,
+                                  final UpdateOptions updateOptions) {
+        notNull("clientSession", clientSession);
+        return executeUpdate(clientSession, filter, update, updateOptions, false);
+
     }
 
     @Override
@@ -457,7 +646,19 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public UpdateResult updateMany(final Bson filter, final Bson update, final UpdateOptions updateOptions) {
-        return update(filter, update, updateOptions, true);
+        return executeUpdate(null, filter, update, updateOptions, true);
+    }
+
+    @Override
+    public UpdateResult updateMany(final ClientSession clientSession, final Bson filter, final Bson update) {
+        return updateMany(clientSession, filter, update, new UpdateOptions());
+    }
+
+    @Override
+    public UpdateResult updateMany(final ClientSession clientSession, final Bson filter, final Bson update,
+                                   final UpdateOptions updateOptions) {
+        notNull("clientSession", clientSession);
+        return executeUpdate(clientSession, filter, update, updateOptions, true);
     }
 
     @Override
@@ -467,12 +668,28 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public TDocument findOneAndDelete(final Bson filter, final FindOneAndDeleteOptions options) {
+        return executeFindOneAndDelete(null, filter, options);
+    }
+
+    @Override
+    public TDocument findOneAndDelete(final ClientSession clientSession, final Bson filter) {
+        return findOneAndDelete(clientSession, filter, new FindOneAndDeleteOptions());
+    }
+
+    @Override
+    public TDocument findOneAndDelete(final ClientSession clientSession, final Bson filter, final FindOneAndDeleteOptions options) {
+        notNull("clientSession", clientSession);
+        return executeFindOneAndDelete(clientSession, filter, options);
+    }
+
+    private TDocument executeFindOneAndDelete(final ClientSession clientSession, final Bson filter, final FindOneAndDeleteOptions options) {
         return executor.execute(new FindAndDeleteOperation<TDocument>(namespace, writeConcern, getCodec())
-                .filter(toBsonDocument(filter))
-                .projection(toBsonDocument(options.getProjection()))
-                .sort(toBsonDocument(options.getSort()))
-                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
-                .collation(options.getCollation()));
+                                        .filter(toBsonDocument(filter))
+                                        .projection(toBsonDocument(options.getProjection()))
+                                        .sort(toBsonDocument(options.getSort()))
+                                        .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
+                                        .collation(options.getCollation()),
+                clientSession);
     }
 
     @Override
@@ -482,16 +699,34 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public TDocument findOneAndReplace(final Bson filter, final TDocument replacement, final FindOneAndReplaceOptions options) {
+        return executeFindOneAndReplace(null, filter, replacement, options);
+    }
+
+    @Override
+    public TDocument findOneAndReplace(final ClientSession clientSession, final Bson filter, final TDocument replacement) {
+        return findOneAndReplace(clientSession, filter, replacement, new FindOneAndReplaceOptions());
+    }
+
+    @Override
+    public TDocument findOneAndReplace(final ClientSession clientSession, final Bson filter, final TDocument replacement,
+                                       final FindOneAndReplaceOptions options) {
+        notNull("clientSession", clientSession);
+        return executeFindOneAndReplace(clientSession, filter, replacement, options);
+    }
+
+    private TDocument executeFindOneAndReplace(final ClientSession clientSession, final Bson filter, final TDocument replacement,
+                                               final FindOneAndReplaceOptions options) {
         return executor.execute(new FindAndReplaceOperation<TDocument>(namespace, writeConcern, getCodec(),
-                documentToBsonDocument(replacement))
-                .filter(toBsonDocument(filter))
-                .projection(toBsonDocument(options.getProjection()))
-                .sort(toBsonDocument(options.getSort()))
-                .returnOriginal(options.getReturnDocument() == ReturnDocument.BEFORE)
-                .upsert(options.isUpsert())
-                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
-                .bypassDocumentValidation(options.getBypassDocumentValidation())
-                .collation(options.getCollation()));
+                                                                              documentToBsonDocument(replacement))
+                                        .filter(toBsonDocument(filter))
+                                        .projection(toBsonDocument(options.getProjection()))
+                                        .sort(toBsonDocument(options.getSort()))
+                                        .returnOriginal(options.getReturnDocument() == ReturnDocument.BEFORE)
+                                        .upsert(options.isUpsert())
+                                        .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
+                                        .bypassDocumentValidation(options.getBypassDocumentValidation())
+                                        .collation(options.getCollation()),
+                clientSession);
     }
 
     @Override
@@ -501,20 +736,46 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public TDocument findOneAndUpdate(final Bson filter, final Bson update, final FindOneAndUpdateOptions options) {
-        return executor.execute(new FindAndUpdateOperation<TDocument>(namespace, writeConcern, getCodec(), toBsonDocument(update))
-                .filter(toBsonDocument(filter))
-                .projection(toBsonDocument(options.getProjection()))
-                .sort(toBsonDocument(options.getSort()))
-                .returnOriginal(options.getReturnDocument() == ReturnDocument.BEFORE)
-                .upsert(options.isUpsert())
-                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
-                .bypassDocumentValidation(options.getBypassDocumentValidation())
-                .collation(options.getCollation()));
+        return executeFindOneAndUpdate(null, filter, update, options);
     }
 
     @Override
+    public TDocument findOneAndUpdate(final ClientSession clientSession, final Bson filter, final Bson update) {
+        return findOneAndUpdate(clientSession, filter, update, new FindOneAndUpdateOptions());
+    }
+
+    @Override
+    public TDocument findOneAndUpdate(final ClientSession clientSession, final Bson filter, final Bson update,
+                                      final FindOneAndUpdateOptions options) {
+        notNull("clientSession", clientSession);
+        return executeFindOneAndUpdate(clientSession, filter, update, options);
+    }
+
+    private TDocument executeFindOneAndUpdate(final ClientSession clientSession, final Bson filter, final Bson update,
+                                              final FindOneAndUpdateOptions options) {
+        return executor.execute(new FindAndUpdateOperation<TDocument>(namespace, writeConcern, getCodec(), toBsonDocument(update))
+                                        .filter(toBsonDocument(filter))
+                                        .projection(toBsonDocument(options.getProjection()))
+                                        .sort(toBsonDocument(options.getSort()))
+                                        .returnOriginal(options.getReturnDocument() == ReturnDocument.BEFORE)
+                                        .upsert(options.isUpsert())
+                                        .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
+                                        .bypassDocumentValidation(options.getBypassDocumentValidation())
+                                        .collation(options.getCollation()),
+                clientSession);
+    }
+    @Override
     public void drop() {
-        executor.execute(new DropCollectionOperation(namespace, writeConcern));
+        executeDrop(null);
+    }
+
+    @Override
+    public void drop(final ClientSession clientSession) {
+        executeDrop(clientSession);
+    }
+
+    private void executeDrop(final ClientSession clientSession) {
+        executor.execute(new DropCollectionOperation(namespace, writeConcern), clientSession);
     }
 
     @Override
@@ -528,7 +789,26 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     @Override
+    public String createIndex(final ClientSession clientSession, final Bson keys) {
+        return createIndex(clientSession, keys, new IndexOptions());
+    }
+
+    @Override
+    public String createIndex(final ClientSession clientSession, final Bson keys, final IndexOptions indexOptions) {
+        return createIndexes(clientSession, singletonList(new IndexModel(keys, indexOptions))).get(0);
+    }
+
+    @Override
     public List<String> createIndexes(final List<IndexModel> indexes) {
+        return executeCreateIndexes(null, indexes);
+    }
+
+    @Override
+    public List<String> createIndexes(final ClientSession clientSession, final List<IndexModel> indexes) {
+        return executeCreateIndexes(clientSession, indexes);
+    }
+
+    private List<String> executeCreateIndexes(final ClientSession clientSession, final List<IndexModel> indexes) {
         notNull("indexes", indexes);
         List<IndexRequest> indexRequests = new ArrayList<IndexRequest>(indexes.size());
         for (IndexModel model : indexes) {
@@ -536,28 +816,28 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
                 throw new IllegalArgumentException("indexes can not contain a null value");
             }
             indexRequests.add(new IndexRequest(toBsonDocument(model.getKeys()))
-                         .name(model.getOptions().getName())
-                         .background(model.getOptions().isBackground())
-                         .unique(model.getOptions().isUnique())
-                         .sparse(model.getOptions().isSparse())
-                         .expireAfter(model.getOptions().getExpireAfter(TimeUnit.SECONDS), TimeUnit.SECONDS)
-                         .version(model.getOptions().getVersion())
-                         .weights(toBsonDocument(model.getOptions().getWeights()))
-                         .defaultLanguage(model.getOptions().getDefaultLanguage())
-                         .languageOverride(model.getOptions().getLanguageOverride())
-                         .textVersion(model.getOptions().getTextVersion())
-                         .sphereVersion(model.getOptions().getSphereVersion())
-                         .bits(model.getOptions().getBits())
-                         .min(model.getOptions().getMin())
-                         .max(model.getOptions().getMax())
-                         .bucketSize(model.getOptions().getBucketSize())
-                         .storageEngine(toBsonDocument(model.getOptions().getStorageEngine()))
-                         .partialFilterExpression(toBsonDocument(model.getOptions().getPartialFilterExpression()))
-                         .collation(model.getOptions().getCollation())
+                                      .name(model.getOptions().getName())
+                                      .background(model.getOptions().isBackground())
+                                      .unique(model.getOptions().isUnique())
+                                      .sparse(model.getOptions().isSparse())
+                                      .expireAfter(model.getOptions().getExpireAfter(TimeUnit.SECONDS), TimeUnit.SECONDS)
+                                      .version(model.getOptions().getVersion())
+                                      .weights(toBsonDocument(model.getOptions().getWeights()))
+                                      .defaultLanguage(model.getOptions().getDefaultLanguage())
+                                      .languageOverride(model.getOptions().getLanguageOverride())
+                                      .textVersion(model.getOptions().getTextVersion())
+                                      .sphereVersion(model.getOptions().getSphereVersion())
+                                      .bits(model.getOptions().getBits())
+                                      .min(model.getOptions().getMin())
+                                      .max(model.getOptions().getMax())
+                                      .bucketSize(model.getOptions().getBucketSize())
+                                      .storageEngine(toBsonDocument(model.getOptions().getStorageEngine()))
+                                      .partialFilterExpression(toBsonDocument(model.getOptions().getPartialFilterExpression()))
+                                      .collation(model.getOptions().getCollation())
             );
         }
         CreateIndexesOperation createIndexesOperation = new CreateIndexesOperation(getNamespace(), indexRequests, writeConcern);
-        executor.execute(createIndexesOperation);
+        executor.execute(createIndexesOperation, clientSession);
         return createIndexesOperation.getIndexNames();
     }
 
@@ -568,22 +848,62 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public <TResult> ListIndexesIterable<TResult> listIndexes(final Class<TResult> resultClass) {
-        return new ListIndexesIterableImpl<TResult>(getNamespace(), resultClass, codecRegistry, ReadPreference.primary(), executor);
+        return executeListIndexes(null, resultClass);
+    }
+
+    @Override
+    public ListIndexesIterable<Document> listIndexes(final ClientSession clientSession) {
+        return listIndexes(clientSession, Document.class);
+    }
+
+    @Override
+    public <TResult> ListIndexesIterable<TResult> listIndexes(final ClientSession clientSession, final Class<TResult> resultClass) {
+        notNull("clientSession", clientSession);
+        return executeListIndexes(clientSession, resultClass);
+    }
+
+    private <TResult> ListIndexesIterable<TResult> executeListIndexes(final ClientSession clientSession, final Class<TResult> resultClass) {
+        return new ListIndexesIterableImpl<TResult>(clientSession, getNamespace(), resultClass, codecRegistry, ReadPreference.primary(),
+                                                           executor);
     }
 
     @Override
     public void dropIndex(final String indexName) {
-        executor.execute(new DropIndexOperation(namespace, indexName, writeConcern));
+        executeDropIndex(null, indexName);
     }
 
     @Override
     public void dropIndex(final Bson keys) {
-        executor.execute(new DropIndexOperation(namespace, keys.toBsonDocument(BsonDocument.class, codecRegistry), writeConcern));
+        executeDropIndex(null, keys);
+    }
+
+    @Override
+    public void dropIndex(final ClientSession clientSession, final String indexName) {
+        executeDropIndex(clientSession, indexName);
+    }
+
+    @Override
+    public void dropIndex(final ClientSession clientSession, final Bson keys) {
+        executeDropIndex(clientSession, keys);
     }
 
     @Override
     public void dropIndexes() {
         dropIndex("*");
+    }
+
+    @Override
+    public void dropIndexes(final ClientSession clientSession) {
+        executeDropIndex(clientSession, "*");
+    }
+
+    private void executeDropIndex(final ClientSession clientSession, final String indexName) {
+        executor.execute(new DropIndexOperation(namespace, indexName, writeConcern), clientSession);
+    }
+
+    private void executeDropIndex(final ClientSession clientSession, final Bson keys) {
+        executor.execute(new DropIndexOperation(namespace, keys.toBsonDocument(BsonDocument.class, codecRegistry), writeConcern),
+                clientSession);
     }
 
     @Override
@@ -593,13 +913,33 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     @Override
     public void renameCollection(final MongoNamespace newCollectionNamespace, final RenameCollectionOptions renameCollectionOptions) {
-        executor.execute(new RenameCollectionOperation(getNamespace(), newCollectionNamespace, writeConcern)
-                             .dropTarget(renameCollectionOptions.isDropTarget()));
+        executeRenameCollection(null, newCollectionNamespace, renameCollectionOptions);
     }
 
-    private DeleteResult delete(final Bson filter, final DeleteOptions deleteOptions, final boolean multi) {
-        com.mongodb.bulk.BulkWriteResult result = executeSingleWriteRequest(null, new DeleteRequest(toBsonDocument(filter)).multi(multi)
-                .collation(deleteOptions.getCollation()), null);
+    @Override
+    public void renameCollection(final ClientSession clientSession, final MongoNamespace newCollectionNamespace) {
+        renameCollection(clientSession, newCollectionNamespace, new RenameCollectionOptions());
+    }
+
+    @Override
+    public void renameCollection(final ClientSession clientSession, final MongoNamespace newCollectionNamespace,
+                                 final RenameCollectionOptions renameCollectionOptions) {
+        notNull("clientSession", clientSession);
+        executeRenameCollection(clientSession, newCollectionNamespace, renameCollectionOptions);
+    }
+
+    private void executeRenameCollection(final ClientSession clientSession, final MongoNamespace newCollectionNamespace,
+                                         final RenameCollectionOptions renameCollectionOptions) {
+        executor.execute(new RenameCollectionOperation(getNamespace(), newCollectionNamespace, writeConcern)
+                                 .dropTarget(renameCollectionOptions.isDropTarget()),
+                clientSession);
+    }
+
+    private DeleteResult executeDelete(final ClientSession clientSession, final Bson filter, final DeleteOptions deleteOptions,
+                                       final boolean multi) {
+        com.mongodb.bulk.BulkWriteResult result = executeSingleWriteRequest(clientSession,
+                new DeleteRequest(toBsonDocument(filter)).multi(multi)
+                        .collation(deleteOptions.getCollation()), null);
         if (result.wasAcknowledged()) {
             return DeleteResult.acknowledged(result.getDeletedCount());
         } else {
@@ -607,8 +947,9 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
         }
     }
 
-    private UpdateResult update(final Bson filter, final Bson update, final UpdateOptions updateOptions, final boolean multi) {
-        return toUpdateResult(executeSingleWriteRequest(null, new UpdateRequest(toBsonDocument(filter), toBsonDocument(update),
+    private UpdateResult executeUpdate(final ClientSession clientSession, final Bson filter, final Bson update,
+                                       final UpdateOptions updateOptions, final boolean multi) {
+        return toUpdateResult(executeSingleWriteRequest(clientSession, new UpdateRequest(toBsonDocument(filter), toBsonDocument(update),
                 WriteRequest.Type.UPDATE).upsert(updateOptions.isUpsert()).multi(multi).collation(updateOptions.getCollation()),
                 updateOptions.getBypassDocumentValidation()));
     }

--- a/driver/src/main/com/mongodb/client/MongoCollection.java
+++ b/driver/src/main/com/mongodb/client/MongoCollection.java
@@ -174,6 +174,39 @@ public interface MongoCollection<TDocument> {
     long count(Bson filter, CountOptions options);
 
     /**
+     * Counts the number of documents in the collection.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @return the number of documents in the collection
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     */
+    long count(ClientSession clientSession);
+
+    /**
+     * Counts the number of documents in the collection according to the given options.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filter the query filter
+     * @return the number of documents in the collection
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     */
+    long count(ClientSession clientSession, Bson filter);
+
+    /**
+     * Counts the number of documents in the collection according to the given options.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filter  the query filter
+     * @param options the options describing the count
+     * @return the number of documents in the collection
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     */
+    long count(ClientSession clientSession, Bson filter, CountOptions options);
+
+    /**
      * Gets the distinct values of the specified field name.
      *
      * @param fieldName   the field name
@@ -195,6 +228,35 @@ public interface MongoCollection<TDocument> {
      * @mongodb.driver.manual reference/command/distinct/ Distinct
      */
     <TResult> DistinctIterable<TResult> distinct(String fieldName, Bson filter, Class<TResult> resultClass);
+
+    /**
+     * Gets the distinct values of the specified field name.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param fieldName   the field name
+     * @param resultClass the class to cast any distinct items into.
+     * @param <TResult>   the target type of the iterable.
+     * @return an iterable of distinct values
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual reference/command/distinct/ Distinct
+     */
+    <TResult> DistinctIterable<TResult> distinct(ClientSession clientSession, String fieldName, Class<TResult> resultClass);
+
+    /**
+     * Gets the distinct values of the specified field name.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param fieldName   the field name
+     * @param filter      the query filter
+     * @param resultClass the class to cast any distinct items into.
+     * @param <TResult>   the target type of the iterable.
+     * @return an iterable of distinct values
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual reference/command/distinct/ Distinct
+     */
+    <TResult> DistinctIterable<TResult> distinct(ClientSession clientSession, String fieldName, Bson filter, Class<TResult> resultClass);
 
     /**
      * Finds all documents in the collection.
@@ -307,6 +369,31 @@ public interface MongoCollection<TDocument> {
     <TResult> AggregateIterable<TResult> aggregate(List<? extends Bson> pipeline, Class<TResult> resultClass);
 
     /**
+     * Aggregates documents according to the specified aggregation pipeline.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param pipeline the aggregation pipeline
+     * @return an iterable containing the result of the aggregation operation
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual aggregation/ Aggregation
+     */
+    AggregateIterable<TDocument> aggregate(ClientSession clientSession, List<? extends Bson> pipeline);
+
+    /**
+     * Aggregates documents according to the specified aggregation pipeline.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param pipeline    the aggregation pipeline
+     * @param resultClass the class to decode each document into
+     * @param <TResult>   the target document type of the iterable.
+     * @return an iterable containing the result of the aggregation operation
+     * @mongodb.driver.manual aggregation/ Aggregation
+     * @mongodb.server.release 2.2
+     */
+    <TResult> AggregateIterable<TResult> aggregate(ClientSession clientSession, List<? extends Bson> pipeline, Class<TResult> resultClass);
+
+    /**
      * Creates a change stream for this collection.
      *
      * @return the change stream iterable
@@ -349,6 +436,56 @@ public interface MongoCollection<TDocument> {
     <TResult> ChangeStreamIterable<TResult> watch(List<? extends Bson> pipeline, Class<TResult> resultClass);
 
     /**
+     * Creates a change stream for this collection.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @return the change stream iterable
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual reference/operator/aggregation/changeStream $changeStream
+     */
+    ChangeStreamIterable<TDocument> watch(ClientSession clientSession);
+
+    /**
+     * Creates a change stream for this collection.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param resultClass the class to decode each document into
+     * @param <TResult>   the target document type of the iterable.
+     * @return the change stream iterable
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual reference/operator/aggregation/changeStream $changeStream
+     */
+    <TResult> ChangeStreamIterable<TResult> watch(ClientSession clientSession, Class<TResult> resultClass);
+
+    /**
+     * Creates a change stream for this collection.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param pipeline the aggregation pipeline to apply to the change stream.
+     * @return the change stream iterable
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual reference/operator/aggregation/changeStream $changeStream
+     */
+    ChangeStreamIterable<TDocument> watch(ClientSession clientSession, List<? extends Bson> pipeline);
+
+    /**
+     * Creates a change stream for this collection.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param pipeline    the aggregation pipeline to apply to the change stream
+     * @param resultClass the class to decode each document into
+     * @param <TResult>   the target document type of the iterable.
+     * @return the change stream iterable
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual reference/operator/aggregation/changeStream $changeStream
+     */
+    <TResult> ChangeStreamIterable<TResult> watch(ClientSession clientSession, List<? extends Bson> pipeline, Class<TResult> resultClass);
+
+    /**
      * Aggregates documents according to the specified map-reduce function.
      *
      * @param mapFunction    A JavaScript function that associates or "maps" a value with a key and emits the key and value pair.
@@ -371,6 +508,35 @@ public interface MongoCollection<TDocument> {
     <TResult> MapReduceIterable<TResult> mapReduce(String mapFunction, String reduceFunction, Class<TResult> resultClass);
 
     /**
+     * Aggregates documents according to the specified map-reduce function.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param mapFunction    A JavaScript function that associates or "maps" a value with a key and emits the key and value pair.
+     * @param reduceFunction A JavaScript function that "reduces" to a single object all the values associated with a particular key.
+     * @return an iterable containing the result of the map-reduce operation
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual reference/command/mapReduce/ map-reduce
+     */
+    MapReduceIterable<TDocument> mapReduce(ClientSession clientSession, String mapFunction, String reduceFunction);
+
+    /**
+     * Aggregates documents according to the specified map-reduce function.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param mapFunction    A JavaScript function that associates or "maps" a value with a key and emits the key and value pair.
+     * @param reduceFunction A JavaScript function that "reduces" to a single object all the values associated with a particular key.
+     * @param resultClass    the class to decode each resulting document into.
+     * @param <TResult>      the target document type of the iterable.
+     * @return an iterable containing the result of the map-reduce operation
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual reference/command/mapReduce/ map-reduce
+     */
+    <TResult> MapReduceIterable<TResult> mapReduce(ClientSession clientSession, String mapFunction, String reduceFunction,
+                                                   Class<TResult> resultClass);
+
+    /**
      * Executes a mix of inserts, updates, replaces, and deletes.
      *
      * @param requests the writes to execute
@@ -390,6 +556,34 @@ public interface MongoCollection<TDocument> {
      * @throws com.mongodb.MongoException          if there's an exception running the operation
      */
     BulkWriteResult bulkWrite(List<? extends WriteModel<? extends TDocument>> requests, BulkWriteOptions options);
+
+    /**
+     * Executes a mix of inserts, updates, replaces, and deletes.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param requests the writes to execute
+     * @return the result of the bulk write
+     * @throws com.mongodb.MongoBulkWriteException if there's an exception in the bulk write operation
+     * @throws com.mongodb.MongoException          if there's an exception running the operation
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     */
+    BulkWriteResult bulkWrite(ClientSession clientSession, List<? extends WriteModel<? extends TDocument>> requests);
+
+    /**
+     * Executes a mix of inserts, updates, replaces, and deletes.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param requests the writes to execute
+     * @param options  the options to apply to the bulk write operation
+     * @return the result of the bulk write
+     * @throws com.mongodb.MongoBulkWriteException if there's an exception in the bulk write operation
+     * @throws com.mongodb.MongoException          if there's an exception running the operation
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     */
+    BulkWriteResult bulkWrite(ClientSession clientSession, List<? extends WriteModel<? extends TDocument>> requests,
+                              BulkWriteOptions options);
 
     /**
      * Inserts the provided document. If the document is missing an identifier, the driver should generate one.
@@ -464,6 +658,33 @@ public interface MongoCollection<TDocument> {
     void insertMany(List<? extends TDocument> documents, InsertManyOptions options);
 
     /**
+     * Inserts one or more documents.  A call to this method is equivalent to a call to the {@code bulkWrite} method
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param documents the documents to insert
+     * @throws com.mongodb.MongoBulkWriteException if there's an exception in the bulk write operation
+     * @throws com.mongodb.MongoException          if the write failed due some other failure
+     * @see com.mongodb.client.MongoCollection#bulkWrite
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     */
+    void insertMany(ClientSession clientSession, List<? extends TDocument> documents);
+
+    /**
+     * Inserts one or more documents.  A call to this method is equivalent to a call to the {@code bulkWrite} method
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param documents the documents to insert
+     * @param options   the options to apply to the operation
+     * @throws com.mongodb.DuplicateKeyException if the write failed to a duplicate unique key
+     * @throws com.mongodb.WriteConcernException if the write failed due being unable to fulfil the write concern
+     * @throws com.mongodb.MongoException        if the write failed due some other failure
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     */
+    void insertMany(ClientSession clientSession, List<? extends TDocument> documents, InsertManyOptions options);
+
+    /**
      * Removes at most one document from the collection that matches the given filter.  If no documents match, the collection is not
      * modified.
      *
@@ -490,6 +711,37 @@ public interface MongoCollection<TDocument> {
     DeleteResult deleteOne(Bson filter, DeleteOptions options);
 
     /**
+     * Removes at most one document from the collection that matches the given filter.  If no documents match, the collection is not
+     * modified.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filter the query filter to apply the the delete operation
+     * @return the result of the remove one operation
+     * @throws com.mongodb.MongoWriteException        if the write failed due some other failure specific to the delete command
+     * @throws com.mongodb.MongoWriteConcernException if the write failed due being unable to fulfil the write concern
+     * @throws com.mongodb.MongoException             if the write failed due some other failure
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     */
+    DeleteResult deleteOne(ClientSession clientSession, Bson filter);
+
+    /**
+     * Removes at most one document from the collection that matches the given filter.  If no documents match, the collection is not
+     * modified.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filter the query filter to apply the the delete operation
+     * @param options  the options to apply to the delete operation
+     * @return the result of the remove one operation
+     * @throws com.mongodb.MongoWriteException        if the write failed due some other failure specific to the delete command
+     * @throws com.mongodb.MongoWriteConcernException if the write failed due being unable to fulfil the write concern
+     * @throws com.mongodb.MongoException             if the write failed due some other failure
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     */
+    DeleteResult deleteOne(ClientSession clientSession, Bson filter, DeleteOptions options);
+
+    /**
      * Removes all documents from the collection that match the given query filter.  If no documents match, the collection is not modified.
      *
      * @param filter the query filter to apply the the delete operation
@@ -512,6 +764,35 @@ public interface MongoCollection<TDocument> {
      * @since 3.4
      */
     DeleteResult deleteMany(Bson filter, DeleteOptions options);
+
+    /**
+     * Removes all documents from the collection that match the given query filter.  If no documents match, the collection is not modified.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filter the query filter to apply the the delete operation
+     * @return the result of the remove many operation
+     * @throws com.mongodb.MongoWriteException        if the write failed due some other failure specific to the delete command
+     * @throws com.mongodb.MongoWriteConcernException if the write failed due being unable to fulfil the write concern
+     * @throws com.mongodb.MongoException             if the write failed due some other failure
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     */
+    DeleteResult deleteMany(ClientSession clientSession, Bson filter);
+
+    /**
+     * Removes all documents from the collection that match the given query filter.  If no documents match, the collection is not modified.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filter the query filter to apply the the delete operation
+     * @param options  the options to apply to the delete operation
+     * @return the result of the remove many operation
+     * @throws com.mongodb.MongoWriteException        if the write failed due some other failure specific to the delete command
+     * @throws com.mongodb.MongoWriteConcernException if the write failed due being unable to fulfil the write concern
+     * @throws com.mongodb.MongoException             if the write failed due some other failure
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     */
+    DeleteResult deleteMany(ClientSession clientSession, Bson filter, DeleteOptions options);
 
     /**
      * Replace a document in the collection according to the specified arguments.
@@ -539,6 +820,39 @@ public interface MongoCollection<TDocument> {
      * @mongodb.driver.manual tutorial/modify-documents/#replace-the-document Replace
      */
     UpdateResult replaceOne(Bson filter, TDocument replacement, UpdateOptions updateOptions);
+
+    /**
+     * Replace a document in the collection according to the specified arguments.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filter      the query filter to apply the the replace operation
+     * @param replacement the replacement document
+     * @return the result of the replace one operation
+     * @throws com.mongodb.MongoWriteException        if the write failed due some other failure specific to the replace command
+     * @throws com.mongodb.MongoWriteConcernException if the write failed due being unable to fulfil the write concern
+     * @throws com.mongodb.MongoException             if the write failed due some other failure
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual tutorial/modify-documents/#replace-the-document Replace
+     */
+    UpdateResult replaceOne(ClientSession clientSession, Bson filter, TDocument replacement);
+
+    /**
+     * Replace a document in the collection according to the specified arguments.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filter        the query filter to apply the the replace operation
+     * @param replacement   the replacement document
+     * @param updateOptions the options to apply to the replace operation
+     * @return the result of the replace one operation
+     * @throws com.mongodb.MongoWriteException        if the write failed due some other failure specific to the replace command
+     * @throws com.mongodb.MongoWriteConcernException if the write failed due being unable to fulfil the write concern
+     * @throws com.mongodb.MongoException             if the write failed due some other failure
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual tutorial/modify-documents/#replace-the-document Replace
+     */
+    UpdateResult replaceOne(ClientSession clientSession, Bson filter, TDocument replacement, UpdateOptions updateOptions);
 
     /**
      * Update a single document in the collection according to the specified arguments.
@@ -570,6 +884,41 @@ public interface MongoCollection<TDocument> {
     UpdateResult updateOne(Bson filter, Bson update, UpdateOptions updateOptions);
 
     /**
+     * Update a single document in the collection according to the specified arguments.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filter a document describing the query filter, which may not be null.
+     * @param update a document describing the update, which may not be null. The update to apply must include only update operators.
+     * @return the result of the update one operation
+     * @throws com.mongodb.MongoWriteException        if the write failed due some other failure specific to the update command
+     * @throws com.mongodb.MongoWriteConcernException if the write failed due being unable to fulfil the write concern
+     * @throws com.mongodb.MongoException             if the write failed due some other failure
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual tutorial/modify-documents/ Updates
+     * @mongodb.driver.manual reference/operator/update/ Update Operators
+     */
+    UpdateResult updateOne(ClientSession clientSession, Bson filter, Bson update);
+
+    /**
+     * Update a single document in the collection according to the specified arguments.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filter        a document describing the query filter, which may not be null.
+     * @param update        a document describing the update, which may not be null. The update to apply must include only update operators.
+     * @param updateOptions the options to apply to the update operation
+     * @return the result of the update one operation
+     * @throws com.mongodb.MongoWriteException        if the write failed due some other failure specific to the update command
+     * @throws com.mongodb.MongoWriteConcernException if the write failed due being unable to fulfil the write concern
+     * @throws com.mongodb.MongoException             if the write failed due some other failure
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual tutorial/modify-documents/ Updates
+     * @mongodb.driver.manual reference/operator/update/ Update Operators
+     */
+    UpdateResult updateOne(ClientSession clientSession, Bson filter, Bson update, UpdateOptions updateOptions);
+
+    /**
      * Update all documents in the collection according to the specified arguments.
      *
      * @param filter a document describing the query filter, which may not be null.
@@ -599,6 +948,41 @@ public interface MongoCollection<TDocument> {
     UpdateResult updateMany(Bson filter, Bson update, UpdateOptions updateOptions);
 
     /**
+     * Update all documents in the collection according to the specified arguments.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filter a document describing the query filter, which may not be null.
+     * @param update a document describing the update, which may not be null. The update to apply must include only update operators.
+     * @return the result of the update many operation
+     * @throws com.mongodb.MongoWriteException        if the write failed due some other failure specific to the update command
+     * @throws com.mongodb.MongoWriteConcernException if the write failed due being unable to fulfil the write concern
+     * @throws com.mongodb.MongoException             if the write failed due some other failure
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual tutorial/modify-documents/ Updates
+     * @mongodb.driver.manual reference/operator/update/ Update Operators
+     */
+    UpdateResult updateMany(ClientSession clientSession, Bson filter, Bson update);
+
+    /**
+     * Update all documents in the collection according to the specified arguments.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filter        a document describing the query filter, which may not be null.
+     * @param update        a document describing the update, which may not be null. The update to apply must include only update operators.
+     * @param updateOptions the options to apply to the update operation
+     * @return the result of the update many operation
+     * @throws com.mongodb.MongoWriteException        if the write failed due some other failure specific to the update command
+     * @throws com.mongodb.MongoWriteConcernException if the write failed due being unable to fulfil the write concern
+     * @throws com.mongodb.MongoException             if the write failed due some other failure
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual tutorial/modify-documents/ Updates
+     * @mongodb.driver.manual reference/operator/update/ Update Operators
+     */
+    UpdateResult updateMany(ClientSession clientSession, Bson filter, Bson update, UpdateOptions updateOptions);
+
+    /**
      * Atomically find a document and remove it.
      *
      * @param filter the query filter to find the document with
@@ -614,6 +998,29 @@ public interface MongoCollection<TDocument> {
      * @return the document that was removed.  If no documents matched the query filter, then null will be returned
      */
     TDocument findOneAndDelete(Bson filter, FindOneAndDeleteOptions options);
+
+    /**
+     * Atomically find a document and remove it.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filter the query filter to find the document with
+     * @return the document that was removed.  If no documents matched the query filter, then null will be returned
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     */
+    TDocument findOneAndDelete(ClientSession clientSession, Bson filter);
+
+    /**
+     * Atomically find a document and remove it.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filter  the query filter to find the document with
+     * @param options the options to apply to the operation
+     * @return the document that was removed.  If no documents matched the query filter, then null will be returned
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     */
+    TDocument findOneAndDelete(ClientSession clientSession, Bson filter, FindOneAndDeleteOptions options);
 
     /**
      * Atomically find a document and replace it.
@@ -639,6 +1046,35 @@ public interface MongoCollection<TDocument> {
     TDocument findOneAndReplace(Bson filter, TDocument replacement, FindOneAndReplaceOptions options);
 
     /**
+     * Atomically find a document and replace it.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filter      the query filter to apply the the replace operation
+     * @param replacement the replacement document
+     * @return the document that was replaced.  Depending on the value of the {@code returnOriginal} property, this will either be the
+     * document as it was before the update or as it is after the update.  If no documents matched the query filter, then null will be
+     * returned
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     */
+    TDocument findOneAndReplace(ClientSession clientSession, Bson filter, TDocument replacement);
+
+    /**
+     * Atomically find a document and replace it.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filter      the query filter to apply the the replace operation
+     * @param replacement the replacement document
+     * @param options     the options to apply to the operation
+     * @return the document that was replaced.  Depending on the value of the {@code returnOriginal} property, this will either be the
+     * document as it was before the update or as it is after the update.  If no documents matched the query filter, then null will be
+     * returned
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     */
+    TDocument findOneAndReplace(ClientSession clientSession, Bson filter, TDocument replacement, FindOneAndReplaceOptions options);
+
+    /**
      * Atomically find a document and update it.
      *
      * @param filter a document describing the query filter, which may not be null.
@@ -661,11 +1097,49 @@ public interface MongoCollection<TDocument> {
     TDocument findOneAndUpdate(Bson filter, Bson update, FindOneAndUpdateOptions options);
 
     /**
+     * Atomically find a document and update it.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filter a document describing the query filter, which may not be null.
+     * @param update a document describing the update, which may not be null. The update to apply must include only update operators.
+     * @return the document that was updated before the update was applied.  If no documents matched the query filter, then null will be
+     * returned
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     */
+    TDocument findOneAndUpdate(ClientSession clientSession, Bson filter, Bson update);
+
+    /**
+     * Atomically find a document and update it.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param filter  a document describing the query filter, which may not be null.
+     * @param update  a document describing the update, which may not be null. The update to apply must include only update operators.
+     * @param options the options to apply to the operation
+     * @return the document that was updated.  Depending on the value of the {@code returnOriginal} property, this will either be the
+     * document as it was before the update or as it is after the update.  If no documents matched the query filter, then null will be
+     * returned
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     */
+    TDocument findOneAndUpdate(ClientSession clientSession, Bson filter, Bson update, FindOneAndUpdateOptions options);
+
+    /**
      * Drops this collection from the Database.
      *
      * @mongodb.driver.manual reference/command/drop/ Drop Collection
      */
     void drop();
+
+    /**
+     * Drops this collection from the Database.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @mongodb.driver.manual reference/command/drop/ Drop Collection
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     */
+    void drop(ClientSession clientSession);
 
     /**
      * Create an index with the given keys.
@@ -687,6 +1161,31 @@ public interface MongoCollection<TDocument> {
     String createIndex(Bson keys, IndexOptions indexOptions);
 
     /**
+     * Create an index with the given keys.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param keys an object describing the index key(s), which may not be null.
+     * @return the index name
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual reference/command/createIndexes Create indexes
+     */
+    String createIndex(ClientSession clientSession, Bson keys);
+
+    /**
+     * Create an index with the given keys and options.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param keys                an object describing the index key(s), which may not be null.
+     * @param indexOptions the options for the index
+     * @return the index name
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual reference/command/createIndexes Create indexes
+     */
+    String createIndex(ClientSession clientSession, Bson keys, IndexOptions indexOptions);
+
+    /**
      * Create multiple indexes.
      *
      * @param indexes the list of indexes
@@ -695,6 +1194,18 @@ public interface MongoCollection<TDocument> {
      * @mongodb.server.release 2.6
      */
     List<String> createIndexes(List<IndexModel> indexes);
+
+    /**
+     * Create multiple indexes.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param indexes the list of indexes
+     * @return the list of index names
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual reference/command/createIndexes Create indexes
+     */
+    List<String> createIndexes(ClientSession clientSession, List<IndexModel> indexes);
 
     /**
      * Get all the indexes in this collection.
@@ -715,6 +1226,30 @@ public interface MongoCollection<TDocument> {
     <TResult> ListIndexesIterable<TResult> listIndexes(Class<TResult> resultClass);
 
     /**
+     * Get all the indexes in this collection.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @return the list indexes iterable interface
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual reference/command/listIndexes/ List indexes
+     */
+    ListIndexesIterable<Document> listIndexes(ClientSession clientSession);
+
+    /**
+     * Get all the indexes in this collection.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param resultClass the class to decode each document into
+     * @param <TResult>   the target document type of the iterable.
+     * @return the list indexes iterable interface
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual reference/command/listIndexes/ List indexes
+     */
+    <TResult> ListIndexesIterable<TResult> listIndexes(ClientSession clientSession, Class<TResult> resultClass);
+
+    /**
      * Drops the index given its name.
      *
      * @param indexName the name of the index to remove
@@ -731,11 +1266,43 @@ public interface MongoCollection<TDocument> {
     void dropIndex(Bson keys);
 
     /**
+     * Drops the index given its name.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param indexName the name of the index to remove
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual reference/command/dropIndexes/ Drop indexes
+     */
+    void dropIndex(ClientSession clientSession, String indexName);
+
+    /**
+     * Drops the index given the keys used to create it.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param keys the keys of the index to remove
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual reference/command/dropIndexes/ Drop indexes
+     */
+    void dropIndex(ClientSession clientSession, Bson keys);
+
+    /**
      * Drop all the indexes on this collection, except for the default on _id.
      *
      * @mongodb.driver.manual reference/command/dropIndexes/ Drop indexes
      */
     void dropIndexes();
+
+    /**
+     * Drop all the indexes on this collection, except for the default on _id.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual reference/command/dropIndexes/ Drop indexes
+     */
+    void dropIndexes(ClientSession clientSession);
 
     /**
      * Rename the collection with oldCollectionName to the newCollectionName.
@@ -758,4 +1325,31 @@ public interface MongoCollection<TDocument> {
      */
     void renameCollection(MongoNamespace newCollectionNamespace, RenameCollectionOptions renameCollectionOptions);
 
+    /**
+     * Rename the collection with oldCollectionName to the newCollectionName.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param newCollectionNamespace the namespace the collection will be renamed to
+     * @throws com.mongodb.MongoServerException if you provide a newCollectionName that is the name of an existing collection, or if the
+     *                                          oldCollectionName is the name of a collection that doesn't exist
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual reference/command/renameCollection Rename collection
+     */
+    void renameCollection(ClientSession clientSession, MongoNamespace newCollectionNamespace);
+
+    /**
+     * Rename the collection with oldCollectionName to the newCollectionName.
+     *
+     * @param clientSession the client session with which to associate this operation
+     * @param newCollectionNamespace  the name the collection will be renamed to
+     * @param renameCollectionOptions the options for renaming a collection
+     * @throws com.mongodb.MongoServerException if you provide a newCollectionName that is the name of an existing collection and dropTarget
+     *                                          is false, or if the oldCollectionName is the name of a collection that doesn't exist
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual reference/command/renameCollection Rename collection
+     */
+    void renameCollection(ClientSession clientSession, MongoNamespace newCollectionNamespace,
+                          RenameCollectionOptions renameCollectionOptions);
 }

--- a/driver/src/main/com/mongodb/client/MongoCollection.java
+++ b/driver/src/main/com/mongodb/client/MongoCollection.java
@@ -388,8 +388,9 @@ public interface MongoCollection<TDocument> {
      * @param resultClass the class to decode each document into
      * @param <TResult>   the target document type of the iterable.
      * @return an iterable containing the result of the aggregation operation
+     * @since 3.6
+     * @mongodb.server.release 3.6
      * @mongodb.driver.manual aggregation/ Aggregation
-     * @mongodb.server.release 2.2
      */
     <TResult> AggregateIterable<TResult> aggregate(ClientSession clientSession, List<? extends Bson> pipeline, Class<TResult> resultClass);
 


### PR DESCRIPTION
This PR finishes out the synchronous MongoCollection interface and implementation.  Still to come:

* MongoDatabase, e.g. runCommand
* MongoClient, e.g. listDatabases
* Async