### PR TITLE
JAVA-2571: Causal consistency

### DIFF
--- a/driver-core/src/main/com/mongodb/ReadConcern.java
+++ b/driver-core/src/main/com/mongodb/ReadConcern.java
@@ -29,15 +29,15 @@ import static com.mongodb.assertions.Assertions.notNull;
  * @since 3.2
  */
 public final class ReadConcern {
-    private final ReadConcernLevel readConcernLevel;
+    private final ReadConcernLevel level;
 
     /**
      * Construct a new read concern
      *
-     * @param readConcernLevel the read concern level
+     * @param level the read concern level
      */
-    public ReadConcern(final ReadConcernLevel readConcernLevel) {
-        this.readConcernLevel = notNull("readConcernLevel", readConcernLevel);
+    public ReadConcern(final ReadConcernLevel level) {
+        this.level = notNull("level", level);
     }
 
     /**
@@ -67,12 +67,21 @@ public final class ReadConcern {
      */
     public static final ReadConcern LINEARIZABLE = new ReadConcern(ReadConcernLevel.LINEARIZABLE);
 
+    /**
+     * Gets the read concern level.
+     *
+     * @return the read concern level, which may be null (which indicates to use the server's default level)
+     * @since 3.6
+     */
+    public ReadConcernLevel getLevel() {
+        return level;
+    }
 
     /**
      * @return true if this is the server default read concern
      */
     public boolean isServerDefault() {
-        return readConcernLevel == null;
+        return level == null;
     }
 
     /**
@@ -82,8 +91,8 @@ public final class ReadConcern {
      */
     public BsonDocument asDocument() {
         BsonDocument readConcern = new BsonDocument();
-        if (!isServerDefault()){
-            readConcern.put("level", new BsonString(readConcernLevel.getValue()));
+        if (level != null) {
+            readConcern.put("level", new BsonString(level.getValue()));
         }
         return readConcern;
     }
@@ -93,25 +102,21 @@ public final class ReadConcern {
         if (this == o) {
             return true;
         }
-        if (o == null) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (getClass() != o.getClass()) {
-            return false;
-        }
+
         ReadConcern that = (ReadConcern) o;
-        if (readConcernLevel != that.readConcernLevel) {
-            return false;
-        }
-        return true;
+
+        return level == that.level;
     }
 
     @Override
     public int hashCode() {
-        return readConcernLevel != null ? readConcernLevel.hashCode() : 0;
+        return level != null ? level.hashCode() : 0;
     }
 
     private ReadConcern() {
-        this.readConcernLevel = null;
+        this.level = null;
     }
 }

--- a/driver-core/src/main/com/mongodb/connection/DefaultServer.java
+++ b/driver-core/src/main/com/mongodb/connection/DefaultServer.java
@@ -240,8 +240,18 @@ class DefaultServer implements ClusterableServer {
         }
 
         @Override
+        public boolean isCausallyConsistent() {
+            return wrapped.isCausallyConsistent();
+        }
+
+        @Override
         public long advanceTransactionNumber() {
             return wrapped.advanceTransactionNumber();
+        }
+
+        @Override
+        public BsonTimestamp getOperationTime() {
+            return wrapped.getOperationTime();
         }
 
         @Override

--- a/driver-core/src/main/com/mongodb/connection/SessionContext.java
+++ b/driver-core/src/main/com/mongodb/connection/SessionContext.java
@@ -35,28 +35,50 @@ public interface SessionContext {
     boolean hasSession();
 
     /**
+     * Gets the session identifier if this context has a session backing it.
      *
      * @return the session id
      */
     BsonDocument getSessionId();
 
     /**
+     * Gets whether this context is associated with a causally consistent session.
+     *
+     * @return true ift his context is associated with a causally consistent session
+     */
+    boolean isCausallyConsistent();
+
+    /**
+     * Advance the transaction number.
      *
      * @return the next transaction number for the session
      */
     long advanceTransactionNumber();
 
     /**
+     * Gets the current operation time for this session context
+     *
+     * @return the current operation time, which may be null
+     */
+    BsonTimestamp getOperationTime();
+
+    /**
+     * Advance the operation time.  If the current operation time is greater than the given operation time, this method has no effect.
+     *
      * @param operationTime the new operation time time
      */
     void advanceOperationTime(BsonTimestamp operationTime);
 
     /**
-     * @return the cluster time
+     * Gets the current cluster time for this session context.
+     *
+     * @return the cluster time, which may be null
      */
     BsonDocument getClusterTime();
 
     /**
+     * Advance the cluster time. If the current cluster time is greater than the given cluster time, this method has no effect.
+     *
      * @param clusterTime the new cluster time
      */
     void advanceClusterTime(BsonDocument clusterTime);

--- a/driver-core/src/main/com/mongodb/internal/connection/NoOpSessionContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/NoOpSessionContext.java
@@ -44,8 +44,18 @@ public final class NoOpSessionContext implements SessionContext {
     }
 
     @Override
+    public boolean isCausallyConsistent() {
+        return false;
+    }
+
+    @Override
     public long advanceTransactionNumber() {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BsonTimestamp getOperationTime() {
+        return null;
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/operation/ReadConcernHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/ReadConcernHelper.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.operation;
+
+import com.mongodb.ReadConcern;
+import com.mongodb.ReadConcernLevel;
+import com.mongodb.connection.SessionContext;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+
+import static com.mongodb.assertions.Assertions.notNull;
+
+final class ReadConcernHelper {
+
+    static void appendReadConcernToCommand(final ReadConcern readConcern, final SessionContext sessionContext,
+                                           final BsonDocument commandDocument) {
+        notNull("readConcern", readConcern);
+        notNull("sessionContext", sessionContext);
+        notNull("commandDocument", commandDocument);
+        BsonDocument readConcernDocument = new BsonDocument();
+        ReadConcernLevel level = getReadConcernLevel(readConcern, sessionContext);
+        if (level != null) {
+            readConcernDocument.append("level", new BsonString(level.getValue()));
+        }
+        if (shouldAddAfterClusterTime(sessionContext)) {
+            readConcernDocument.append("afterClusterTime", sessionContext.getOperationTime());
+        }
+        if (!readConcernDocument.isEmpty()) {
+            commandDocument.append("readConcern", readConcernDocument);
+        }
+    }
+
+    private static ReadConcernLevel getReadConcernLevel(final ReadConcern readConcern, final SessionContext sessionContext) {
+        if (readConcern.getLevel() == null && shouldAddAfterClusterTime(sessionContext)) {
+            return ReadConcernLevel.LOCAL;
+        } else {
+            return readConcern.getLevel();
+        }
+    }
+
+    private static boolean shouldAddAfterClusterTime(final SessionContext sessionContext) {
+        return sessionContext.isCausallyConsistent() && sessionContext.getOperationTime() != null;
+    }
+
+    private ReadConcernHelper() {
+    }
+}

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -21,8 +21,10 @@ import com.mongodb.async.FutureResultCallback;
 import com.mongodb.async.SingleResultCallback;
 import com.mongodb.binding.AsyncClusterBinding;
 import com.mongodb.binding.AsyncConnectionSource;
+import com.mongodb.binding.AsyncReadBinding;
 import com.mongodb.binding.AsyncReadWriteBinding;
 import com.mongodb.binding.AsyncSingleConnectionBinding;
+import com.mongodb.binding.AsyncWriteBinding;
 import com.mongodb.binding.ClusterBinding;
 import com.mongodb.binding.ReadWriteBinding;
 import com.mongodb.binding.SingleConnectionBinding;
@@ -373,7 +375,7 @@ public final class ClusterFixture {
         return executeAsync(op, getAsyncBinding());
     }
 
-    public static <T> T executeAsync(final AsyncWriteOperation<T> op, final AsyncReadWriteBinding binding) throws Throwable {
+    public static <T> T executeAsync(final AsyncWriteOperation<T> op, final AsyncWriteBinding binding) throws Throwable {
         final FutureResultCallback<T> futureResultCallback = new FutureResultCallback<T>();
         op.executeAsync(binding, futureResultCallback);
         return futureResultCallback.get(TIMEOUT, SECONDS);
@@ -383,7 +385,7 @@ public final class ClusterFixture {
         return executeAsync(op, getAsyncBinding());
     }
 
-    public static <T> T executeAsync(final AsyncReadOperation<T> op, final AsyncReadWriteBinding binding) throws Throwable {
+    public static <T> T executeAsync(final AsyncReadOperation<T> op, final AsyncReadBinding binding) throws Throwable {
         final FutureResultCallback<T> futureResultCallback = new FutureResultCallback<T>();
         op.executeAsync(binding, futureResultCallback);
         return futureResultCallback.get(TIMEOUT, SECONDS);

--- a/driver-core/src/test/functional/com/mongodb/operation/AggregateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/AggregateOperationSpecification.groovy
@@ -22,17 +22,29 @@ import com.mongodb.MongoNamespace
 import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.ReadConcern
 import com.mongodb.ReadPreference
+import com.mongodb.ServerAddress
 import com.mongodb.WriteConcern
+import com.mongodb.binding.AsyncConnectionSource
+import com.mongodb.binding.AsyncReadBinding
+import com.mongodb.binding.ConnectionSource
+import com.mongodb.binding.ReadBinding
 import com.mongodb.client.model.Collation
 import com.mongodb.client.model.CreateCollectionOptions
+import com.mongodb.connection.AsyncConnection
+import com.mongodb.connection.ClusterId
+import com.mongodb.connection.Connection
 import com.mongodb.connection.ConnectionDescription
+import com.mongodb.connection.ConnectionId
+import com.mongodb.connection.ServerId
 import com.mongodb.connection.ServerVersion
+import com.mongodb.connection.SessionContext
 import org.bson.BsonArray
 import org.bson.BsonBoolean
 import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.BsonInt64
 import org.bson.BsonString
+import org.bson.BsonTimestamp
 import org.bson.Document
 import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.DocumentCodec
@@ -41,11 +53,14 @@ import spock.lang.IgnoreIf
 import static com.mongodb.ClusterFixture.collectCursorResults
 import static com.mongodb.ClusterFixture.disableMaxTimeFailPoint
 import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint
+import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.getCluster
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.connection.ServerType.STANDALONE
+import static com.mongodb.operation.ReadConcernHelper.appendReadConcernToCommand
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static java.util.concurrent.TimeUnit.SECONDS
 
@@ -374,6 +389,86 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
 
         where:
         async << [true, false]
+    }
+
+    def 'should add read concern to command'() {
+        given:
+        def binding = Stub(ReadBinding)
+        def source = Stub(ConnectionSource)
+        def connection = Mock(Connection)
+        binding.readPreference >> ReadPreference.primary()
+        binding.readConnectionSource >> source
+        binding.sessionContext >> sessionContext
+        source.connection >> connection
+        source.retain() >> source
+        def commandDocument = new BsonDocument('aggregate', new BsonString(getCollectionName()))
+                .append('pipeline', new BsonArray())
+                .append('cursor', new BsonDocument())
+        appendReadConcernToCommand(ReadConcern.MAJORITY, sessionContext, commandDocument)
+
+        def operation = new AggregateOperation<Document>(getNamespace(), [], new DocumentCodec())
+                .readConcern(ReadConcern.MAJORITY)
+
+        when:
+        operation.execute(binding)
+
+        then:
+        _ * connection.description >> new ConnectionDescription(new ConnectionId(new ServerId(new ClusterId(), new ServerAddress())),
+                new ServerVersion(3, 6), STANDALONE, 1000, 100000, 100000, [])
+        1 * connection.command(_, commandDocument, _, _, _, sessionContext) >>
+                new BsonDocument('cursor', new BsonDocument('id', new BsonInt64(1))
+                        .append('ns', new BsonString(getNamespace().getFullName()))
+                        .append('firstBatch', new BsonArrayWrapper([])))
+        1 * connection.release()
+
+        where:
+        sessionContext << [
+                Stub(SessionContext) {
+                    isCausallyConsistent() >> true
+                    getOperationTime() >> new BsonTimestamp(42, 0)
+                }
+        ]
+    }
+
+    def 'should add read concern to command asynchronously'() {
+        given:
+        def binding = Stub(AsyncReadBinding)
+        def source = Stub(AsyncConnectionSource)
+        def connection = Mock(AsyncConnection)
+        binding.readPreference >> ReadPreference.primary()
+        binding.getReadConnectionSource(_) >> { it[0].onResult(source, null) }
+        binding.sessionContext >> sessionContext
+        source.getConnection(_) >> { it[0].onResult(connection, null) }
+        source.retain() >> source
+        def commandDocument = new BsonDocument('aggregate', new BsonString(getCollectionName()))
+                .append('pipeline', new BsonArray())
+                .append('cursor', new BsonDocument())
+        appendReadConcernToCommand(ReadConcern.MAJORITY, sessionContext, commandDocument)
+        appendReadConcernToCommand(ReadConcern.MAJORITY, sessionContext, commandDocument)
+
+        def operation = new AggregateOperation<Document>(getNamespace(), [], new DocumentCodec())
+                .readConcern(ReadConcern.MAJORITY)
+
+        when:
+        executeAsync(operation, binding)
+
+        then:
+        _ * connection.description >> new ConnectionDescription(new ConnectionId(new ServerId(new ClusterId(), new ServerAddress())),
+                new ServerVersion(3, 6), STANDALONE, 1000, 100000, 100000, [])
+        1 * connection.commandAsync(_, commandDocument, _, _, _, sessionContext, _) >> {
+            it[6].onResult(new BsonDocument('cursor', new BsonDocument('id', new BsonInt64(1))
+                    .append('ns', new BsonString(getNamespace().getFullName()))
+                    .append('firstBatch', new BsonArrayWrapper([]))), null)
+        }
+        1 * connection.release()
+
+        where:
+        sessionContext << [
+                Stub(SessionContext) {
+                    isCausallyConsistent() >> true
+                    getOperationTime() >> new BsonTimestamp(42, 0)
+                }
+        ]
     }
 
     def 'should use the ReadBindings readPreference to set slaveOK'() {

--- a/driver-core/src/test/functional/com/mongodb/operation/CountOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/CountOperationSpecification.groovy
@@ -24,12 +24,25 @@ import com.mongodb.MongoNamespace
 import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.ReadConcern
 import com.mongodb.ReadPreference
+import com.mongodb.ServerAddress
+import com.mongodb.binding.AsyncConnectionSource
+import com.mongodb.binding.AsyncReadBinding
+import com.mongodb.binding.ConnectionSource
+import com.mongodb.binding.ReadBinding
 import com.mongodb.bulk.IndexRequest
+import com.mongodb.connection.AsyncConnection
+import com.mongodb.connection.ClusterId
+import com.mongodb.connection.Connection
 import com.mongodb.connection.ConnectionDescription
+import com.mongodb.connection.ConnectionId
+import com.mongodb.connection.ServerId
+import com.mongodb.connection.ServerVersion
+import com.mongodb.connection.SessionContext
 import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.BsonInt64
 import org.bson.BsonString
+import org.bson.BsonTimestamp
 import org.bson.Document
 import org.bson.codecs.DocumentCodec
 import org.junit.experimental.categories.Category
@@ -41,6 +54,8 @@ import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.connection.ServerType.STANDALONE
+import static com.mongodb.operation.ReadConcernHelper.appendReadConcernToCommand
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static java.util.concurrent.TimeUnit.SECONDS
 
@@ -349,6 +364,76 @@ class CountOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
+    def 'should add read concern to command'() {
+        given:
+        def binding = Stub(ReadBinding)
+        def source = Stub(ConnectionSource)
+        def connection = Mock(Connection)
+        binding.readPreference >> ReadPreference.primary()
+        binding.readConnectionSource >> source
+        binding.sessionContext >> sessionContext
+        source.connection >> connection
+        source.retain() >> source
+        def commandDocument = new BsonDocument('count', new BsonString(getCollectionName()))
+        appendReadConcernToCommand(ReadConcern.MAJORITY, sessionContext, commandDocument)
+
+        def operation = new CountOperation(getNamespace())
+                .readConcern(ReadConcern.MAJORITY)
+
+        when:
+        operation.execute(binding)
+
+        then:
+        _ * connection.description >> new ConnectionDescription(new ConnectionId(new ServerId(new ClusterId(), new ServerAddress())),
+                new ServerVersion(3, 6), STANDALONE, 1000, 100000, 100000, [])
+        1 * connection.command(_, commandDocument, _, _, _, sessionContext) >>
+                new BsonDocument('n', new BsonInt64(42))
+        1 * connection.release()
+
+        where:
+        sessionContext << [
+                Stub(SessionContext) {
+                    isCausallyConsistent() >> true
+                    getOperationTime() >> new BsonTimestamp(42, 0)
+                }
+        ]
+    }
+
+    def 'should add read concern to command asynchronously'() {
+        given:
+        def binding = Stub(AsyncReadBinding)
+        def source = Stub(AsyncConnectionSource)
+        def connection = Mock(AsyncConnection)
+        binding.readPreference >> ReadPreference.primary()
+        binding.getReadConnectionSource(_) >> { it[0].onResult(source, null) }
+        binding.sessionContext >> sessionContext
+        source.getConnection(_) >> { it[0].onResult(connection, null) }
+        source.retain() >> source
+        def commandDocument = new BsonDocument('count', new BsonString(getCollectionName()))
+        appendReadConcernToCommand(ReadConcern.MAJORITY, sessionContext, commandDocument)
+
+        def operation = new CountOperation(getNamespace())
+                .readConcern(ReadConcern.MAJORITY)
+
+        when:
+        executeAsync(operation, binding)
+
+        then:
+        _ * connection.description >> new ConnectionDescription(new ConnectionId(new ServerId(new ClusterId(), new ServerAddress())),
+                new ServerVersion(3, 6), STANDALONE, 1000, 100000, 100000, [])
+        1 * connection.commandAsync(_, commandDocument, _, _, _, sessionContext, _) >> {
+            it[6].onResult(new BsonDocument('n', new BsonInt64(42)), null)
+        }
+        1 * connection.release()
+
+        where:
+        sessionContext << [
+                Stub(SessionContext) {
+                    isCausallyConsistent() >> true
+                    getOperationTime() >> new BsonTimestamp(42, 0)
+                }
+        ]
+    }
     def helper = [
         dbName: 'db',
         namespace: new MongoNamespace('db', 'coll'),

--- a/driver-core/src/test/functional/com/mongodb/operation/DistinctOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/DistinctOperationSpecification.groovy
@@ -21,27 +21,45 @@ import com.mongodb.MongoNamespace
 import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.ReadConcern
 import com.mongodb.ReadPreference
+import com.mongodb.ServerAddress
+import com.mongodb.binding.AsyncConnectionSource
+import com.mongodb.binding.AsyncReadBinding
+import com.mongodb.binding.ConnectionSource
+import com.mongodb.binding.ReadBinding
 import com.mongodb.client.test.Worker
 import com.mongodb.client.test.WorkerCodec
+import com.mongodb.connection.AsyncConnection
+import com.mongodb.connection.ClusterId
+import com.mongodb.connection.Connection
+import com.mongodb.connection.ConnectionDescription
+import com.mongodb.connection.ConnectionId
+import com.mongodb.connection.ServerId
+import com.mongodb.connection.ServerVersion
+import com.mongodb.connection.SessionContext
 import org.bson.BsonBoolean
 import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.BsonInt64
 import org.bson.BsonInvalidOperationException
 import org.bson.BsonString
+import org.bson.BsonTimestamp
 import org.bson.Document
 import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.BsonValueCodecProvider
 import org.bson.codecs.Decoder
 import org.bson.codecs.DocumentCodec
 import org.bson.codecs.DocumentCodecProvider
+import org.bson.codecs.StringCodec
 import org.bson.codecs.ValueCodecProvider
 import org.bson.types.ObjectId
 import spock.lang.IgnoreIf
 
 import static com.mongodb.ClusterFixture.disableMaxTimeFailPoint
 import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint
+import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.connection.ServerType.STANDALONE
+import static com.mongodb.operation.ReadConcernHelper.appendReadConcernToCommand
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static java.util.concurrent.TimeUnit.SECONDS
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders
@@ -270,6 +288,80 @@ class DistinctOperationSpecification extends OperationFunctionalSpecification {
         where:
         async << [true, false]
     }
+
+    def 'should add read concern to command'() {
+        given:
+        def binding = Stub(ReadBinding)
+        def source = Stub(ConnectionSource)
+        def connection = Mock(Connection)
+        binding.readPreference >> ReadPreference.primary()
+        binding.readConnectionSource >> source
+        binding.sessionContext >> sessionContext
+        source.connection >> connection
+        source.retain() >> source
+        def commandDocument = new BsonDocument('distinct', new BsonString(getCollectionName()))
+                .append('key', new BsonString('str'))
+        appendReadConcernToCommand(ReadConcern.MAJORITY, sessionContext, commandDocument)
+
+        def operation = new DistinctOperation<String>(getNamespace(), 'str', new StringCodec())
+                .readConcern(ReadConcern.MAJORITY)
+
+        when:
+        operation.execute(binding)
+
+        then:
+        _ * connection.description >> new ConnectionDescription(new ConnectionId(new ServerId(new ClusterId(), new ServerAddress())),
+                new ServerVersion(3, 6), STANDALONE, 1000, 100000, 100000, [])
+        1 * connection.command(_, commandDocument, _, _, _, sessionContext) >>
+                new BsonDocument('values', new BsonArrayWrapper([]))
+        1 * connection.release()
+
+        where:
+        sessionContext << [
+                Stub(SessionContext) {
+                    isCausallyConsistent() >> true
+                    getOperationTime() >> new BsonTimestamp(42, 0)
+                }
+        ]
+    }
+
+    def 'should add read concern to command asynchronously'() {
+        given:
+        def binding = Stub(AsyncReadBinding)
+        def source = Stub(AsyncConnectionSource)
+        def connection = Mock(AsyncConnection)
+        binding.readPreference >> ReadPreference.primary()
+        binding.getReadConnectionSource(_) >> { it[0].onResult(source, null) }
+        binding.sessionContext >> sessionContext
+        source.getConnection(_) >> { it[0].onResult(connection, null) }
+        source.retain() >> source
+        def commandDocument = new BsonDocument('distinct', new BsonString(getCollectionName()))
+                .append('key', new BsonString('str'))
+        appendReadConcernToCommand(ReadConcern.MAJORITY, sessionContext, commandDocument)
+
+        def operation = new DistinctOperation<String>(getNamespace(), 'str', new StringCodec())
+                .readConcern(ReadConcern.MAJORITY)
+
+        when:
+        executeAsync(operation, binding)
+
+        then:
+        _ * connection.description >> new ConnectionDescription(new ConnectionId(new ServerId(new ClusterId(), new ServerAddress())),
+                new ServerVersion(3, 6), STANDALONE, 1000, 100000, 100000, [])
+        1 * connection.commandAsync(_, commandDocument, _, _, _, sessionContext, _) >> {
+            it[6].onResult(new BsonDocument('values', new BsonArrayWrapper([])), null)
+        }
+        1 * connection.release()
+
+        where:
+        sessionContext << [
+                Stub(SessionContext) {
+                    isCausallyConsistent() >> true
+                    getOperationTime() >> new BsonTimestamp(42, 0)
+                }
+        ]
+    }
+
 
     def helper = [
         dbName: 'db',

--- a/driver-core/src/test/functional/com/mongodb/operation/FindOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/FindOperationSpecification.groovy
@@ -26,10 +26,13 @@ import com.mongodb.ReadPreference
 import com.mongodb.ServerAddress
 import com.mongodb.async.FutureResultCallback
 import com.mongodb.binding.AsyncClusterBinding
+import com.mongodb.binding.AsyncConnectionSource
+import com.mongodb.binding.AsyncReadBinding
 import com.mongodb.binding.ClusterBinding
 import com.mongodb.binding.ConnectionSource
 import com.mongodb.binding.ReadBinding
 import com.mongodb.client.model.CreateCollectionOptions
+import com.mongodb.connection.AsyncConnection
 import com.mongodb.connection.ClusterId
 import com.mongodb.connection.Connection
 import com.mongodb.connection.ConnectionDescription
@@ -37,10 +40,13 @@ import com.mongodb.connection.ConnectionId
 import com.mongodb.connection.QueryResult
 import com.mongodb.connection.ServerId
 import com.mongodb.connection.ServerVersion
+import com.mongodb.connection.SessionContext
 import org.bson.BsonBoolean
 import org.bson.BsonDocument
 import org.bson.BsonInt32
+import org.bson.BsonInt64
 import org.bson.BsonString
+import org.bson.BsonTimestamp
 import org.bson.Document
 import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.DocumentCodec
@@ -60,6 +66,7 @@ import static com.mongodb.CursorType.Tailable
 import static com.mongodb.CursorType.TailableAwait
 import static com.mongodb.ExplainVerbosity.QUERY_PLANNER
 import static com.mongodb.connection.ServerType.STANDALONE
+import static com.mongodb.operation.ReadConcernHelper.appendReadConcernToCommand
 import static java.util.Arrays.asList
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static java.util.concurrent.TimeUnit.SECONDS
@@ -515,6 +522,81 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
 
         where:
         async << [true, false]
+    }
+
+    def 'should add read concern to command'() {
+        given:
+        def binding = Stub(ReadBinding)
+        def source = Stub(ConnectionSource)
+        def connection = Mock(Connection)
+        binding.readPreference >> ReadPreference.primary()
+        binding.readConnectionSource >> source
+        binding.sessionContext >> sessionContext
+        source.connection >> connection
+        source.retain() >> source
+        def commandDocument = new BsonDocument('find', new BsonString(getCollectionName()))
+        appendReadConcernToCommand(ReadConcern.MAJORITY, sessionContext, commandDocument)
+
+        def operation = new FindOperation<Document>(getNamespace(), new DocumentCodec())
+            .readConcern(ReadConcern.MAJORITY)
+
+        when:
+        operation.execute(binding)
+
+        then:
+        _ * connection.description >> new ConnectionDescription(new ConnectionId(new ServerId(new ClusterId(), new ServerAddress())),
+                new ServerVersion(3, 6), STANDALONE, 1000, 100000, 100000, [])
+        1 * connection.command(_, commandDocument, _, _, _, sessionContext) >>
+                new BsonDocument('cursor', new BsonDocument('id', new BsonInt64(1))
+                        .append('ns', new BsonString(getNamespace().getFullName()))
+                        .append('firstBatch', new BsonArrayWrapper([])))
+        1 * connection.release()
+
+        where:
+        sessionContext << [
+                Stub(SessionContext) {
+                    isCausallyConsistent() >> true
+                    getOperationTime() >> new BsonTimestamp(42, 0)
+                }
+        ]
+    }
+
+    def 'should add read concern to command asynchronously'() {
+        given:
+        def binding = Stub(AsyncReadBinding)
+        def source = Stub(AsyncConnectionSource)
+        def connection = Mock(AsyncConnection)
+        binding.readPreference >> ReadPreference.primary()
+        binding.getReadConnectionSource(_) >> { it[0].onResult(source, null) }
+        binding.sessionContext >> sessionContext
+        source.getConnection(_) >> { it[0].onResult(connection, null) }
+        source.retain() >> source
+        def commandDocument = new BsonDocument('find', new BsonString(getCollectionName()))
+        appendReadConcernToCommand(ReadConcern.MAJORITY, sessionContext, commandDocument)
+
+        def operation = new FindOperation<Document>(getNamespace(), new DocumentCodec())
+                .readConcern(ReadConcern.MAJORITY)
+
+        when:
+        executeAsync(operation, binding)
+
+        then:
+        _ * connection.description >> new ConnectionDescription(new ConnectionId(new ServerId(new ClusterId(), new ServerAddress())),
+                new ServerVersion(3, 6), STANDALONE, 1000, 100000, 100000, [])
+        1 * connection.commandAsync(_, commandDocument, _, _, _, sessionContext, _) >> {
+            it[6].onResult(new BsonDocument('cursor', new BsonDocument('id', new BsonInt64(1))
+                    .append('ns', new BsonString(getNamespace().getFullName()))
+                    .append('firstBatch', new BsonArrayWrapper([]))), null)
+        }
+        1 * connection.release()
+
+        where:
+        sessionContext << [
+                Stub(SessionContext) {
+                    isCausallyConsistent() >> true
+                    getOperationTime() >> new BsonTimestamp(42, 0)
+                }
+        ]
     }
 
     def 'should call query on Connection with no $query when there are no other meta operators'() {

--- a/driver-core/src/test/functional/com/mongodb/operation/MapReduceWithInlineResultsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/MapReduceWithInlineResultsOperationSpecification.groovy
@@ -20,7 +20,20 @@ import com.mongodb.MongoNamespace
 import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.ReadConcern
 import com.mongodb.ReadPreference
+import com.mongodb.ServerAddress
+import com.mongodb.binding.AsyncConnectionSource
+import com.mongodb.binding.AsyncReadBinding
+import com.mongodb.binding.ConnectionSource
+import com.mongodb.binding.ReadBinding
 import com.mongodb.client.test.CollectionHelper
+import com.mongodb.connection.AsyncConnection
+import com.mongodb.connection.ClusterId
+import com.mongodb.connection.Connection
+import com.mongodb.connection.ConnectionDescription
+import com.mongodb.connection.ConnectionId
+import com.mongodb.connection.ServerId
+import com.mongodb.connection.ServerVersion
+import com.mongodb.connection.SessionContext
 import org.bson.BsonBoolean
 import org.bson.BsonDocument
 import org.bson.BsonInt32
@@ -28,11 +41,15 @@ import org.bson.BsonInt64
 import org.bson.BsonJavaScript
 import org.bson.BsonNull
 import org.bson.BsonString
+import org.bson.BsonTimestamp
 import org.bson.Document
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
 
+import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
+import static com.mongodb.connection.ServerType.STANDALONE
+import static com.mongodb.operation.ReadConcernHelper.appendReadConcernToCommand
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
 class MapReduceWithInlineResultsOperationSpecification extends OperationFunctionalSpecification {
@@ -246,6 +263,110 @@ class MapReduceWithInlineResultsOperationSpecification extends OperationFunction
 
         where:
         async << [true, false]
+    }
+
+    def 'should add read concern to command'() {
+        given:
+        def binding = Stub(ReadBinding)
+        def source = Stub(ConnectionSource)
+        def connection = Mock(Connection)
+        binding.readPreference >> ReadPreference.primary()
+        binding.readConnectionSource >> source
+        binding.sessionContext >> sessionContext
+        source.connection >> connection
+        source.retain() >> source
+        def commandDocument = BsonDocument.parse('''
+            { "mapreduce" : "coll",
+              "map" : { "$code" : "function(){ }" },
+              "reduce" : { "$code" : "function(key, values){ }" },
+              "out" : { "inline" : 1 },
+              "query" : null,
+              "sort" : null,
+              "finalize" : null,
+              "scope" : null,
+              "verbose" : false,
+              }''')
+        appendReadConcernToCommand(ReadConcern.MAJORITY, sessionContext, commandDocument)
+
+        def operation = new MapReduceWithInlineResultsOperation<Document>(helper.namespace, new BsonJavaScript('function(){ }'),
+                new BsonJavaScript('function(key, values){ }'), documentCodec)
+                .readConcern(ReadConcern.MAJORITY)
+
+        when:
+        operation.execute(binding)
+
+        then:
+        _ * connection.description >> new ConnectionDescription(new ConnectionId(new ServerId(new ClusterId(), new ServerAddress())),
+                new ServerVersion(3, 6), STANDALONE, 1000, 100000, 100000, [])
+        1 * connection.command(_, commandDocument, _, _, _, sessionContext) >>
+                new BsonDocument('results', new BsonArrayWrapper([]))
+                        .append('counts',
+                        new BsonDocument('input', new BsonInt32(0))
+                                .append('output', new BsonInt32(0))
+                                .append('emit', new BsonInt32(0)))
+                        .append('timeMillis', new BsonInt32(0))
+        1 * connection.release()
+
+        where:
+        sessionContext << [
+                Stub(SessionContext) {
+                    isCausallyConsistent() >> true
+                    getOperationTime() >> new BsonTimestamp(42, 0)
+                }
+        ]
+    }
+
+    def 'should add read concern to command asynchronously'() {
+        given:
+        def binding = Stub(AsyncReadBinding)
+        def source = Stub(AsyncConnectionSource)
+        def connection = Mock(AsyncConnection)
+        binding.readPreference >> ReadPreference.primary()
+        binding.getReadConnectionSource(_) >> { it[0].onResult(source, null) }
+        binding.sessionContext >> sessionContext
+        source.getConnection(_) >> { it[0].onResult(connection, null) }
+        source.retain() >> source
+        def commandDocument = BsonDocument.parse('''
+            { "mapreduce" : "coll",
+              "map" : { "$code" : "function(){ }" },
+              "reduce" : { "$code" : "function(key, values){ }" },
+              "out" : { "inline" : 1 },
+              "query" : null,
+              "sort" : null,
+              "finalize" : null,
+              "scope" : null,
+              "verbose" : false,
+              }''')
+        appendReadConcernToCommand(ReadConcern.MAJORITY, sessionContext, commandDocument)
+
+        def operation = new MapReduceWithInlineResultsOperation<Document>(helper.namespace, new BsonJavaScript('function(){ }'),
+                new BsonJavaScript('function(key, values){ }'), documentCodec)
+                .readConcern(ReadConcern.MAJORITY)
+
+        when:
+        executeAsync(operation, binding)
+
+        then:
+        _ * connection.description >> new ConnectionDescription(new ConnectionId(new ServerId(new ClusterId(), new ServerAddress())),
+                new ServerVersion(3, 6), STANDALONE, 1000, 100000, 100000, [])
+        1 * connection.commandAsync(_, commandDocument, _, _, _, sessionContext, _) >> {
+            it[6].onResult(new BsonDocument('results', new BsonArrayWrapper([]))
+                    .append('counts',
+                    new BsonDocument('input', new BsonInt32(0))
+                            .append('output', new BsonInt32(0))
+                            .append('emit', new BsonInt32(0)))
+                    .append('timeMillis', new BsonInt32(0)),
+                    null)
+        }
+        1 * connection.release()
+
+        where:
+        sessionContext << [
+                Stub(SessionContext) {
+                    isCausallyConsistent() >> true
+                    getOperationTime() >> new BsonTimestamp(42, 0)
+                }
+        ]
     }
 
     def helper = [

--- a/driver-core/src/test/functional/com/mongodb/operation/ParallelCollectionScanOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ParallelCollectionScanOperationSpecification.groovy
@@ -23,19 +23,26 @@ import com.mongodb.MongoNamespace
 import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.ReadConcern
 import com.mongodb.ReadPreference
+import com.mongodb.ServerAddress
 import com.mongodb.async.SingleResultCallback
 import com.mongodb.binding.AsyncConnectionSource
 import com.mongodb.binding.AsyncReadBinding
 import com.mongodb.binding.ConnectionSource
 import com.mongodb.binding.ReadBinding
 import com.mongodb.connection.AsyncConnection
+import com.mongodb.connection.ClusterId
 import com.mongodb.connection.Connection
 import com.mongodb.connection.ConnectionDescription
+import com.mongodb.connection.ConnectionId
+import com.mongodb.connection.ServerId
 import com.mongodb.connection.ServerVersion
+import com.mongodb.connection.SessionContext
+import org.bson.BsonArray
 import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.BsonJavaScript
 import org.bson.BsonString
+import org.bson.BsonTimestamp
 import org.bson.Document
 import org.bson.codecs.Decoder
 import org.bson.codecs.DocumentCodec
@@ -48,6 +55,8 @@ import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.ClusterFixture.loopCursor
+import static com.mongodb.connection.ServerType.STANDALONE
+import static com.mongodb.operation.ReadConcernHelper.appendReadConcernToCommand
 import static org.junit.Assert.assertTrue
 
 @IgnoreIf({ isSharded() })
@@ -290,6 +299,79 @@ class ParallelCollectionScanOperationSpecification extends OperationFunctionalSp
 
         where:
         readConcern << [ReadConcern.MAJORITY, ReadConcern.LOCAL]
+    }
+
+    def 'should add read concern to command'() {
+        given:
+        def binding = Stub(ReadBinding)
+        def source = Stub(ConnectionSource)
+        def connection = Mock(Connection)
+        binding.readPreference >> ReadPreference.primary()
+        binding.readConnectionSource >> source
+        binding.sessionContext >> sessionContext
+        source.connection >> connection
+        source.retain() >> source
+        def commandDocument = new BsonDocument('parallelCollectionScan', new BsonString(getCollectionName()))
+            .append('numCursors', new BsonInt32(1))
+        appendReadConcernToCommand(ReadConcern.MAJORITY, sessionContext, commandDocument)
+
+        def operation = new ParallelCollectionScanOperation<Document>(getNamespace(), 1, new DocumentCodec())
+                .readConcern(ReadConcern.MAJORITY)
+
+        when:
+        operation.execute(binding)
+
+        then:
+        _ * connection.description >> new ConnectionDescription(new ConnectionId(new ServerId(new ClusterId(), new ServerAddress())),
+                new ServerVersion(3, 6), STANDALONE, 1000, 100000, 100000, [])
+        1 * connection.command(_, commandDocument, _, _, _, sessionContext) >>
+                new BsonDocument('cursors', new BsonArray())
+        1 * connection.release()
+
+        where:
+        sessionContext << [
+                Stub(SessionContext) {
+                    isCausallyConsistent() >> true
+                    getOperationTime() >> new BsonTimestamp(42, 0)
+                }
+        ]
+    }
+
+    def 'should add read concern to command asynchronously'() {
+        given:
+        def binding = Stub(AsyncReadBinding)
+        def source = Stub(AsyncConnectionSource)
+        def connection = Mock(AsyncConnection)
+        binding.readPreference >> ReadPreference.primary()
+        binding.getReadConnectionSource(_) >> { it[0].onResult(source, null) }
+        binding.sessionContext >> sessionContext
+        source.getConnection(_) >> { it[0].onResult(connection, null) }
+        source.retain() >> source
+        def commandDocument = new BsonDocument('parallelCollectionScan', new BsonString(getCollectionName()))
+                .append('numCursors', new BsonInt32(1))
+        appendReadConcernToCommand(ReadConcern.MAJORITY, sessionContext, commandDocument)
+
+        def operation = new ParallelCollectionScanOperation<Document>(getNamespace(), 1, new DocumentCodec())
+                .readConcern(ReadConcern.MAJORITY)
+
+        when:
+        executeAsync(operation, binding)
+
+        then:
+        _ * connection.description >> new ConnectionDescription(new ConnectionId(new ServerId(new ClusterId(), new ServerAddress())),
+                new ServerVersion(3, 6), STANDALONE, 1000, 100000, 100000, [])
+        1 * connection.commandAsync(_, commandDocument, _, _, _, sessionContext, _) >> {
+            it[6].onResult(new BsonDocument('cursors', new BsonArray()), null)
+        }
+        1 * connection.release()
+
+        where:
+        sessionContext << [
+                Stub(SessionContext) {
+                    isCausallyConsistent() >> true
+                    getOperationTime() >> new BsonTimestamp(42, 0)
+                }
+        ]
     }
 
     def helper = [

--- a/driver-core/src/test/functional/com/mongodb/operation/ReadConcernHelperSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ReadConcernHelperSpecification.groovy
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.operation
+
+import com.mongodb.ReadConcern
+import com.mongodb.connection.SessionContext
+import org.bson.BsonDocument
+import org.bson.BsonString
+import org.bson.BsonTimestamp
+import spock.lang.Specification
+
+import static com.mongodb.operation.ReadConcernHelper.appendReadConcernToCommand
+
+class ReadConcernHelperSpecification extends Specification {
+
+    def 'should throw IllegalArgumentException if command document is null'() {
+        when:
+        appendReadConcernToCommand(ReadConcern.MAJORITY, Stub(SessionContext), null)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def 'should throw IllegalArgumentException if read concern is null'() {
+        def commandDocument = new BsonDocument()
+
+        when:
+        appendReadConcernToCommand(null, Stub(SessionContext), commandDocument)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def 'should throw IllegalArgumentException if session context is null'() {
+        when:
+        appendReadConcernToCommand(ReadConcern.MAJORITY, null, new BsonDocument())
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def 'should add afterClusterTime to majority read concern when session is causally consistent'() {
+        given:
+        def operationTime = new BsonTimestamp(42, 1)
+        def sessionContext = Stub(SessionContext) {
+            isCausallyConsistent() >> true
+            getOperationTime() >> operationTime
+        }
+        def commandDocument = new BsonDocument()
+
+        when:
+        appendReadConcernToCommand(ReadConcern.MAJORITY, sessionContext, commandDocument)
+
+        then:
+        commandDocument == new BsonDocument('readConcern',
+                new BsonDocument('level', new BsonString('majority')).append('afterClusterTime', operationTime))
+    }
+
+    def 'should add afterClusterTime and local level to default read concern when session is causally consistent'() {
+        given:
+        def operationTime = new BsonTimestamp(42, 1)
+        def sessionContext = Stub(SessionContext) {
+            isCausallyConsistent() >> true
+            getOperationTime() >> operationTime
+        }
+        def commandDocument = new BsonDocument()
+
+        when:
+        appendReadConcernToCommand(ReadConcern.DEFAULT, sessionContext, commandDocument)
+
+        then:
+        commandDocument == new BsonDocument('readConcern',
+                new BsonDocument(new BsonDocument('level', new BsonString('local')))
+                        .append('afterClusterTime', operationTime))
+    }
+
+    def 'should not add afterClusterTime to ReadConcern when session is not causally consistent'() {
+        given:
+        def sessionContext = Stub(SessionContext) {
+            isCausallyConsistent() >> false
+            getOperationTime() >> { throw new UnsupportedOperationException() }
+        }
+        def commandDocument = new BsonDocument()
+
+        when:
+        appendReadConcernToCommand(ReadConcern.MAJORITY, sessionContext, commandDocument)
+
+        then:
+        commandDocument == new BsonDocument('readConcern',
+                new BsonDocument('level', new BsonString('majority')))
+    }
+
+    def 'should not add the default read concern to the command document'() {
+        def sessionContext = Stub(SessionContext) {
+            isCausallyConsistent() >> false
+            getOperationTime() >> { throw new UnsupportedOperationException() }
+        }
+        def commandDocument = new BsonDocument()
+
+        when:
+        appendReadConcernToCommand(ReadConcern.DEFAULT, sessionContext, commandDocument)
+
+        then:
+        commandDocument == new BsonDocument()
+    }
+
+    def 'should not add afterClusterTime to ReadConcern when operation time is null'() {
+        given:
+        def sessionContext = Stub(SessionContext) {
+            isCausallyConsistent() >> true
+            getOperationTime() >> null
+        }
+        def commandDocument = new BsonDocument()
+
+        when:
+        appendReadConcernToCommand(ReadConcern.MAJORITY, sessionContext, commandDocument)
+
+        then:
+        commandDocument == new BsonDocument('readConcern',
+                new BsonDocument('level', new BsonString('majority')))
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/ReadConcernSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/ReadConcernSpecification.groovy
@@ -23,14 +23,15 @@ class ReadConcernSpecification extends Specification {
 
     def 'should have the expected read concern levels'() {
         expect:
-        staticValue == expected
+        staticValue == expectedReadConcern
+        staticValue.getLevel() == expectedLevel
 
         where:
-        staticValue              | expected
-        ReadConcern.DEFAULT      | new ReadConcern()
-        ReadConcern.LOCAL        | new ReadConcern(ReadConcernLevel.LOCAL)
-        ReadConcern.MAJORITY     | new ReadConcern(ReadConcernLevel.MAJORITY)
-        ReadConcern.LINEARIZABLE | new ReadConcern(ReadConcernLevel.LINEARIZABLE)
+        staticValue              | expectedLevel                 | expectedReadConcern
+        ReadConcern.DEFAULT      | null                          | new ReadConcern()
+        ReadConcern.LOCAL        | ReadConcernLevel.LOCAL        | new ReadConcern(ReadConcernLevel.LOCAL)
+        ReadConcern.MAJORITY     | ReadConcernLevel.MAJORITY     | new ReadConcern(ReadConcernLevel.MAJORITY)
+        ReadConcern.LINEARIZABLE | ReadConcernLevel.LINEARIZABLE | new ReadConcern(ReadConcernLevel.LINEARIZABLE)
     }
 
     def 'should create the expected Documents'() {

--- a/driver-core/src/test/unit/com/mongodb/connection/TestSessionContext.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/TestSessionContext.java
@@ -44,6 +44,11 @@ class TestSessionContext implements SessionContext {
     }
 
     @Override
+    public boolean isCausallyConsistent() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public long advanceTransactionNumber() {
         throw new UnsupportedOperationException();
     }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/NoOpSessionContextSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/NoOpSessionContextSpecification.groovy
@@ -29,6 +29,8 @@ class NoOpSessionContextSpecification extends Specification {
         expect:
         !sessionContext.hasSession()
         sessionContext.getClusterTime() == null
+        sessionContext.getOperationTime() == null
+        !sessionContext.isCausallyConsistent()
 
         when:
         sessionContext.advanceOperationTime(new BsonTimestamp(42, 1))

--- a/driver/src/main/com/mongodb/ClientSessionContext.java
+++ b/driver/src/main/com/mongodb/ClientSessionContext.java
@@ -46,8 +46,18 @@ class ClientSessionContext implements SessionContext {
     }
 
     @Override
+    public boolean isCausallyConsistent() {
+        return clientSession.isCausallyConsistent();
+    }
+
+    @Override
     public long advanceTransactionNumber() {
         return clientSession.getServerSession().advanceTransactionNumber();
+    }
+
+    @Override
+    public BsonTimestamp getOperationTime() {
+        return clientSession.getOperationTime();
     }
 
     @Override

--- a/driver/src/main/com/mongodb/ClientSessionOptions.java
+++ b/driver/src/main/com/mongodb/ClientSessionOptions.java
@@ -41,7 +41,7 @@ public final class ClientSessionOptions {
      * Whether operations using the session should causally consistent with each other.
      *
      * @return whether operations using the session should be causally consistent.  A null value indicates to use the the global default,
-     * which is currently false.
+     * which is currently true.
      */
     public Boolean isCausallyConsistent() {
         return causallyConsistent;

--- a/driver/src/main/com/mongodb/MongoCollectionImpl.java
+++ b/driver/src/main/com/mongodb/MongoCollectionImpl.java
@@ -200,7 +200,8 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
                                            .skip(options.getSkip())
                                            .limit(options.getLimit())
                                            .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
-                                           .collation(options.getCollation());
+                                           .collation(options.getCollation())
+                                           .readConcern(readConcern);
         if (options.getHint() != null) {
             operation.hint(toBsonDocument(options.getHint()));
         } else if (options.getHintString() != null) {

--- a/driver/src/test/unit/com/mongodb/AggregateIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/AggregateIterableSpecification.groovy
@@ -43,7 +43,7 @@ class AggregateIterableSpecification extends Specification {
     def namespace = new MongoNamespace('db', 'coll')
     def codecRegistry = fromProviders([new ValueCodecProvider(), new DocumentCodecProvider(), new BsonValueCodecProvider()])
     def readPreference = secondary()
-    def readConcern = ReadConcern.DEFAULT
+    def readConcern = ReadConcern.MAJORITY
     def writeConcern = WriteConcern.MAJORITY
     def collation = Collation.builder().locale('en').build()
 
@@ -62,7 +62,8 @@ class AggregateIterableSpecification extends Specification {
 
         then:
         expect operation, isTheSameAs(new AggregateOperation<Document>(namespace,
-                [new BsonDocument('$match', new BsonInt32(1))], new DocumentCodec()));
+                [new BsonDocument('$match', new BsonInt32(1))], new DocumentCodec())
+                .readConcern(readConcern));
         readPreference == secondary()
 
         when: 'overriding initial options'
@@ -81,6 +82,7 @@ class AggregateIterableSpecification extends Specification {
                 .collation(collation)
                 .maxAwaitTime(99, MILLISECONDS)
                 .maxTime(999, MILLISECONDS)
+                .readConcern(readConcern)
                 .useCursor(true))
     }
 

--- a/driver/src/test/unit/com/mongodb/ChangeStreamIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/ChangeStreamIterableSpecification.groovy
@@ -43,7 +43,7 @@ class ChangeStreamIterableSpecification extends Specification {
     def namespace = new MongoNamespace('db', 'coll')
     def codecRegistry = fromProviders([new ValueCodecProvider(), new DocumentCodecProvider(), new BsonValueCodecProvider()])
     def readPreference = secondary()
-    def readConcern = ReadConcern.DEFAULT
+    def readConcern = ReadConcern.MAJORITY
     def writeConcern = WriteConcern.MAJORITY
     def collation = Collation.builder().locale('en').build()
 
@@ -63,7 +63,8 @@ class ChangeStreamIterableSpecification extends Specification {
 
         then:
         expect operation, isTheSameAs(new ChangeStreamOperation<Document>(namespace, FullDocument.DEFAULT,
-                [BsonDocument.parse('{$match: 1}')], codec))
+                [BsonDocument.parse('{$match: 1}')], codec)
+                .readConcern(readConcern))
         readPreference == secondary()
 
         when: 'overriding initial options'
@@ -77,7 +78,8 @@ class ChangeStreamIterableSpecification extends Specification {
         expect operation, isTheSameAs(new ChangeStreamOperation<Document>(namespace, FullDocument.UPDATE_LOOKUP,
                 [BsonDocument.parse('{$match: 1}')], codec)
                 .collation(collation).maxAwaitTime(99, MILLISECONDS)
-                .resumeAfter(resumeToken))
+                .resumeAfter(resumeToken)
+                .readConcern(readConcern))
     }
 
     def 'should use ClientSession'() {

--- a/driver/src/test/unit/com/mongodb/ClientSessionContextSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/ClientSessionContextSpecification.groovy
@@ -57,10 +57,22 @@ class ClientSessionContextSpecification extends Specification {
         }
 
         when:
+        context.isCausallyConsistent()
+
+        then:
+        1 * clientSession.isCausallyConsistent()
+
+        when:
         context.advanceClusterTime(expectedClusterTime)
 
         then:
         1 * clientSession.advanceClusterTime(expectedClusterTime)
+
+        when:
+        context.getOperationTime()
+
+        then:
+        1 * clientSession.getOperationTime()
 
         when:
         context.advanceOperationTime(expectedOperationTime)

--- a/driver/src/test/unit/com/mongodb/DistinctIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/DistinctIterableSpecification.groovy
@@ -40,7 +40,7 @@ class DistinctIterableSpecification extends Specification {
     def namespace = new MongoNamespace('db', 'coll')
     def codecRegistry = fromProviders([new ValueCodecProvider(), new DocumentCodecProvider(), new BsonValueCodecProvider()])
     def readPreference = secondary()
-    def readConcern = ReadConcern.DEFAULT
+    def readConcern = ReadConcern.MAJORITY
     def collation = Collation.builder().locale('en').build()
 
     def 'should build the expected DistinctOperation'() {
@@ -57,7 +57,8 @@ class DistinctIterableSpecification extends Specification {
 
         then:
         expect operation, isTheSameAs(new DistinctOperation<Document>(namespace, 'field', new DocumentCodec())
-                .filter(new BsonDocument()));
+                .filter(new BsonDocument())
+                .readConcern(readConcern))
         readPreference == secondary()
 
         when: 'overriding initial options'
@@ -67,7 +68,9 @@ class DistinctIterableSpecification extends Specification {
 
         then: 'should use the overrides'
         expect operation, isTheSameAs(new DistinctOperation<Document>(namespace, 'field', new DocumentCodec())
-                .filter(new BsonDocument('field', new BsonInt32(1))).maxTime(999, MILLISECONDS).collation(collation))
+                .filter(new BsonDocument('field', new BsonInt32(1)))
+                .maxTime(999, MILLISECONDS).collation(collation)
+                .readConcern(readConcern))
     }
 
     def 'should use ClientSession'() {

--- a/driver/src/test/unit/com/mongodb/FindIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/FindIterableSpecification.groovy
@@ -41,7 +41,7 @@ class FindIterableSpecification extends Specification {
     def codecRegistry = fromProviders([new ValueCodecProvider(),  new DocumentCodecProvider(),
                                        new DBObjectCodecProvider(), new BsonValueCodecProvider()])
     def readPreference = secondary()
-    def readConcern = ReadConcern.DEFAULT
+    def readConcern = ReadConcern.MAJORITY
     def namespace = new MongoNamespace('db', 'coll')
     def collation = Collation.builder().locale('en').build()
 
@@ -97,6 +97,7 @@ class FindIterableSpecification extends Specification {
                 .min(new BsonDocument('min', new BsonInt32(1)))
                 .max(new BsonDocument('max', new BsonInt32(1)))
                 .maxScan(42L)
+                .readConcern(readConcern)
                 .returnKey(false)
                 .showRecordId(false)
                 .snapshot(false)
@@ -152,6 +153,7 @@ class FindIterableSpecification extends Specification {
                 .min(new BsonDocument('min', new BsonInt32(2)))
                 .max(new BsonDocument('max', new BsonInt32(2)))
                 .maxScan(88L)
+                .readConcern(readConcern)
                 .returnKey(true)
                 .showRecordId(true)
                 .snapshot(true)
@@ -204,6 +206,7 @@ class FindIterableSpecification extends Specification {
                 .sort(new BsonDocument('sort', new BsonInt32(1)))
                 .modifiers(new BsonDocument('modifier', new BsonInt32(1)))
                 .cursorType(CursorType.NonTailable)
+                .readConcern(readConcern)
                 .slaveOk(true)
         )
     }

--- a/driver/src/test/unit/com/mongodb/MapReduceIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/MapReduceIterableSpecification.groovy
@@ -44,7 +44,7 @@ class MapReduceIterableSpecification extends Specification {
     def namespace = new MongoNamespace('db', 'coll')
     def codecRegistry = fromProviders([new ValueCodecProvider(), new DocumentCodecProvider(), new BsonValueCodecProvider()])
     def readPreference = secondary()
-    def readConcern = ReadConcern.DEFAULT
+    def readConcern = ReadConcern.MAJORITY
     def writeConcern = WriteConcern.MAJORITY
     def collation = Collation.builder().locale('en').build()
 
@@ -62,7 +62,9 @@ class MapReduceIterableSpecification extends Specification {
 
         then:
         expect operation, isTheSameAs(new MapReduceWithInlineResultsOperation<Document>(namespace, new BsonJavaScript('map'),
-                new BsonJavaScript('reduce'), new DocumentCodec()).verbose(true));
+                new BsonJavaScript('reduce'), new DocumentCodec())
+                .verbose(true)
+                .readConcern(readConcern))
         readPreference == secondary()
 
         when: 'overriding initial options'
@@ -89,6 +91,7 @@ class MapReduceIterableSpecification extends Specification {
                 .sort(new BsonDocument('sort', new BsonInt32(1)))
                 .verbose(false)
                 .collation(collation)
+                .readConcern(readConcern)
         )
     }
 
@@ -214,6 +217,7 @@ class MapReduceIterableSpecification extends Specification {
         where:
         clientSession << [null, Stub(ClientSession)]
     }
+
 
     def 'should handle exceptions correctly'() {
         given:

--- a/driver/src/test/unit/com/mongodb/MongoCollectionSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/MongoCollectionSpecification.groovy
@@ -71,6 +71,7 @@ import java.util.concurrent.TimeUnit
 import static com.mongodb.CustomMatchers.isTheSameAs
 import static com.mongodb.ReadPreference.primary
 import static com.mongodb.ReadPreference.secondary
+import static com.mongodb.TestHelper.execute
 import static com.mongodb.WriteConcern.ACKNOWLEDGED
 import static com.mongodb.WriteConcern.UNACKNOWLEDGED
 import static com.mongodb.bulk.BulkWriteResult.acknowledged
@@ -82,7 +83,6 @@ import static com.mongodb.bulk.WriteRequest.Type.UPDATE
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders
 import static org.bson.codecs.configuration.CodecRegistries.fromRegistries
-import static com.mongodb.TestHelper.execute
 import static spock.util.matcher.HamcrestSupport.expect
 
 @SuppressWarnings('ClassSize')
@@ -91,7 +91,7 @@ class MongoCollectionSpecification extends Specification {
     def namespace = new MongoNamespace('databaseName', 'collectionName')
     def codecRegistry = MongoClient.getDefaultCodecRegistry()
     def readPreference = secondary()
-    def readConcern = ReadConcern.DEFAULT
+    def readConcern = ReadConcern.MAJORITY
     def collation = Collation.builder().locale('en').build()
 
     def 'should return the correct name from getName'() {
@@ -183,7 +183,10 @@ class MongoCollectionSpecification extends Specification {
         def executor = new TestOperationExecutor([1L, 2L, 3L])
         def filter = new BsonDocument()
         def collection = new MongoCollectionImpl(namespace, Document, codecRegistry, readPreference, ACKNOWLEDGED, readConcern, executor)
-        def expectedOperation = new CountOperation(namespace).filter(filter)
+        def expectedOperation = new CountOperation(namespace)
+                .filter(filter)
+                .readConcern(readConcern)
+
         def countMethod = collection.&count
 
         when:


### PR DESCRIPTION
Support causal consistency by appending afterClusterTime to the readConcern document.

Lots of files touched but it's mostly bookkeeping.  Three main changes necessary:

* Add causallyConsistent and operationTime properties to SessionContext
* Use those properties in the new ReadConcernHelper class
* Make use of the ReadConcernHelper everywhere that ReadConcern is currently appended to a command.



Patch build: https://evergreen.mongodb.com/version/59d28d45e3c331361000048e