### PR TITLE
JAVA-2564: session pool

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/DefaultConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/connection/DefaultConnectionPool.java
@@ -36,6 +36,7 @@ import com.mongodb.event.ConnectionPoolWaitQueueEnteredEvent;
 import com.mongodb.event.ConnectionPoolWaitQueueExitedEvent;
 import com.mongodb.event.ConnectionRemovedEvent;
 import com.mongodb.internal.connection.ConcurrentPool;
+import com.mongodb.internal.connection.ConcurrentPool.Prune;
 import com.mongodb.internal.thread.DaemonThreadFactory;
 import org.bson.ByteBuf;
 import org.bson.codecs.Decoder;
@@ -551,8 +552,8 @@ class DefaultConnectionPool implements ConnectionPool {
         }
 
         @Override
-        public boolean shouldPrune(final UsageTrackingInternalConnection usageTrackingConnection) {
-            return DefaultConnectionPool.this.shouldPrune(usageTrackingConnection);
+        public Prune shouldPrune(final UsageTrackingInternalConnection usageTrackingConnection) {
+            return DefaultConnectionPool.this.shouldPrune(usageTrackingConnection) ? Prune.YES : Prune.NO;
         }
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/ConcurrentLinkedDeque.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ConcurrentLinkedDeque.java
@@ -917,7 +917,6 @@ implements Deque<E>, java.io.Serializable {
          *
          * @return true if the element was successfully removed by this call, false if the element had already been removed by a concurrent
          * removal
-         * @implSpec
          * @throws IllegalStateException if the {@code next} method has not
          *         yet been called, or the {@code remove} method has already
          *         been called after the last call to the {@code next}

--- a/driver-core/src/main/com/mongodb/internal/connection/ConcurrentLinkedDeque.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ConcurrentLinkedDeque.java
@@ -866,11 +866,11 @@ implements Deque<E>, java.io.Serializable {
      *
      * @return an iterator over the elements in this deque in proper sequence
      */
-    public Iterator<E> iterator() {
+    public RemovalReportingIterator<E> iterator() {
         return new CLDIterator();
     }
 
-    final class CLDIterator implements Iterator<E> {
+    final class CLDIterator implements RemovalReportingIterator<E> {
         Node<E> last;
         Node<E> next = header.forward();
 
@@ -887,11 +887,19 @@ implements Deque<E>, java.io.Serializable {
         }
 
         public void remove() {
+            reportingRemove();
+        }
+
+        @Override
+        public boolean reportingRemove() {
             Node<E> l = last;
             if (l == null)
                 throw new IllegalStateException();
-            while (!l.delete() && !l.isDeleted())
-                ;
+            boolean successfullyRemoved = l.delete();
+            while (!successfullyRemoved && !l.isDeleted()) {
+                successfullyRemoved = l.delete();
+            }
+            return successfullyRemoved;
         }
     }
 
@@ -900,5 +908,21 @@ implements Deque<E>, java.io.Serializable {
      */
     public Iterator<E> descendingIterator() {
         throw new UnsupportedOperationException();
+    }
+
+    public interface RemovalReportingIterator<E> extends Iterator<E> {
+        /**
+         * Removes from the underlying collection the last element returned by this iterator and reports whether the current element was
+         * removed by the call.  This method can be called only once per call to {@link #next}.
+         *
+         * @return true if the element was successfully removed by this call, false if the element had already been removed by a concurrent
+         * removal
+         * @implSpec
+         * @throws IllegalStateException if the {@code next} method has not
+         *         yet been called, or the {@code remove} method has already
+         *         been called after the last call to the {@code next}
+         *         method
+         */
+        boolean reportingRemove();
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/ConcurrentPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ConcurrentPool.java
@@ -19,8 +19,8 @@ package com.mongodb.internal.connection;
 import com.mongodb.MongoInternalException;
 import com.mongodb.MongoInterruptedException;
 import com.mongodb.MongoTimeoutException;
+import com.mongodb.internal.connection.ConcurrentLinkedDeque.RemovalReportingIterator;
 
-import java.util.Deque;
 import java.util.Iterator;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
@@ -35,10 +35,24 @@ public class ConcurrentPool<T> implements Pool<T> {
     private final int maxSize;
     private final ItemFactory<T> itemFactory;
 
-    private final Deque<T> available = new ConcurrentLinkedDeque<T>();
+    private final ConcurrentLinkedDeque<T> available = new ConcurrentLinkedDeque<T>();
     private final Semaphore permits;
     private volatile boolean closed;
 
+    public enum Prune {
+        /**
+         * Prune this element
+         */
+        YES,
+        /**
+         * Don't prone this element
+         */
+        NO,
+        /**
+         * Don't prune this element and stop attempting to prune additional elements
+         */
+        STOP
+    }
     /**
      * Factory for creating and closing pooled items.
      *
@@ -49,7 +63,7 @@ public class ConcurrentPool<T> implements Pool<T> {
 
         void close(T t);
 
-        boolean shouldPrune(T t);
+        Prune shouldPrune(T t);
     }
 
     /**
@@ -136,17 +150,18 @@ public class ConcurrentPool<T> implements Pool<T> {
     }
 
     public void prune() {
-        int currentAvailableCount = getAvailableCount();
-        for (int numAttempts = 0; numAttempts < currentAvailableCount; numAttempts++) {
-            if (!acquirePermit(10, TimeUnit.MILLISECONDS)) {
+        for (RemovalReportingIterator<T> iter = available.iterator(); iter.hasNext();) {
+            T cur = iter.next();
+            Prune shouldPrune = itemFactory.shouldPrune(cur);
+            if (shouldPrune == Prune.YES) {
+                boolean removed = iter.reportingRemove();
+                if (removed) {
+                    close(cur);
+                }
+            }
+            if (shouldPrune == Prune.STOP) {
                 break;
             }
-            T cur = available.pollFirst();
-            if (cur == null) {
-                releasePermit();
-                break;
-            }
-            release(cur, itemFactory.shouldPrune(cur));
         }
     }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/ConcurrentPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ConcurrentPool.java
@@ -153,14 +153,16 @@ public class ConcurrentPool<T> implements Pool<T> {
         for (RemovalReportingIterator<T> iter = available.iterator(); iter.hasNext();) {
             T cur = iter.next();
             Prune shouldPrune = itemFactory.shouldPrune(cur);
+
+            if (shouldPrune == Prune.STOP) {
+                break;
+            }
+
             if (shouldPrune == Prune.YES) {
                 boolean removed = iter.reportingRemove();
                 if (removed) {
                     close(cur);
                 }
-            }
-            if (shouldPrune == Prune.STOP) {
-                break;
             }
         }
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/PowerOfTwoBufferPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/PowerOfTwoBufferPool.java
@@ -17,6 +17,7 @@
 package com.mongodb.internal.connection;
 
 import com.mongodb.connection.BufferProvider;
+import com.mongodb.internal.connection.ConcurrentPool.Prune;
 import org.bson.ByteBuf;
 import org.bson.ByteBufNIO;
 
@@ -63,8 +64,8 @@ public class PowerOfTwoBufferPool implements BufferProvider {
                                                                              }
 
                                                                              @Override
-                                                                             public boolean shouldPrune(final ByteBuffer byteBuffer) {
-                                                                                 return false;
+                                                                             public Prune shouldPrune(final ByteBuffer byteBuffer) {
+                                                                                 return Prune.STOP;
                                                                              }
                                                                          }));
             powerOfTwo = powerOfTwo << 1;

--- a/driver-core/src/test/unit/com/mongodb/connection/ConcurrentLinkedDequeSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/ConcurrentLinkedDequeSpecification.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.connection
+
+import com.mongodb.internal.connection.ConcurrentLinkedDeque
+import spock.lang.Specification
+
+// Mostly untested since it was a straight copy from an existing high-quality open source implementation
+class ConcurrentLinkedDequeSpecification extends Specification {
+    def 'should report successful removal from iterator'() {
+        given:
+        def deque = new ConcurrentLinkedDeque<Integer>()
+        deque.add(1)
+        deque.add(2)
+        deque.add(3)
+        def iter = deque.iterator()
+
+        when:
+        def next = iter.next()
+        def successfullyRemoved = iter.reportingRemove()
+
+        then:
+        next == 1
+        successfullyRemoved
+
+        when:
+        next = iter.next()
+        successfullyRemoved = iter.reportingRemove()
+
+        then:
+        next == 2
+        successfullyRemoved
+
+        when:
+        next = iter.next()
+        successfullyRemoved = iter.reportingRemove()
+
+        then:
+        next == 3
+        successfullyRemoved
+    }
+
+    def 'should report unsuccessful removal from iterator'() {
+        given:
+        def deque = new ConcurrentLinkedDeque<Integer>()
+        deque.add(1)
+        deque.add(2)
+        deque.add(3)
+        def iter = deque.iterator()
+
+        when:
+        def next = iter.next()
+        deque.remove(next)
+        def successfullyRemoved = iter.reportingRemove()
+
+        then:
+        next == 1
+        !successfullyRemoved
+
+        when:
+        next = iter.next()
+        deque.remove(next)
+        successfullyRemoved = iter.reportingRemove()
+
+        then:
+        next == 2
+        !successfullyRemoved
+
+        when:
+        next = iter.next()
+        deque.remove(next)
+        successfullyRemoved = iter.reportingRemove()
+
+        then:
+        next == 3
+        !successfullyRemoved
+    }
+
+}

--- a/driver/src/main/com/mongodb/Mongo.java
+++ b/driver/src/main/com/mongodb/Mongo.java
@@ -857,7 +857,7 @@ public class Mongo {
     }
 
     ClientSession createClientSession(final ClientSessionOptions options) {
-        if (cluster.getDescription().getLogicalSessionTimeoutMinutes() != null) {
+        if (cluster.getDescription().getLogicalSessionTimeoutMinutes() != null && credentialsList.size() < 2) {
             return new ClientSessionImpl(this, options);
         } else {
             return null;

--- a/driver/src/main/com/mongodb/Mongo.java
+++ b/driver/src/main/com/mongodb/Mongo.java
@@ -99,7 +99,7 @@ public class Mongo {
 
     private final ConcurrentLinkedQueue<ServerCursorAndNamespace> orphanedCursors = new ConcurrentLinkedQueue<ServerCursorAndNamespace>();
     private final ExecutorService cursorCleaningService;
-    private final ServerSessionPool serverSessionPool = new ServerSessionPool();
+    private final ServerSessionPool serverSessionPool;
 
     /**
      * Creates a Mongo instance based on a (single) mongodb node (localhost, default port)
@@ -314,6 +314,7 @@ public class Mongo {
 
     Mongo(final Cluster cluster, final MongoClientOptions options, final List<MongoCredential> credentialsList) {
         this.cluster = cluster;
+        this.serverSessionPool = new ServerSessionPool(cluster);
         this.options = options;
         this.readPreference = options.getReadPreference() != null ? options.getReadPreference() : primary();
         this.writeConcern = options.getWriteConcern() != null ? options.getWriteConcern() : WriteConcern.UNACKNOWLEDGED;
@@ -531,8 +532,8 @@ public class Mongo {
      * databases obtained from it can no longer be used.
      */
     public void close() {
-        cluster.close();
         serverSessionPool.close();
+        cluster.close();
         if (cursorCleaningService != null) {
             cursorCleaningService.shutdownNow();
         }

--- a/driver/src/main/com/mongodb/ServerSession.java
+++ b/driver/src/main/com/mongodb/ServerSession.java
@@ -38,4 +38,11 @@ public interface ServerSession {
      * @return the next transaction number
      */
     long advanceTransactionNumber();
+
+    /**
+     * Whether the server session is closed.
+     *
+     * @return true if the session has been closed
+     */
+    boolean isClosed();
 }

--- a/driver/src/main/com/mongodb/ServerSessionPool.java
+++ b/driver/src/main/com/mongodb/ServerSessionPool.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb;
+
+import com.mongodb.internal.connection.ConcurrentPool;
+import org.bson.BsonBinary;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentWriter;
+import org.bson.UuidRepresentation;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.UuidCodec;
+
+import java.util.UUID;
+
+class ServerSessionPool {
+    private final ConcurrentPool<ServerSession> serverSessionPool =
+            new ConcurrentPool<ServerSession>(Integer.MAX_VALUE, new ServerSessionItemFactory());
+
+    ServerSession get() {
+        return serverSessionPool.get();
+    }
+
+    void release(final ServerSession serverSession) {
+        serverSessionPool.release(serverSession);
+    }
+
+    void close() {
+        serverSessionPool.close();
+    }
+
+    private static class ServerSessionImpl implements ServerSession {
+        private final BsonDocument identifier;
+        private int transactionNumber;
+
+        ServerSessionImpl(final BsonBinary identifier) {
+            this.identifier = new BsonDocument("id", identifier);
+        }
+
+        @Override
+        public BsonDocument getIdentifier() {
+            return identifier;
+        }
+
+        @Override
+        public long advanceTransactionNumber() {
+            return transactionNumber++;
+        }
+    }
+
+    private static final class ServerSessionItemFactory implements ConcurrentPool.ItemFactory<ServerSession> {
+        @Override
+        public ServerSession create(final boolean initialize) {
+            return new ServerSessionImpl(createNewServerSessionIdentifier());
+        }
+
+        @Override
+        public void close(final ServerSession serverSession) {
+            // TODO: pruning
+        }
+
+        @Override
+        public boolean shouldPrune(final ServerSession serverSession) {
+            return false;
+        }
+
+        private BsonBinary createNewServerSessionIdentifier() {
+            UuidCodec uuidCodec = new UuidCodec(UuidRepresentation.STANDARD);
+            BsonDocument holder = new BsonDocument();
+            BsonDocumentWriter bsonDocumentWriter = new BsonDocumentWriter(holder);
+            bsonDocumentWriter.writeStartDocument();
+            bsonDocumentWriter.writeName("id");
+            uuidCodec.encode(bsonDocumentWriter, UUID.randomUUID(), EncoderContext.builder().build());
+            bsonDocumentWriter.writeEndDocument();
+            return holder.getBinary("id");
+        }
+    }
+}

--- a/driver/src/main/com/mongodb/ServerSessionPool.java
+++ b/driver/src/main/com/mongodb/ServerSessionPool.java
@@ -17,6 +17,7 @@
 package com.mongodb;
 
 import com.mongodb.internal.connection.ConcurrentPool;
+import com.mongodb.internal.connection.ConcurrentPool.Prune;
 import org.bson.BsonBinary;
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentWriter;
@@ -73,8 +74,8 @@ class ServerSessionPool {
         }
 
         @Override
-        public boolean shouldPrune(final ServerSession serverSession) {
-            return false;
+        public Prune shouldPrune(final ServerSession serverSession) {
+            return Prune.STOP;
         }
 
         private BsonBinary createNewServerSessionIdentifier() {

--- a/driver/src/test/functional/com/mongodb/MongoClientSessionSpecification.groovy
+++ b/driver/src/test/functional/com/mongodb/MongoClientSessionSpecification.groovy
@@ -266,7 +266,6 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         then:
         def pingCommandStartedEvent = commandListener.events.get(0)
         !(pingCommandStartedEvent as CommandStartedEvent).command.containsKey('lsid')
-
         cleanup:
         client?.close()
     }

--- a/driver/src/test/unit/com/mongodb/ServerSessionPoolSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/ServerSessionPoolSpecification.groovy
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb
+
+import com.mongodb.connection.Cluster
+import com.mongodb.connection.ClusterDescription
+import com.mongodb.connection.ClusterSettings
+import com.mongodb.connection.Connection
+import com.mongodb.connection.Server
+import com.mongodb.connection.ServerDescription
+import com.mongodb.connection.ServerSettings
+import com.mongodb.internal.connection.NoOpSessionContext
+import com.mongodb.internal.validator.NoOpFieldNameValidator
+import com.mongodb.selector.ReadPreferenceServerSelector
+import org.bson.BsonArray
+import org.bson.BsonBinarySubType
+import org.bson.BsonDocument
+import org.bson.codecs.BsonDocumentCodec
+import spock.lang.Specification
+
+import static com.mongodb.ReadPreference.primaryPreferred
+import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE
+import static com.mongodb.connection.ClusterType.REPLICA_SET
+import static com.mongodb.connection.ServerConnectionState.CONNECTED
+import static com.mongodb.connection.ServerConnectionState.CONNECTING
+import static com.mongodb.connection.ServerType.REPLICA_SET_PRIMARY
+import static com.mongodb.connection.ServerType.UNKNOWN
+import static java.util.concurrent.TimeUnit.MINUTES
+
+class ServerSessionPoolSpecification extends Specification {
+
+    def connectedDescription = new ClusterDescription(MULTIPLE, REPLICA_SET,
+            [
+                    ServerDescription.builder().ok(true)
+                            .state(CONNECTED)
+                            .address(new ServerAddress())
+                            .type(REPLICA_SET_PRIMARY)
+                            .logicalSessionTimeoutMinutes(30)
+                            .build()
+            ], ClusterSettings.builder().hosts([new ServerAddress()]).build(), ServerSettings.builder().build())
+
+    def unconnectedDescription = new ClusterDescription(MULTIPLE, REPLICA_SET,
+            [
+                    ServerDescription.builder().ok(true)
+                            .state(CONNECTING)
+                            .address(new ServerAddress())
+                            .type(UNKNOWN)
+                            .logicalSessionTimeoutMinutes(null)
+                            .build()
+            ], ClusterSettings.builder().hosts([new ServerAddress()]).build(), ServerSettings.builder().build())
+
+    def 'should get session'() {
+        given:
+        def cluster = Stub(Cluster) {
+            getDescription() >> connectedDescription
+        }
+        def pool = new ServerSessionPool(cluster)
+
+        when:
+        def session = pool.get()
+
+        then:
+        session != null
+    }
+
+    def 'should throw IllegalStateException if pool is closed'() {
+        given:
+        def cluster = Stub(Cluster) {
+            getDescription() >> connectedDescription
+        }
+        def pool = new ServerSessionPool(cluster)
+        pool.close()
+
+        when:
+        pool.get()
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    def 'should pool session'() {
+        given:
+        def cluster = Stub(Cluster) {
+            getDescription() >> connectedDescription
+        }
+        def pool = new ServerSessionPool(cluster)
+        def session = pool.get()
+
+        when:
+        pool.release(session)
+        def pooledSession = pool.get()
+
+        then:
+        session == pooledSession
+    }
+
+    def 'should prune session'() {
+        given:
+        def cluster = Mock(Cluster) {
+            getDescription() >> connectedDescription
+        }
+        def clock = Stub(ServerSessionPool.Clock) {
+            millis() >>> [0,
+                          1,
+                          MINUTES.toMillis(29),
+                          MINUTES.toMillis(29) + 1]
+        }
+        def pool = new ServerSessionPool(cluster, clock)
+        def session = pool.get()
+
+        when:
+        pool.release(session)
+        def newSession = pool.get()
+
+        then:
+        session == newSession
+
+        when:
+        pool.release(newSession)
+        newSession = pool.get()
+
+        then:
+        session != newSession
+        0 * cluster.selectServer(_)
+    }
+
+    def 'should not prune session when timeout is null'() {
+        given:
+        def cluster = Stub(Cluster) {
+            getDescription() >> unconnectedDescription
+        }
+        def clock = Stub(ServerSessionPool.Clock) {
+            millis() >>> [0, 0,
+                          MINUTES.toMillis(29) + 1]
+        }
+        def pool = new ServerSessionPool(cluster, clock)
+        def session = pool.get()
+
+        when:
+        pool.release(session)
+        def newSession = pool.get()
+
+        then:
+        session == newSession
+    }
+
+    def 'should initialize session'() {
+        given:
+        def cluster = Stub(Cluster) {
+            getDescription() >> connectedDescription
+        }
+        def clock = Stub(ServerSessionPool.Clock) {
+            millis() >> 42
+        }
+        def pool = new ServerSessionPool(cluster, clock)
+
+        when:
+        def session = pool.get() as ServerSessionPool.ServerSessionImpl
+
+        then:
+        session.lastUsedAtMillis == 42
+        session.transactionNumber == 0
+        def uuid = session.identifier.getBinary('id')
+        uuid != null
+        uuid.type == BsonBinarySubType.UUID_STANDARD.value
+        uuid.data.length == 16
+        session.advanceTransactionNumber() == 0
+        session.advanceTransactionNumber() == 1
+    }
+
+    def 'should end pooled sessions when pool is closed'() {
+        given:
+        def connection = Mock(Connection)
+        def server = Stub(Server) {
+            getConnection() >> connection
+        }
+        def cluster = Mock(Cluster) {
+            getDescription() >> connectedDescription
+        }
+        def pool = new ServerSessionPool(cluster)
+        // check out sessions up the the endSessions batch size
+        def sessions = []
+        10000.times { sessions.add(pool.get()) }
+        // and then check out one more
+        def oneOverBatchSizeSession = pool.get()
+
+        // now release them all before closing the pool
+        for (def cur : sessions) {
+            pool.release(cur)
+        }
+        pool.release(oneOverBatchSizeSession)
+
+        when:
+        pool.close()
+
+        then:
+        // first batch is the first 10K sessions, final batch is the last one
+        1 * cluster.selectServer { (it as ReadPreferenceServerSelector).readPreference == primaryPreferred() }  >> server
+        1 * connection.command('admin',
+                new BsonDocument('endSessions', new BsonArray(sessions*.getIdentifier())),
+                primaryPreferred(), { it instanceof NoOpFieldNameValidator },
+                { it instanceof BsonDocumentCodec }, NoOpSessionContext.INSTANCE) >> new BsonDocument()
+        1 * connection.release()
+
+        1 * cluster.selectServer { (it as ReadPreferenceServerSelector).readPreference == primaryPreferred() }  >> server
+        1 * connection.command('admin',
+                new BsonDocument('endSessions', new BsonArray([oneOverBatchSizeSession.getIdentifier()])),
+                primaryPreferred(), { it instanceof NoOpFieldNameValidator },
+                { it instanceof BsonDocumentCodec }, NoOpSessionContext.INSTANCE) >> new BsonDocument()
+        1 * connection.release()
+    }
+
+}


### PR DESCRIPTION
Two functional changes implemented that are required by the spec:

1. Don't use implicit sessions when more than one user is authenticated
2. Server session pool pruning

The latter change was more involved, and involved three precursor steps:

1. Refactor the server session pool from a nested class within the Mongo class into its own top-level class.
2. Add capability to our private copy of ConcurrentLinkedDeque to support a variant of Iterator.remove that returns a boolean whether the remove actually happened.  This enabled a cleaner implementation of the following change...
3. Support breaking out of the loop in ConcurrentPool.prune, which is required by the sessions spec

Patch build: https://evergreen.mongodb.com/version/59d288d4e3c331361000034a