### PR TITLE
JAVA-2611: Lookup SRV and TXT records in DNS

### DIFF
--- a/driver-async/src/test/functional/com/mongodb/async/client/InitialDnsSeedlistDiscoveryTest.java
+++ b/driver-async/src/test/functional/com/mongodb/async/client/InitialDnsSeedlistDiscoveryTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.async.client;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientException;
+import com.mongodb.ServerAddress;
+import com.mongodb.async.SingleResultCallback;
+import com.mongodb.connection.ClusterSettings;
+import com.mongodb.connection.ConnectionPoolSettings;
+import com.mongodb.connection.ServerDescription;
+import com.mongodb.connection.ServerSettings;
+import com.mongodb.connection.SocketSettings;
+import com.mongodb.event.ClusterClosedEvent;
+import com.mongodb.event.ClusterDescriptionChangedEvent;
+import com.mongodb.event.ClusterListener;
+import com.mongodb.event.ClusterOpeningEvent;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+import org.bson.Document;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import util.JsonPoweredTestHelper;
+
+import javax.naming.Context;
+import javax.naming.NameNotFoundException;
+import javax.naming.NamingException;
+import javax.naming.directory.InitialDirContext;
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.mongodb.ClusterFixture.getSslSettingsBuilder;
+import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
+// See https://github.com/mongodb/specifications/tree/master/source/initial-dns-seedlist-discovery/tests
+@RunWith(Parameterized.class)
+public class InitialDnsSeedlistDiscoveryTest {
+
+    private final String filename;
+    private final String uri;
+    private final List<String> seeds;
+    private final List<ServerAddress> hosts;
+    private final BsonDocument options;
+
+    public InitialDnsSeedlistDiscoveryTest(final String filename, final String uri, final List<String> seeds,
+                                           final List<ServerAddress> hosts, final BsonDocument options) {
+        this.filename = filename;
+        this.uri = uri;
+        this.seeds = seeds;
+        this.hosts = hosts;
+        this.options = options;
+    }
+
+    @Test
+    public void shouldResolve() {
+        ConnectionString connectionString = new ConnectionString(this.uri);
+
+        if (seeds.isEmpty()) {
+            try {
+                connectionString.applyDirectoryResolution(createDnsDirContext());
+                fail();
+            } catch (MongoClientException e) {
+                assertEquals(NameNotFoundException.class, e.getCause().getClass());
+            }
+        } else {
+            ConnectionString resolvedConnectionString = connectionString.applyDirectoryResolution(createDnsDirContext());
+
+            assertEquals(seeds.size(), resolvedConnectionString.getHosts().size());
+            assertTrue(resolvedConnectionString.getHosts().containsAll(seeds));
+
+            for (Map.Entry<String, BsonValue> entry : options.entrySet()) {
+                if (entry.getKey().equals("connectTimeoutMS")) {
+                    assertEquals(entry.getValue().asNumber().intValue(), (int) resolvedConnectionString.getConnectTimeout());
+                } else if (entry.getKey().equals("replicaSet")) {
+                    assertEquals(entry.getValue().asString().getValue(), resolvedConnectionString.getRequiredReplicaSetName());
+                } else if (entry.getKey().equals("socketTimeoutMS")) {
+                    assertEquals(entry.getValue().asNumber().intValue(), (int) resolvedConnectionString.getSocketTimeout());
+                } else {
+                    throw new UnsupportedOperationException("No support configured yet for " + entry.getKey());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void shouldDiscover() throws InterruptedException {
+        assumeTrue(!seeds.isEmpty());
+        assumeTrue(isDiscoverableReplicaSet());
+
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        MongoClient client = MongoClients.create(new ConnectionString(uri),
+                ClusterSettings.builder().addClusterListener(new ClusterListener() {
+                    @Override
+                    public void clusterOpening(final ClusterOpeningEvent event) {
+                    }
+
+                    @Override
+                    public void clusterClosed(final ClusterClosedEvent event) {
+                    }
+
+                    @Override
+                    public void clusterDescriptionChanged(final ClusterDescriptionChangedEvent event) {
+                        List<ServerAddress> curHostList = new ArrayList<ServerAddress>();
+                        for (ServerDescription cur : event.getNewDescription().getServerDescriptions()) {
+                            if (cur.isOk()) {
+                                curHostList.add(cur.getAddress());
+                            }
+                        }
+                        if (hosts.size() == curHostList.size() && curHostList.containsAll(hosts)) {
+                            latch.countDown();
+                        }
+
+                    }
+                }), ConnectionPoolSettings.builder(), ServerSettings.builder(),
+                getSslSettingsBuilder(),
+                SocketSettings.builder());
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
+
+        final CountDownLatch pingLatch = new CountDownLatch(1);
+        client.getDatabase("admin").runCommand(new Document("ping", 1), new SingleResultCallback<Document>() {
+            @Override
+            public void onResult(final Document result, final Throwable t) {
+                if (t == null) {
+                    pingLatch.countDown();
+                }
+            }
+        });
+
+        assertTrue(pingLatch.await(5, TimeUnit.SECONDS));
+
+        client.close();
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+        List<Object[]> data = new ArrayList<Object[]>();
+        for (File file : JsonPoweredTestHelper.getTestFiles("/initial-dns-seedlist-discovery")) {
+            BsonDocument testDocument = JsonPoweredTestHelper.getTestDocument(file);
+            data.add(new Object[]{
+                    file.getName(),
+                    testDocument.getString("uri").getValue(),
+                    toStringList(testDocument.getArray("seeds")),
+                    toServerAddressList(testDocument.getArray("hosts")),
+                    testDocument.getDocument("options", new BsonDocument())
+            });
+
+        }
+        return data;
+    }
+
+    private static List<String> toStringList(final BsonArray bsonArray) {
+        List<String> retVal = new ArrayList<String>(bsonArray.size());
+        for (BsonValue cur : bsonArray) {
+            retVal.add(cur.asString().getValue());
+        }
+        return retVal;
+    }
+
+    private static List<ServerAddress> toServerAddressList(final BsonArray bsonArray) {
+        List<ServerAddress> retVal = new ArrayList<ServerAddress>(bsonArray.size());
+        for (BsonValue cur : bsonArray) {
+            retVal.add(new ServerAddress(cur.asString().getValue()));
+        }
+        return retVal;
+    }
+
+    private static InitialDirContext createDnsDirContext() {
+        Hashtable<String, String> envProps = new Hashtable<String, String>();
+        envProps.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.dns.DnsContextFactory");
+        try {
+            return new InitialDirContext(envProps);
+        } catch (NamingException e) {
+            throw new MongoClientException("Unable to create JNDI context for resolving SRV records", e);
+        }
+    }
+}

--- a/driver-core/src/main/com/mongodb/ConnectionString.java
+++ b/driver-core/src/main/com/mongodb/ConnectionString.java
@@ -836,6 +836,10 @@ public class ConnectionString {
             }
             hosts.add(host);
         }
+        if (requiresDirectoryResolution && hosts.size() > 1) {
+            throw new IllegalArgumentException("The mongodb+srv protocol requires a single host name but this connection string has more "
+                    + "than one: " + connectionString);
+        }
         Collections.sort(hosts);
         return hosts;
     }

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -284,11 +284,15 @@ public final class ClusterFixture {
     }
 
     public static SslSettings getSslSettings() {
+        return getSslSettingsBuilder().build();
+    }
+
+    public static SslSettings.Builder getSslSettingsBuilder() {
         SslSettings.Builder builder = SslSettings.builder().applyConnectionString(getConnectionString());
         if (System.getProperty("java.version").startsWith("1.6.")) {
             builder.invalidHostNameAllowed(true);
         }
-        return builder.build();
+        return builder;
     }
 
     @SuppressWarnings("deprecation")

--- a/driver-core/src/test/resources/connection-string/invalid-uris.json
+++ b/driver-core/src/test/resources/connection-string/invalid-uris.json
@@ -1,220 +1,265 @@
 {
-    "tests": [
-        {
-            "auth": null, 
-            "description": "Empty string", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid scheme", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongo://localhost:27017", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Missing host", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Double colon in host identifier", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://localhost::27017", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Double colon in host identifier and trailing slash", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://localhost::27017/", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Double colon in host identifier with missing host and port", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://::", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Double colon in host identifier with missing port", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://localhost,localhost::", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Double colon in host identifier and second host", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://localhost::27017,abc", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid port (negative number) with hostname", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://localhost:-1", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid port (zero) with hostname", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://localhost:0/", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid port (positive number) with hostname", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://localhost:65536", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid port (positive number) with hostname and trailing slash", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://localhost:65536/", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid port (non-numeric string) with hostname", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://localhost:foo", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid port (negative number) with IP literal", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://[::1]:-1", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid port (zero) with IP literal", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://[::1]:0/", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid port (positive number) with IP literal", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://[::1]:65536", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid port (positive number) with IP literal and trailing slash", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://[::1]:65536/", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Invalid port (non-numeric string) with IP literal", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://[::1]:foo", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Missing delimiting slash between hosts and options", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://example.com?w=1", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Incomplete key value pair for option", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://example.com/?w", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Username with password containing an unescaped colon", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://alice:foo:bar@127.0.0.1", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Username containing an unescaped at-sign", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://alice@@127.0.0.1", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Username with password containing an unescaped at-sign", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb://alice@foo:bar@127.0.0.1", 
-            "valid": false, 
-            "warning": null
-        }, 
-        {
-            "auth": null, 
-            "description": "Host with unescaped slash", 
-            "hosts": null, 
-            "options": null, 
-            "uri": "mongodb:///tmp/mongodb-27017.sock/", 
-            "valid": false, 
-            "warning": null
-        }
-    ]
+  "tests": [
+    {
+      "description": "Empty string",
+      "uri": "",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid scheme",
+      "uri": "mongo://localhost:27017",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Missing host",
+      "uri": "mongodb://",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Double colon in host identifier",
+      "uri": "mongodb://localhost::27017",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Double colon in host identifier and trailing slash",
+      "uri": "mongodb://localhost::27017/",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Double colon in host identifier with missing host and port",
+      "uri": "mongodb://::",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Double colon in host identifier with missing port",
+      "uri": "mongodb://localhost,localhost::",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Double colon in host identifier and second host",
+      "uri": "mongodb://localhost::27017,abc",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (negative number) with hostname",
+      "uri": "mongodb://localhost:-1",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (zero) with hostname",
+      "uri": "mongodb://localhost:0/",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (positive number) with hostname",
+      "uri": "mongodb://localhost:65536",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (positive number) with hostname and trailing slash",
+      "uri": "mongodb://localhost:65536/",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (non-numeric string) with hostname",
+      "uri": "mongodb://localhost:foo",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (negative number) with IP literal",
+      "uri": "mongodb://[::1]:-1",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (zero) with IP literal",
+      "uri": "mongodb://[::1]:0/",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (positive number) with IP literal",
+      "uri": "mongodb://[::1]:65536",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (positive number) with IP literal and trailing slash",
+      "uri": "mongodb://[::1]:65536/",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Invalid port (non-numeric string) with IP literal",
+      "uri": "mongodb://[::1]:foo",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Missing delimiting slash between hosts and options",
+      "uri": "mongodb://example.com?w=1",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Incomplete key value pair for option",
+      "uri": "mongodb://example.com/?w",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username with password containing an unescaped colon",
+      "uri": "mongodb://alice:foo:bar@127.0.0.1",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username containing an unescaped at-sign",
+      "uri": "mongodb://alice@@127.0.0.1",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username with password containing an unescaped at-sign",
+      "uri": "mongodb://alice@foo:bar@127.0.0.1",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username containing an unescaped slash",
+      "uri": "mongodb://alice/@localhost/db",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username containing unescaped slash with password",
+      "uri": "mongodb://alice/bob:foo@localhost/db",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Username with password containing an unescaped slash",
+      "uri": "mongodb://alice:foo/bar@localhost/db",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Host with unescaped slash",
+      "uri": "mongodb:///tmp/mongodb-27017.sock/",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "mongodb+srv with multiple service names",
+      "uri": "mongodb+srv://test5.test.mongodb.com,test6.test.mongodb.com",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "mongodb+srv with port number",
+      "uri": "mongodb+srv://test7.test.mongodb.com:27018",
+      "valid": false,
+      "warning": null,
+      "hosts": null,
+      "auth": null,
+      "options": null
+    }
+  ]
 }

--- a/driver-core/src/test/resources/connection-string/valid-auth.json
+++ b/driver-core/src/test/resources/connection-string/valid-auth.json
@@ -1,330 +1,311 @@
 {
-    "tests": [
+  "tests": [
+    {
+      "description": "User info for single IPv4 host without database",
+      "uri": "mongodb://alice:foo@127.0.0.1",
+      "valid": true,
+      "warning": false,
+      "hosts": [
         {
-            "auth": {
-                "db": null, 
-                "password": "foo", 
-                "username": "alice"
-            }, 
-            "description": "User info for single IPv4 host without database", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": null, 
-                    "type": "ipv4"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://alice:foo@127.0.0.1", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "test", 
-                "password": "foo", 
-                "username": "alice"
-            }, 
-            "description": "User info for single IPv4 host with database", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": null, 
-                    "type": "ipv4"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://alice:foo@127.0.0.1/test", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "t\u0000est", 
-                "password": "f\u0000oo", 
-                "username": "a\u0000lice"
-            }, 
-            "description": "User info for single IPv4 host with database (escaped null bytes)", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": null, 
-                    "type": "ipv4"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://a%00lice:f%00oo@127.0.0.1/t%00est", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": null, 
-                "password": "bar", 
-                "username": "bob"
-            }, 
-            "description": "User info for single IP literal host without database", 
-            "hosts": [
-                {
-                    "host": "::1", 
-                    "port": 27018, 
-                    "type": "ip_literal"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://bob:bar@[::1]:27018", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin", 
-                "password": "bar", 
-                "username": "bob"
-            }, 
-            "description": "User info for single IP literal host with database", 
-            "hosts": [
-                {
-                    "host": "::1", 
-                    "port": 27018, 
-                    "type": "ip_literal"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://bob:bar@[::1]:27018/admin", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": null, 
-                "password": "baz", 
-                "username": "eve"
-            }, 
-            "description": "User info for single hostname without database", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://eve:baz@example.com", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "db2", 
-                "password": "baz", 
-                "username": "eve"
-            }, 
-            "description": "User info for single hostname with database", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://eve:baz@example.com/db2", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": null, 
-                "password": "secret", 
-                "username": "alice"
-            }, 
-            "description": "User info for multiple hosts without database", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": null, 
-                    "type": "ipv4"
-                }, 
-                {
-                    "host": "example.com", 
-                    "port": 27018, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://alice:secret@127.0.0.1,example.com:27018", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin", 
-                "password": "secret", 
-                "username": "alice"
-            }, 
-            "description": "User info for multiple hosts with database", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }, 
-                {
-                    "host": "::1", 
-                    "port": 27019, 
-                    "type": "ip_literal"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://alice:secret@example.com,[::1]:27019/admin", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": null, 
-                "password": null, 
-                "username": "alice"
-            }, 
-            "description": "Username without password", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": null, 
-                    "type": "ipv4"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://alice@127.0.0.1", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": null, 
-                "password": "", 
-                "username": "alice"
-            }, 
-            "description": "Username with empty password", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": null, 
-                    "type": "ipv4"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://alice:@127.0.0.1", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "my=db", 
-                "password": null, 
-                "username": "@l:ce"
-            }, 
-            "description": "Escaped username and database without password", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://%40l%3Ace@example.com/my%3Ddb", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin?", 
-                "password": "f:zzb@zz", 
-                "username": "$am"
-            }, 
-            "description": "Escaped user info and database (MONGODB-CR)", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": null, 
-                    "type": "ipv4"
-                }
-            ], 
-            "options": {
-                "authmechanism": "MONGODB-CR"
-            }, 
-            "uri": "mongodb://%24am:f%3Azzb%40zz@127.0.0.1/admin%3F?authMechanism=MONGODB-CR", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": null, 
-                "password": null, 
-                "username": "CN=myName,OU=myOrgUnit,O=myOrg,L=myLocality,ST=myState,C=myCountry"
-            }, 
-            "description": "Escaped username (MONGODB-X509)", 
-            "hosts": [
-                {
-                    "host": "localhost", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": {
-                "authmechanism": "MONGODB-X509"
-            }, 
-            "uri": "mongodb://CN%3DmyName%2COU%3DmyOrgUnit%2CO%3DmyOrg%2CL%3DmyLocality%2CST%3DmyState%2CC%3DmyCountry@localhost/?authMechanism=MONGODB-X509", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": null, 
-                "password": "secret", 
-                "username": "user@EXAMPLE.COM"
-            }, 
-            "description": "Escaped username (GSSAPI)", 
-            "hosts": [
-                {
-                    "host": "localhost", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": {
-                "authmechanism": "GSSAPI", 
-                "authmechanismproperties": {
-                    "CANONICALIZE_HOST_NAME": true, 
-                    "SERVICE_NAME": "other"
-                }
-            }, 
-            "uri": "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authMechanism=GSSAPI", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin", 
-                "password": "secret", 
-                "username": "alice"
-            }, 
-            "description": "At-signs in options aren't part of the userinfo", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": {
-                "replicaset": "my@replicaset"
-            }, 
-            "uri": "mongodb://alice:secret@example.com/admin?replicaset=my@replicaset", 
-            "valid": true, 
-            "warning": false
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": null
         }
