### PR TITLE
JAVA-2617: Add Filters methods for $expr and $jsonSchema

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/Filters.java
+++ b/driver-core/src/main/com/mongodb/client/model/Filters.java
@@ -469,6 +469,20 @@ public final class Filters {
     }
 
     /**
+     * Creates a filter that matches all documents that validate against the given JSON schema document.
+     *
+     * @param expression the aggregation expression
+     * @param <TExpression> the expression type
+     * @return the filter
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual reference/operator/query/expr/ $expr
+     */
+    public static <TExpression> Bson expr(final TExpression expression) {
+        return new SimpleEncodingFilter<TExpression>("$expr", expression);
+    }
+
+    /**
      * Creates a filter that matches all documents where the value of a field is an array that contains all the specified values.
      *
      * @param fieldName the field name
@@ -826,6 +840,19 @@ public final class Filters {
     public static Bson nearSphere(final String fieldName, final double x, final double y, final Double maxDistance,
                                   final Double minDistance) {
         return createNearFilterDocument(fieldName, x, y, maxDistance, minDistance, "$nearSphere");
+    }
+
+    /**
+     * Creates a filter that matches all documents that validate against the given JSON schema document.
+     *
+     * @param schema the JSON schema to validate against
+     * @return the filter
+     * @since 3.6
+     * @mongodb.server.release 3.6
+     * @mongodb.driver.manual reference/operator/query/jsonSchema/ $jsonSchema
+     */
+    public static Bson jsonSchema(final Bson schema) {
+        return new SimpleEncodingFilter<Bson>("$jsonSchema", schema);
     }
 
     private static Bson createNearFilterDocument(final String fieldName, final double x, final double y, final Double maxDistance,

--- a/driver-core/src/test/functional/com/mongodb/client/model/FiltersFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/FiltersFunctionalSpecification.groovy
@@ -35,8 +35,10 @@ import static com.mongodb.client.model.Filters.bitsAnySet
 import static com.mongodb.client.model.Filters.elemMatch
 import static com.mongodb.client.model.Filters.eq
 import static com.mongodb.client.model.Filters.exists
+import static com.mongodb.client.model.Filters.expr
 import static com.mongodb.client.model.Filters.gt
 import static com.mongodb.client.model.Filters.gte
+import static com.mongodb.client.model.Filters.jsonSchema
 import static com.mongodb.client.model.Filters.lt
 import static com.mongodb.client.model.Filters.lte
 import static com.mongodb.client.model.Filters.mod
@@ -295,5 +297,18 @@ class FiltersFunctionalSpecification extends OperationFunctionalSpecification {
     def 'should render $where'() {
         expect:
         find(where('Array.isArray(this.a)')) == [a, b]
+    }
+
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    def '$expr'() {
+        expect:
+        find(expr(Document.parse('{ $eq: [ "$x" , 3 ] } '))) == [c]
+    }
+
+
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    def '$jsonSchema'() {
+        expect:
+        find(jsonSchema(Document.parse('{ bsonType : "object", properties: { x : {type : "number", minimum : 2} } } '))) == [b, c]
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/client/model/FiltersSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/FiltersSpecification.groovy
@@ -24,6 +24,7 @@ import org.bson.BsonArray
 import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.BsonInt64
+import org.bson.BsonString
 import org.bson.BsonType
 import org.bson.Document
 import org.bson.codecs.BsonValueCodecProvider
@@ -45,6 +46,7 @@ import static com.mongodb.client.model.Filters.bitsAnyClear
 import static com.mongodb.client.model.Filters.bitsAnySet
 import static com.mongodb.client.model.Filters.elemMatch
 import static com.mongodb.client.model.Filters.eq
+import static com.mongodb.client.model.Filters.expr
 import static com.mongodb.client.model.Filters.geoIntersects
 import static com.mongodb.client.model.Filters.geoWithin
 import static com.mongodb.client.model.Filters.geoWithinBox
@@ -53,6 +55,7 @@ import static com.mongodb.client.model.Filters.geoWithinCenterSphere
 import static com.mongodb.client.model.Filters.geoWithinPolygon
 import static com.mongodb.client.model.Filters.gt
 import static com.mongodb.client.model.Filters.gte
+import static com.mongodb.client.model.Filters.jsonSchema
 import static com.mongodb.client.model.Filters.lt
 import static com.mongodb.client.model.Filters.lte
 import static com.mongodb.client.model.Filters.mod
@@ -273,6 +276,12 @@ class FiltersSpecification extends Specification {
     def 'should render $where'() {
         expect:
         toBson(where('this.credits == this.debits')) == parse('{$where: "this.credits == this.debits"}')
+    }
+
+    def 'should render $expr'() {
+        expect:
+        toBson(expr(new BsonDocument('$gt', new BsonArray([new BsonString('$spent'), new BsonString('$budget')])))) ==
+                parse('{$expr: { $gt: [ "$spent" , "$budget" ] } }')
     }
 
     def 'should render $geoWithin'() {
@@ -612,6 +621,15 @@ class FiltersSpecification extends Specification {
                                                                                          $minDistance: 1000.0,
                                                                                          }
                                                                                       }
+                                                                                    }''')
+    }
+
+    def 'should render $jsonSchema'() {
+        expect:
+        toBson(jsonSchema(new BsonDocument('bsonType', new BsonString('object')))) == parse( '''{
+                                                                                       $jsonSchema : {
+                                                                                          bsonType : "object"
+                                                                                       }
                                                                                     }''')
     }
 


### PR DESCRIPTION
Turns out this is all that's need to support schema validation, since the schema is just specified as a query.  

Added $expr support as that's the only other new filter expression afaik.