-    ]
+      ],
+      "auth": {
+        "username": "alice",
+        "password": "foo",
+        "db": null
+      },
+      "options": null
+    },
+    {
+      "description": "User info for single IPv4 host with database",
+      "uri": "mongodb://alice:foo@127.0.0.1/test",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "alice",
+        "password": "foo",
+        "db": "test"
+      },
+      "options": null
+    },
+    {
+      "description": "User info for single IP literal host without database",
+      "uri": "mongodb://bob:bar@[::1]:27018",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ip_literal",
+          "host": "::1",
+          "port": 27018
+        }
+      ],
+      "auth": {
+        "username": "bob",
+        "password": "bar",
+        "db": null
+      },
+      "options": null
+    },
+    {
+      "description": "User info for single IP literal host with database",
+      "uri": "mongodb://bob:bar@[::1]:27018/admin",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ip_literal",
+          "host": "::1",
+          "port": 27018
+        }
+      ],
+      "auth": {
+        "username": "bob",
+        "password": "bar",
+        "db": "admin"
+      },
+      "options": null
+    },
+    {
+      "description": "User info for single hostname without database",
+      "uri": "mongodb://eve:baz@example.com",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "eve",
+        "password": "baz",
+        "db": null
+      },
+      "options": null
+    },
+    {
+      "description": "User info for single hostname with database",
+      "uri": "mongodb://eve:baz@example.com/db2",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "eve",
+        "password": "baz",
+        "db": "db2"
+      },
+      "options": null
+    },
+    {
+      "description": "User info for multiple hosts without database",
+      "uri": "mongodb://alice:secret@127.0.0.1,example.com:27018",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": null
+        },
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": 27018
+        }
+      ],
+      "auth": {
+        "username": "alice",
+        "password": "secret",
+        "db": null
+      },
+      "options": null
+    },
+    {
+      "description": "User info for multiple hosts with database",
+      "uri": "mongodb://alice:secret@example.com,[::1]:27019/admin",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        },
+        {
+          "type": "ip_literal",
+          "host": "::1",
+          "port": 27019
+        }
+      ],
+      "auth": {
+        "username": "alice",
+        "password": "secret",
+        "db": "admin"
+      },
+      "options": null
+    },
+    {
+      "description": "Username without password",
+      "uri": "mongodb://alice@127.0.0.1",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "alice",
+        "password": null,
+        "db": null
+      },
+      "options": null
+    },
+    {
+      "description": "Username with empty password",
+      "uri": "mongodb://alice:@127.0.0.1",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "alice",
+        "password": "",
+        "db": null
+      },
+      "options": null
+    },
+    {
+      "description": "Escaped username and database without password",
+      "uri": "mongodb://%40l%3Ace%2F%3D@example.com/my%3Ddb",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "@l:ce/=",
+        "password": null,
+        "db": "my=db"
+      },
+      "options": null
+    },
+    {
+      "description": "Escaped user info and database (MONGODB-CR)",
+      "uri": "mongodb://%24am:f%3Azzb%40z%2Fz%3D@127.0.0.1/admin%3F?authMechanism=MONGODB-CR",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "$am",
+        "password": "f:zzb@z/z=",
+        "db": "admin?"
+      },
+      "options": {
+        "authmechanism": "MONGODB-CR"
+      }
+    },
+    {
+      "description": "Escaped username (MONGODB-X509)",
+      "uri": "mongodb://CN%3DmyName%2COU%3DmyOrgUnit%2CO%3DmyOrg%2CL%3DmyLocality%2CST%3DmyState%2CC%3DmyCountry@localhost/?authMechanism=MONGODB-X509",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "localhost",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "CN=myName,OU=myOrgUnit,O=myOrg,L=myLocality,ST=myState,C=myCountry",
+        "password": null,
+        "db": null
+      },
+      "options": {
+        "authmechanism": "MONGODB-X509"
+      }
+    },
+    {
+      "description": "Escaped username (GSSAPI)",
+      "uri": "mongodb://user%40EXAMPLE.COM:secret@localhost/?authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authMechanism=GSSAPI",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "localhost",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "user@EXAMPLE.COM",
+        "password": "secret",
+        "db": null
+      },
+      "options": {
+        "authmechanism": "GSSAPI",
+        "authmechanismproperties": {
+          "SERVICE_NAME": "other",
+          "CANONICALIZE_HOST_NAME": true
+        }
+      }
+    },
+    {
+      "description": "At-signs in options aren't part of the userinfo",
+      "uri": "mongodb://alice:secret@example.com/admin?replicaset=my@replicaset",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "alice",
+        "password": "secret",
+        "db": "admin"
+      },
+      "options": {
+        "replicaset": "my@replicaset"
+      }
+    }
+  ]
 }

--- a/driver-core/src/test/resources/connection-string/valid-host_identifiers.json
+++ b/driver-core/src/test/resources/connection-string/valid-host_identifiers.json
@@ -1,154 +1,154 @@
 {
-    "tests": [
+  "tests": [
+    {
+      "description": "Single IPv4 host without port",
+      "uri": "mongodb://127.0.0.1",
+      "valid": true,
+      "warning": false,
+      "hosts": [
         {
-            "auth": null, 
-            "description": "Single IPv4 host without port", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": null, 
-                    "type": "ipv4"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://127.0.0.1", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Single IPv4 host with port", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": 27018, 
-                    "type": "ipv4"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://127.0.0.1:27018", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Single IP literal host without port", 
-            "hosts": [
-                {
-                    "host": "::1", 
-                    "port": null, 
-                    "type": "ip_literal"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://[::1]", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Single IP literal host with port", 
-            "hosts": [
-                {
-                    "host": "::1", 
-                    "port": 27019, 
-                    "type": "ip_literal"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://[::1]:27019", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Single hostname without port", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://example.com", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Single hostname with port", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": 27020, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://example.com:27020", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Single hostname (resembling IPv4) without port", 
-            "hosts": [
-                {
-                    "host": "256.0.0.1", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://256.0.0.1", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Multiple hosts (mixed formats)", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": null, 
-                    "type": "ipv4"
-                }, 
-                {
-                    "host": "::1", 
-                    "port": 27018, 
-                    "type": "ip_literal"
-                }, 
-                {
-                    "host": "example.com", 
-                    "port": 27019, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://127.0.0.1,[::1]:27018,example.com:27019", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "UTF-8 hosts", 
-            "hosts": [
-                {
-                    "host": "b\u00fccher.example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }, 
-                {
-                    "host": "uml\u00e4ut.example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://b\u00fccher.example.com,uml\u00e4ut.example.com/", 
-            "valid": true, 
-            "warning": false
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": null
         }
-    ]
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Single IPv4 host with port",
+      "uri": "mongodb://127.0.0.1:27018",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": 27018
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Single IP literal host without port",
+      "uri": "mongodb://[::1]",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ip_literal",
+          "host": "::1",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Single IP literal host with port",
+      "uri": "mongodb://[::1]:27019",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ip_literal",
+          "host": "::1",
+          "port": 27019
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Single hostname without port",
+      "uri": "mongodb://example.com",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Single hostname with port",
+      "uri": "mongodb://example.com:27020",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": 27020
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Single hostname (resembling IPv4) without port",
+      "uri": "mongodb://256.0.0.1",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "256.0.0.1",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Multiple hosts (mixed formats)",
+      "uri": "mongodb://127.0.0.1,[::1]:27018,example.com:27019",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": null
+        },
+        {
+          "type": "ip_literal",
+          "host": "::1",
+          "port": 27018
+        },
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": 27019
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "UTF-8 hosts",
+      "uri": "mongodb://bücher.example.com,umläut.example.com/",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "bücher.example.com",
+          "port": null
+        },
+        {
+          "type": "hostname",
+          "host": "umläut.example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    }
+  ]
 }

--- a/driver-core/src/test/resources/connection-string/valid-options.json
+++ b/driver-core/src/test/resources/connection-string/valid-options.json
@@ -1,42 +1,25 @@
 {
-    "tests": [
+  "tests": [
+    {
+      "description": "Option names are normalized to lowercase",
+      "uri": "mongodb://alice:secret@example.com/admin?AUTHMechanism=MONGODB-CR",
+      "valid": true,
+      "warning": false,
+      "hosts": [
         {
-            "auth": {
-                "db": "admin", 
-                "password": "secret", 
-                "username": "alice"
-            }, 
-            "description": "Option names are normalized to lowercase", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": {
-                "authmechanism": "MONGODB-CR"
-            }, 
-            "uri": "mongodb://alice:secret@example.com/admin?AUTHMechanism=MONGODB-CR", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Option key and value (escaped null bytes)", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": {
-                "replicaset": "my\u0000rs"
-            }, 
-            "uri": "mongodb://example.com/?replicaSet=my%00rs", 
-            "valid": true, 
-            "warning": false
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
         }
-    ]
+      ],
+      "auth": {
+        "username": "alice",
+        "password": "secret",
+        "db": "admin"
+      },
+      "options": {
+        "authmechanism": "MONGODB-CR"
+      }
+    }
+  ]
 }

--- a/driver-core/src/test/resources/connection-string/valid-unix_socket-absolute.json
+++ b/driver-core/src/test/resources/connection-string/valid-unix_socket-absolute.json
@@ -1,251 +1,251 @@
 {
-    "tests": [
+  "tests": [
+    {
+      "description": "Unix domain socket (absolute path with trailing slash)",
+      "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock/",
+      "valid": true,
+      "warning": false,
+      "hosts": [
         {
-            "auth": null, 
-            "description": "Unix domain socket (absolute path with trailing slash)", 
-            "hosts": [
-                {
-                    "host": "/tmp/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock/", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Unix domain socket (absolute path without trailing slash)", 
-            "hosts": [
-                {
-                    "host": "/tmp/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Unix domain socket (absolute path with spaces in path)", 
-            "hosts": [
-                {
-                    "host": "/tmp/ /mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://%2Ftmp%2F %2Fmongodb-27017.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Multiple Unix domain sockets (absolute paths)", 
-            "hosts": [
-                {
-                    "host": "/tmp/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }, 
-                {
-                    "host": "/tmp/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Multiple hosts (absolute path and ipv4)", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": 27017, 
-                    "type": "ipv4"
-                }, 
-                {
-                    "host": "/tmp/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://127.0.0.1:27017,%2Ftmp%2Fmongodb-27017.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Multiple hosts (absolute path and hostname resembling relative path)", 
-            "hosts": [
-                {
-                    "host": "mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "hostname"
-                }, 
-                {
-                    "host": "/tmp/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://mongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin", 
-                "password": "foo", 
-                "username": "alice"
-            }, 
-            "description": "Unix domain socket with auth database (absolute path)", 
-            "hosts": [
-                {
-                    "host": "/tmp/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://alice:foo@%2Ftmp%2Fmongodb-27017.sock/admin", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Unix domain socket with path resembling socket file (absolute path with trailing slash)", 
-            "hosts": [
-                {
-                    "host": "/tmp/path.to.sock/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://%2Ftmp%2Fpath.to.sock%2Fmongodb-27017.sock/", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Unix domain socket with path resembling socket file (absolute path without trailing slash)", 
-            "hosts": [
-                {
-                    "host": "/tmp/path.to.sock/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://%2Ftmp%2Fpath.to.sock%2Fmongodb-27017.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin", 
-                "password": "bar", 
-                "username": "bob"
-            }, 
-            "description": "Unix domain socket with path resembling socket file and auth (absolute path)", 
-            "hosts": [
-                {
-                    "host": "/tmp/path.to.sock/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://bob:bar@%2Ftmp%2Fpath.to.sock%2Fmongodb-27017.sock/admin", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin.sock", 
-                "password": null, 
-                "username": null
-            }, 
-            "description": "Multiple Unix domain sockets and auth DB resembling a socket (absolute path)", 
-            "hosts": [
-                {
-                    "host": "/tmp/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }, 
-                {
-                    "host": "/tmp/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock/admin.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin.shoe", 
-                "password": null, 
-                "username": null
-            }, 
-            "description": "Multiple Unix domain sockets with auth DB resembling a path (absolute path)", 
-            "hosts": [
-                {
-                    "host": "/tmp/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }, 
-                {
-                    "host": "/tmp/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock/admin.shoe", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin", 
-                "password": "bar", 
-                "username": "bob"
-            }, 
-            "description": "Multiple Unix domain sockets with auth and query string (absolute path)", 
-            "hosts": [
-                {
-                    "host": "/tmp/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }, 
-                {
-                    "host": "/tmp/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": {
-                "w": 1
-            }, 
-            "uri": "mongodb://bob:bar@%2Ftmp%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock/admin?w=1", 
-            "valid": true, 
-            "warning": false
+          "type": "unix",
+          "host": "/tmp/mongodb-27017.sock",
+          "port": null
         }
-    ]
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unix domain socket (absolute path without trailing slash)",
+      "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unix domain socket (absolute path with spaces in path)",
+      "uri": "mongodb://%2Ftmp%2F %2Fmongodb-27017.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/ /mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Multiple Unix domain sockets (absolute paths)",
+      "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Multiple hosts (absolute path and ipv4)",
+      "uri": "mongodb://127.0.0.1:27017,%2Ftmp%2Fmongodb-27017.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": 27017
+        },
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Multiple hosts (absolute path and hostname resembling relative path)",
+      "uri": "mongodb://mongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unix domain socket with auth database (absolute path)",
+      "uri": "mongodb://alice:foo@%2Ftmp%2Fmongodb-27017.sock/admin",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "alice",
+        "password": "foo",
+        "db": "admin"
+      },
+      "options": null
+    },
+    {
+      "description": "Unix domain socket with path resembling socket file (absolute path with trailing slash)",
+      "uri": "mongodb://%2Ftmp%2Fpath.to.sock%2Fmongodb-27017.sock/",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/path.to.sock/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unix domain socket with path resembling socket file (absolute path without trailing slash)",
+      "uri": "mongodb://%2Ftmp%2Fpath.to.sock%2Fmongodb-27017.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/path.to.sock/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unix domain socket with path resembling socket file and auth (absolute path)",
+      "uri": "mongodb://bob:bar@%2Ftmp%2Fpath.to.sock%2Fmongodb-27017.sock/admin",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/path.to.sock/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "bob",
+        "password": "bar",
+        "db": "admin"
+      },
+      "options": null
+    },
+    {
+      "description": "Multiple Unix domain sockets and auth DB (absolute path)",
+      "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock/admin",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": null,
+        "password": null,
+        "db": "admin"
+      },
+      "options": null
+    },
+    {
+      "description": "Multiple Unix domain sockets with auth DB (absolute path)",
+      "uri": "mongodb://%2Ftmp%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock/admin",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": null,
+        "password": null,
+        "db": "admin"
+      },
+      "options": null
+    },
+    {
+      "description": "Multiple Unix domain sockets with auth and query string (absolute path)",
+      "uri": "mongodb://bob:bar@%2Ftmp%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock/admin?w=1",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "bob",
+        "password": "bar",
+        "db": "admin"
+      },
+      "options": {
+        "w": 1
+      }
+    }
+  ]
 }

--- a/driver-core/src/test/resources/connection-string/valid-unix_socket-relative.json
+++ b/driver-core/src/test/resources/connection-string/valid-unix_socket-relative.json
@@ -1,271 +1,271 @@
 {
-    "tests": [
+  "tests": [
+    {
+      "description": "Unix domain socket (relative path with trailing slash)",
+      "uri": "mongodb://rel%2Fmongodb-27017.sock/",
+      "valid": true,
+      "warning": false,
+      "hosts": [
         {
-            "auth": null, 
-            "description": "Unix domain socket (relative path with trailing slash)", 
-            "hosts": [
-                {
-                    "host": "rel/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://rel%2Fmongodb-27017.sock/", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Unix domain socket (relative path without trailing slash)", 
-            "hosts": [
-                {
-                    "host": "rel/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://rel%2Fmongodb-27017.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Unix domain socket (relative path with spaces)", 
-            "hosts": [
-                {
-                    "host": "rel/ /mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://rel%2F %2Fmongodb-27017.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Multiple Unix domain sockets (relative paths)", 
-            "hosts": [
-                {
-                    "host": "rel/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }, 
-                {
-                    "host": "rel/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://rel%2Fmongodb-27017.sock,rel%2Fmongodb-27018.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Multiple Unix domain sockets (relative and absolute paths)", 
-            "hosts": [
-                {
-                    "host": "rel/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }, 
-                {
-                    "host": "/tmp/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://rel%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Multiple hosts (relative path and ipv4)", 
-            "hosts": [
-                {
-                    "host": "127.0.0.1", 
-                    "port": 27017, 
-                    "type": "ipv4"
-                }, 
-                {
-                    "host": "rel/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://127.0.0.1:27017,rel%2Fmongodb-27017.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Multiple hosts (relative path and hostname resembling relative path)", 
-            "hosts": [
-                {
-                    "host": "mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "hostname"
-                }, 
-                {
-                    "host": "rel/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://mongodb-27017.sock,rel%2Fmongodb-27018.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin", 
-                "password": "foo", 
-                "username": "alice"
-            }, 
-            "description": "Unix domain socket with auth database (relative path)", 
-            "hosts": [
-                {
-                    "host": "rel/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://alice:foo@rel%2Fmongodb-27017.sock/admin", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Unix domain socket with path resembling socket file (relative path with trailing slash)", 
-            "hosts": [
-                {
-                    "host": "rel/path.to.sock/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://rel%2Fpath.to.sock%2Fmongodb-27017.sock/", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": null, 
-            "description": "Unix domain socket with path resembling socket file (relative path without trailing slash)", 
-            "hosts": [
-                {
-                    "host": "rel/path.to.sock/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://rel%2Fpath.to.sock%2Fmongodb-27017.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin", 
-                "password": "bar", 
-                "username": "bob"
-            }, 
-            "description": "Unix domain socket with path resembling socket file and auth (relative path)", 
-            "hosts": [
-                {
-                    "host": "rel/path.to.sock/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://bob:bar@rel%2Fpath.to.sock%2Fmongodb-27017.sock/admin", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin.sock", 
-                "password": null, 
-                "username": null
-            }, 
-            "description": "Multiple Unix domain sockets and auth DB resembling a socket (relative path)", 
-            "hosts": [
-                {
-                    "host": "rel/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }, 
-                {
-                    "host": "rel/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://rel%2Fmongodb-27017.sock,rel%2Fmongodb-27018.sock/admin.sock", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin.shoe", 
-                "password": null, 
-                "username": null
-            }, 
-            "description": "Multiple Unix domain sockets with auth DB resembling a path (relative path)", 
-            "hosts": [
-                {
-                    "host": "rel/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }, 
-                {
-                    "host": "rel/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://rel%2Fmongodb-27017.sock,rel%2Fmongodb-27018.sock/admin.shoe", 
-            "valid": true, 
-            "warning": false
-        }, 
-        {
-            "auth": {
-                "db": "admin", 
-                "password": "bar", 
-                "username": "bob"
-            }, 
-            "description": "Multiple Unix domain sockets with auth and query string (relative path)", 
-            "hosts": [
-                {
-                    "host": "rel/mongodb-27017.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }, 
-                {
-                    "host": "rel/mongodb-27018.sock", 
-                    "port": null, 
-                    "type": "unix"
-                }
-            ], 
-            "options": {
-                "w": 1
-            }, 
-            "uri": "mongodb://bob:bar@rel%2Fmongodb-27017.sock,rel%2Fmongodb-27018.sock/admin?w=1", 
-            "valid": true, 
-            "warning": false
+          "type": "unix",
+          "host": "rel/mongodb-27017.sock",
+          "port": null
         }
-    ]
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unix domain socket (relative path without trailing slash)",
+      "uri": "mongodb://rel%2Fmongodb-27017.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unix domain socket (relative path with spaces)",
+      "uri": "mongodb://rel%2F %2Fmongodb-27017.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/ /mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Multiple Unix domain sockets (relative paths)",
+      "uri": "mongodb://rel%2Fmongodb-27017.sock,rel%2Fmongodb-27018.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Multiple Unix domain sockets (relative and absolute paths)",
+      "uri": "mongodb://rel%2Fmongodb-27017.sock,%2Ftmp%2Fmongodb-27018.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "/tmp/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Multiple hosts (relative path and ipv4)",
+      "uri": "mongodb://127.0.0.1:27017,rel%2Fmongodb-27017.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": 27017
+        },
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Multiple hosts (relative path and hostname resembling relative path)",
+      "uri": "mongodb://mongodb-27017.sock,rel%2Fmongodb-27018.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unix domain socket with auth database (relative path)",
+      "uri": "mongodb://alice:foo@rel%2Fmongodb-27017.sock/admin",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "alice",
+        "password": "foo",
+        "db": "admin"
+      },
+      "options": null
+    },
+    {
+      "description": "Unix domain socket with path resembling socket file (relative path with trailing slash)",
+      "uri": "mongodb://rel%2Fpath.to.sock%2Fmongodb-27017.sock/",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/path.to.sock/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unix domain socket with path resembling socket file (relative path without trailing slash)",
+      "uri": "mongodb://rel%2Fpath.to.sock%2Fmongodb-27017.sock",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/path.to.sock/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unix domain socket with path resembling socket file and auth (relative path)",
+      "uri": "mongodb://bob:bar@rel%2Fpath.to.sock%2Fmongodb-27017.sock/admin",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/path.to.sock/mongodb-27017.sock",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "bob",
+        "password": "bar",
+        "db": "admin"
+      },
+      "options": null
+    },
+    {
+      "description": "Multiple Unix domain sockets and auth DB resembling a socket (relative path)",
+      "uri": "mongodb://rel%2Fmongodb-27017.sock,rel%2Fmongodb-27018.sock/admin",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": null,
+        "password": null,
+        "db": "admin"
+      },
+      "options": null
+    },
+    {
+      "description": "Multiple Unix domain sockets with auth DB resembling a path (relative path)",
+      "uri": "mongodb://rel%2Fmongodb-27017.sock,rel%2Fmongodb-27018.sock/admin",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": null,
+        "password": null,
+        "db": "admin"
+      },
+      "options": null
+    },
+    {
+      "description": "Multiple Unix domain sockets with auth and query string (relative path)",
+      "uri": "mongodb://bob:bar@rel%2Fmongodb-27017.sock,rel%2Fmongodb-27018.sock/admin?w=1",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27017.sock",
+          "port": null
+        },
+        {
+          "type": "unix",
+          "host": "rel/mongodb-27018.sock",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "bob",
+        "password": "bar",
+        "db": "admin"
+      },
+      "options": {
+        "w": 1
+      }
+    }
+  ]
 }

--- a/driver-core/src/test/resources/connection-string/valid-warnings.json
+++ b/driver-core/src/test/resources/connection-string/valid-warnings.json
@@ -1,68 +1,68 @@
 {
-    "tests": [
+  "tests": [
+    {
+      "description": "Unrecognized option keys are ignored",
+      "uri": "mongodb://example.com/?foo=bar",
+      "valid": true,
+      "warning": true,
+      "hosts": [
         {
-            "auth": null, 
-            "description": "Unrecognized option keys are ignored", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://example.com/?foo=bar", 
-            "valid": true, 
-            "warning": true
-        }, 
-        {
-            "auth": null, 
-            "description": "Unsupported option values are ignored", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": null, 
-            "uri": "mongodb://example.com/?fsync=ifPossible", 
-            "valid": true, 
-            "warning": true
-        }, 
-        {
-            "auth": null, 
-            "description": "Repeated option keys", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": {
-                "replicaset": "test"
-            }, 
-            "uri": "mongodb://example.com/?replicaSet=test&replicaSet=test", 
-            "valid": true, 
-            "warning": true
-        }, 
-        {
-            "auth": null, 
-            "description": "Deprecated (or unknown) options are ignored if replacement exists", 
-            "hosts": [
-                {
-                    "host": "example.com", 
-                    "port": null, 
-                    "type": "hostname"
-                }
-            ], 
-            "options": {
-                "wtimeoutms": 10
-            }, 
-            "uri": "mongodb://example.com/?wtimeout=5&wtimeoutMS=10", 
-            "valid": true, 
-            "warning": true
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
         }
-    ]
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Unsupported option values are ignored",
+      "uri": "mongodb://example.com/?fsync=ifPossible",
+      "valid": true,
+      "warning": true,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": null
+    },
+    {
+      "description": "Repeated option keys",
+      "uri": "mongodb://example.com/?replicaSet=test&replicaSet=test",
+      "valid": true,
+      "warning": true,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": {
+        "replicaset": "test"
+      }
+    },
+    {
+      "description": "Deprecated (or unknown) options are ignored if replacement exists",
+      "uri": "mongodb://example.com/?wtimeout=5&wtimeoutMS=10",
+      "valid": true,
+      "warning": true,
+      "hosts": [
+        {
+          "type": "hostname",
+          "host": "example.com",
+          "port": null
+        }
+      ],
+      "auth": null,
+      "options": {
+        "wtimeoutms": 10
+      }
+    }
+  ]
 }

--- a/driver-core/src/test/resources/initial-dns-seedlist-discovery/no-results.json
+++ b/driver-core/src/test/resources/initial-dns-seedlist-discovery/no-results.json
@@ -1,0 +1,5 @@
+{
+  "uri": "mongodb+srv://test4.test.build.10gen.cc/",
+  "seeds": [],
+  "hosts": []
+}

--- a/driver-core/src/test/resources/initial-dns-seedlist-discovery/one-result-default-port.json
+++ b/driver-core/src/test/resources/initial-dns-seedlist-discovery/one-result-default-port.json
@@ -1,0 +1,11 @@
+{
+  "uri": "mongodb+srv://test3.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [
+    "localhost.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ]
+}

--- a/driver-core/src/test/resources/initial-dns-seedlist-discovery/one-txt-record.json
+++ b/driver-core/src/test/resources/initial-dns-seedlist-discovery/one-txt-record.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test5.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [
+    "localhost.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "connectTimeoutMS": 300000,
+    "replicaSet": "repl0",
+    "socketTimeoutMS": 300000
+  }
+}

--- a/driver-core/src/test/resources/initial-dns-seedlist-discovery/two-results-default-port.json
+++ b/driver-core/src/test/resources/initial-dns-seedlist-discovery/two-results-default-port.json
@@ -1,0 +1,12 @@
+{
+  "uri": "mongodb+srv://test1.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [
+    "localhost.build.10gen.cc:27017",
+    "localhost.build.10gen.cc:27018"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ]
+}

--- a/driver-core/src/test/resources/initial-dns-seedlist-discovery/two-results-nonstandard-port.json
+++ b/driver-core/src/test/resources/initial-dns-seedlist-discovery/two-results-nonstandard-port.json
@@ -1,0 +1,12 @@
+{
+  "uri": "mongodb+srv://test2.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [
+    "localhost.build.10gen.cc:27018",
+    "localhost.build.10gen.cc:27019"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ]
+}

--- a/driver-core/src/test/resources/initial-dns-seedlist-discovery/two-txt-records-with-override.json
+++ b/driver-core/src/test/resources/initial-dns-seedlist-discovery/two-txt-records-with-override.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test6.test.build.10gen.cc/?replicaSet=repl0&connectTimeoutMS=250000",
+  "seeds": [
+    "localhost.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "connectTimeoutMS": 250000,
+    "replicaSet": "repl0",
+    "socketTimeoutMS": 200000
+  }
+}

--- a/driver-core/src/test/resources/initial-dns-seedlist-discovery/two-txt-records.json
+++ b/driver-core/src/test/resources/initial-dns-seedlist-discovery/two-txt-records.json
@@ -1,0 +1,16 @@
+{
+  "uri": "mongodb+srv://test6.test.build.10gen.cc/?replicaSet=repl0",
+  "seeds": [
+    "localhost.build.10gen.cc:27017"
+  ],
+  "hosts": [
+    "localhost:27017",
+    "localhost:27018",
+    "localhost:27019"
+  ],
+  "options": {
+    "connectTimeoutMS": 200000,
+    "replicaSet": "repl0",
+    "socketTimeoutMS": 200000
+  }
+}

--- a/driver-core/src/test/unit/com/mongodb/ConnectionStringSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/ConnectionStringSpecification.groovy
@@ -83,6 +83,22 @@ class ConnectionStringSpecification extends Specification {
                                                                 'host3:9']          | 'bar'    | null       | 'user'   | 'pass' as char[]
     }
 
+    def 'should throw exception if mongod+srv host contains a port'() {
+        when:
+        new ConnectionString('mongodb+srv://host1:27017')
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def 'should throw exception if mongod+srv contains multiple hosts'() {
+        when:
+        new ConnectionString('mongodb+srv://host1,host2')
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
     def 'should apply directory resolution'() {
         given:
         def connectionString = new ConnectionString('mongodb+srv://user:pass@host1/db1.coll1' +

--- a/driver-core/src/test/unit/com/mongodb/ConnectionStringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/ConnectionStringTest.java
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-package com.mongodb.client;
+package com.mongodb;
 
-import com.mongodb.AuthenticationMechanism;
-import com.mongodb.ConnectionString;
-import com.mongodb.MongoCredential;
 import junit.framework.TestCase;
 import org.bson.BsonDocument;
 import org.bson.BsonValue;
@@ -35,6 +32,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assume.assumeFalse;
 
 // See https://github.com/mongodb/specifications/tree/master/source/crud/tests
 @RunWith(Parameterized.class)
@@ -55,6 +54,9 @@ public class ConnectionStringTest extends TestCase {
     @Test
     public void shouldPassAllOutcomes() {
         if (filename.equals("invalid-uris.json")) {
+            // See JAVA-2645
+            assumeFalse(description.equals("Username containing unescaped slash with password"));
+            assumeFalse(description.equals("Username with password containing an unescaped slash"));
             testInvalidUris();
         } else if (filename.equals("valid-auth.json")) {
             testValidAuth();

--- a/driver/src/test/functional/com/mongodb/client/InitialDnsSeedlistDiscoveryTest.java
+++ b/driver/src/test/functional/com/mongodb/client/InitialDnsSeedlistDiscoveryTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client;
+
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientException;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoClientURI;
+import com.mongodb.ServerAddress;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+import org.bson.Document;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import util.JsonPoweredTestHelper;
+
+import javax.naming.Context;
+import javax.naming.NameNotFoundException;
+import javax.naming.NamingException;
+import javax.naming.directory.InitialDirContext;
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.mongodb.ClusterFixture.getSslSettings;
+import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
+// See https://github.com/mongodb/specifications/tree/master/source/initial-dns-seedlist-discovery/tests
+@RunWith(Parameterized.class)
+public class InitialDnsSeedlistDiscoveryTest {
+
+    private final String filename;
+    private final String uri;
+    private final List<String> seeds;
+    private final List<ServerAddress> hosts;
+    private final BsonDocument options;
+
+    public InitialDnsSeedlistDiscoveryTest(final String filename, final String uri, final List<String> seeds,
+                                           final List<ServerAddress> hosts, final BsonDocument options) {
+        this.filename = filename;
+        this.uri = uri;
+        this.seeds = seeds;
+        this.hosts = hosts;
+        this.options = options;
+    }
+
+    @Test
+    public void shouldResolve() {
+        MongoClientURI uri = new MongoClientURI(this.uri);
+
+        if (seeds.isEmpty()) {
+            try {
+                uri.applyDirectoryResolution(createDnsDirContext());
+                fail();
+            } catch (MongoClientException e) {
+                assertEquals(NameNotFoundException.class, e.getCause().getClass());
+            }
+        } else {
+            MongoClientURI resolvedURI = uri.applyDirectoryResolution(createDnsDirContext());
+
+            assertEquals(seeds.size(), resolvedURI.getHosts().size());
+            assertTrue(resolvedURI.getHosts().containsAll(seeds));
+
+            MongoClientOptions mongoClientOptions = resolvedURI.getOptions();
+            for (Map.Entry<String, BsonValue> entry : options.entrySet()) {
+                if (entry.getKey().equals("connectTimeoutMS")) {
+                    assertEquals(entry.getValue().asNumber().intValue(), mongoClientOptions.getConnectTimeout());
+                } else if (entry.getKey().equals("replicaSet")) {
+                    assertEquals(entry.getValue().asString().getValue(), mongoClientOptions.getRequiredReplicaSetName());
+                } else if (entry.getKey().equals("socketTimeoutMS")) {
+                    assertEquals(entry.getValue().asNumber().intValue(), mongoClientOptions.getSocketTimeout());
+                } else {
+                    throw new UnsupportedOperationException("No support configured yet for " + entry.getKey());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void shouldDiscover() throws InterruptedException {
+        assumeTrue(!seeds.isEmpty());
+        assumeTrue(isDiscoverableReplicaSet());
+
+        MongoClientOptions.Builder optionsBuilder = MongoClientOptions.builder();
+
+        optionsBuilder.sslEnabled(getSslSettings().isEnabled());
+        optionsBuilder.sslInvalidHostNameAllowed(getSslSettings().isInvalidHostNameAllowed());
+
+        MongoClient client = new MongoClient(new MongoClientURI(uri, optionsBuilder));
+        long startTime = System.currentTimeMillis();
+        long currentTime = startTime;
+        boolean hostsMatch = false;
+        while (currentTime < startTime + TimeUnit.SECONDS.toMillis(5)) {
+
+            List<ServerAddress> currentAddresses = client.getServerAddressList();
+            if (currentAddresses.size() == hosts.size() && currentAddresses.containsAll(hosts)) {
+                hostsMatch = true;
+                break;
+            }
+
+            Thread.sleep(100);
+            currentTime = System.currentTimeMillis();
+        }
+
+        assertTrue(hostsMatch);
+
+        assertTrue(client.getDatabase("admin").runCommand(new Document("ping", 1)).containsKey("ok"));
+
+        client.close();
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+        List<Object[]> data = new ArrayList<Object[]>();
+        for (File file : JsonPoweredTestHelper.getTestFiles("/initial-dns-seedlist-discovery")) {
+            BsonDocument testDocument = util.JsonPoweredTestHelper.getTestDocument(file);
+            data.add(new Object[]{
+                    file.getName(),
+                    testDocument.getString("uri").getValue(),
+                    toStringList(testDocument.getArray("seeds")),
+                    toServerAddressList(testDocument.getArray("hosts")),
+                    testDocument.getDocument("options", new BsonDocument())
+            });
+
+        }
+        return data;
+    }
+
+    private static List<String> toStringList(final BsonArray bsonArray) {
+        List<String> retVal = new ArrayList<String>(bsonArray.size());
+        for (BsonValue cur : bsonArray) {
+            retVal.add(cur.asString().getValue());
+        }
+        return retVal;
+    }
+
+    private static List<ServerAddress> toServerAddressList(final BsonArray bsonArray) {
+        List<ServerAddress> retVal = new ArrayList<ServerAddress>(bsonArray.size());
+        for (BsonValue cur : bsonArray) {
+            retVal.add(new ServerAddress(cur.asString().getValue()));
+        }
+        return retVal;
+    }
+
+    private static InitialDirContext createDnsDirContext() {
+        Hashtable<String, String> envProps = new Hashtable<String, String>();
+        envProps.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.dns.DnsContextFactory");
+        try {
+            return new InitialDirContext(envProps);
+        } catch (NamingException e) {
+            throw new MongoClientException("Unable to create JNDI context for resolving SRV records", e);
+        }
+    }
+}


### PR DESCRIPTION
Lookup SRV and TXT records in DNS when connection string protocol is mongodb+srv

Note: Currently requires that the JNDI initial context factory "com.sun.jndi.dns.DnsContextFactory" is available in the JDK, though we could add a way to configure this via system property in the future.

Note: Currently the DNS resolution is synchronous, in contrast to SDAM-related discovery.  

Patch build: https://evergreen.mongodb.com/version/59f09886e3c3316d0f012022

