### PR TITLE
Java-2656: Deprecate methods/constructors that support more than one MongoCredential

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/MongoClientSettings.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoClientSettings.java
@@ -37,8 +37,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static com.mongodb.assertions.Assertions.isTrue;
 import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
+import static java.util.Collections.singletonList;
 
 
 /**
@@ -255,9 +257,24 @@ public final class MongoClientSettings {
          * @param credentialList the credential list
          * @return {@code this}
          * @see MongoClientSettings#getCredentialList()
+         * @deprecated Prefer {@link #credential(MongoCredential)}
          */
+        @Deprecated
         public Builder credentialList(final List<MongoCredential> credentialList) {
             this.credentialList = Collections.unmodifiableList(notNull("credentialList", credentialList));
+            return this;
+        }
+
+        /**
+         * Sets the credential.
+         *
+         * @param credential the credential
+         * @return {@code this}
+         * @see MongoClientSettings#getCredentialList()
+         * @since 3.6
+         */
+        public Builder credential(final MongoCredential credential) {
+            this.credentialList = singletonList(notNull("credential", credential));
             return this;
         }
 
@@ -362,9 +379,22 @@ public final class MongoClientSettings {
      * Gets the credential list.
      *
      * @return the credential list
+     * @deprecated Prefer {@link #getCredential()}
      */
+    @Deprecated
     public List<MongoCredential> getCredentialList() {
         return credentialList;
+    }
+
+    /**
+     * Gets the credential list.
+     *
+     * @return the credential list
+     * @since 3.6
+     */
+    public MongoCredential getCredential() {
+        isTrue("Single or no credential", credentialList.size() <= 1);
+        return credentialList.isEmpty() ? null : credentialList.get(0);
     }
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/MongoClients.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoClients.java
@@ -145,13 +145,16 @@ public final class MongoClients {
                 .serverSettings(ServerSettings.builder()
                         .applyConnectionString(connectionString)
                         .build())
-                .credentialList(connectionString.getCredentialList())
                 .sslSettings(SslSettings.builder()
                         .applyConnectionString(connectionString)
                         .build())
                 .socketSettings(SocketSettings.builder()
                         .applyConnectionString(connectionString)
                         .build());
+
+        if (connectionString.getCredential() != null) {
+            builder.credential(connectionString.getCredential());
+        }
 
         if (connectionString.getReadPreference() != null) {
             builder.readPreference(connectionString.getReadPreference());
@@ -183,6 +186,7 @@ public final class MongoClients {
         }
     }
 
+    @SuppressWarnings("deprecation")
     static MongoClient createMongoClient(final MongoClientSettings settings, final MongoDriverInformation mongoDriverInformation,
                                          final StreamFactory streamFactory, final StreamFactory heartbeatStreamFactory,
                                          final Closeable externalResourceCloser) {

--- a/driver-async/src/test/unit/com/mongodb/async/client/MongoClientSettingsSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/MongoClientSettingsSpecification.groovy
@@ -53,6 +53,8 @@ class MongoClientSettingsSpecification extends Specification {
         options.serverSettings == ServerSettings.builder().build()
         options.streamFactoryFactory == null
         options.compressorList == []
+        options.credentialList == []
+        options.credential == null
     }
 
     @SuppressWarnings('UnnecessaryObjectReferences')
@@ -97,6 +99,11 @@ class MongoClientSettingsSpecification extends Specification {
 
         when:
         builder.writeConcern(null)
+        then:
+        thrown(IllegalArgumentException)
+
+        when:
+        builder.credential(null)
         then:
         thrown(IllegalArgumentException)
 
@@ -169,6 +176,7 @@ class MongoClientSettingsSpecification extends Specification {
         options.serverSettings == serverSettings
         options.codecRegistry == codecRegistry
         options.credentialList == credentialList
+        options.credential == credentialList.get(0)
         options.connectionPoolSettings == connectionPoolSettings
         options.clusterSettings == clusterSettings
         options.streamFactoryFactory == streamFactoryFactory

--- a/driver-core/src/main/com/mongodb/ConnectionString.java
+++ b/driver-core/src/main/com/mongodb/ConnectionString.java
@@ -199,7 +199,7 @@ public class ConnectionString {
 
     private static final Logger LOGGER = Loggers.getLogger("uri");
 
-    private final MongoCredential credentials;
+    private final MongoCredential credential;
     private final List<String> hosts;
     private final String database;
     private final String collection;
@@ -311,7 +311,7 @@ public class ConnectionString {
 
         Map<String, List<String>> optionsMap = parseOptions(unprocessedConnectionString);
         translateOptions(optionsMap);
-        credentials = createCredentials(optionsMap, userName, password);
+        credential = createCredentials(optionsMap, userName, password);
         warnOnUnsupportedOptions(optionsMap);
     }
 
@@ -824,7 +824,7 @@ public class ConnectionString {
      * @return the username
      */
     public String getUsername() {
-        return credentials != null ? credentials.getUserName() : null;
+        return credential != null ? credential.getUserName() : null;
     }
 
     /**
@@ -833,7 +833,7 @@ public class ConnectionString {
      * @return the password
      */
     public char[] getPassword() {
-        return credentials != null ? credentials.getPassword() : null;
+        return credential != null ? credential.getPassword() : null;
     }
 
     /**
@@ -890,9 +890,21 @@ public class ConnectionString {
      * Gets the credentials in an immutable list.  The list will be empty if no credentials were specified in the connection string.
      *
      * @return the credentials in an immutable list
+     * @deprecated Prefer {@link #getCredential()}
      */
+    @Deprecated
     public List<MongoCredential> getCredentialList() {
-        return credentials != null ? singletonList(credentials) : Collections.<MongoCredential>emptyList();
+        return credential != null ? singletonList(credential) : Collections.<MongoCredential>emptyList();
+    }
+
+    /**
+     * Gets the credentials in an immutable list.  The list will be empty if no credentials were specified in the connection string.
+     *
+     * @return the credentials in an immutable list
+     * @since 3.6
+     */
+    public MongoCredential getCredential() {
+        return credential;
     }
 
     /**
@@ -1091,7 +1103,7 @@ public class ConnectionString {
         if (connectTimeout != null ? !connectTimeout.equals(that.connectTimeout) : that.connectTimeout != null) {
             return false;
         }
-        if (credentials != null ? !credentials.equals(that.credentials) : that.credentials != null) {
+        if (credential != null ? !credential.equals(that.credential) : that.credential != null) {
             return false;
         }
         if (database != null ? !database.equals(that.database) : that.database != null) {
@@ -1152,7 +1164,7 @@ public class ConnectionString {
 
     @Override
     public int hashCode() {
-        int result = credentials != null ? credentials.hashCode() : 0;
+        int result = credential != null ? credential.hashCode() : 0;
         result = 31 * result + hosts.hashCode();
         result = 31 * result + (database != null ? database.hashCode() : 0);
         result = 31 * result + (collection != null ? collection.hashCode() : 0);

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -257,6 +257,7 @@ public final class ClusterFixture {
         return asyncCluster;
     }
 
+    @SuppressWarnings("deprecation")
     public static Cluster createCluster(final StreamFactory streamFactory) {
         return new DefaultClusterFactory().createCluster(ClusterSettings.builder().applyConnectionString(getConnectionString()).build(),
                                                   ServerSettings.builder().build(),
@@ -301,6 +302,7 @@ public final class ClusterFixture {
         return serverDescriptions.get(0).getAddress();
     }
 
+    @SuppressWarnings("deprecation")
     public static List<MongoCredential> getCredentialList() {
         return getConnectionString().getCredentialList();
     }
@@ -319,7 +321,7 @@ public final class ClusterFixture {
     }
 
     public static boolean isAuthenticated() {
-        return !getConnectionString().getCredentialList().isEmpty();
+        return getConnectionString().getCredential() != null;
     }
 
     public static void enableMaxTimeFailPoint() {

--- a/driver-core/src/test/unit/com/mongodb/ConnectionStringSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/ConnectionStringSpecification.groovy
@@ -212,54 +212,55 @@ class ConnectionStringSpecification extends Specification {
     @Unroll
     def 'should support all credential types'() {
         expect:
-        uri.credentialList == credentialList
+        uri.credential == credential
+        uri.credentialList == [credential]
 
         where:
-        uri                                                   | credentialList
-        new ConnectionString('mongodb://jeff:123@localhost')  | asList(createCredential('jeff', 'admin', '123'.toCharArray()))
+        uri                                                   | credential
+        new ConnectionString('mongodb://jeff:123@localhost')  | createCredential('jeff', 'admin', '123'.toCharArray())
         new ConnectionString('mongodb://jeff:123@localhost/?' +
-                           '&authSource=test')                | asList(createCredential('jeff', 'test', '123'.toCharArray()))
+                           '&authSource=test')                | createCredential('jeff', 'test', '123'.toCharArray())
         new ConnectionString('mongodb://jeff:123@localhost/?' +
-                           'authMechanism=MONGODB-CR')        | asList(createMongoCRCredential('jeff', 'admin', '123'.toCharArray()))
+                           'authMechanism=MONGODB-CR')        | createMongoCRCredential('jeff', 'admin', '123'.toCharArray())
         new ConnectionString('mongodb://jeff:123@localhost/?' +
                            'authMechanism=MONGODB-CR' +
-                           '&authSource=test')                | asList(createMongoCRCredential('jeff', 'test', '123'.toCharArray()))
+                           '&authSource=test')                | createMongoCRCredential('jeff', 'test', '123'.toCharArray())
         new ConnectionString('mongodb://jeff:123@localhost/?' +
-                             'authMechanism=SCRAM-SHA-1')     | asList(createScramSha1Credential('jeff', 'admin', '123'.toCharArray()))
+                             'authMechanism=SCRAM-SHA-1')     | createScramSha1Credential('jeff', 'admin', '123'.toCharArray())
         new ConnectionString('mongodb://jeff:123@localhost/?' +
                              'authMechanism=SCRAM-SHA-1' +
-                             '&authSource=test')              | asList(createScramSha1Credential('jeff', 'test', '123'.toCharArray()))
+                             '&authSource=test')              | createScramSha1Credential('jeff', 'test', '123'.toCharArray())
         new ConnectionString('mongodb://jeff@localhost/?' +
-                           'authMechanism=GSSAPI')            | asList(createGSSAPICredential('jeff'))
+                           'authMechanism=GSSAPI')            | createGSSAPICredential('jeff')
         new ConnectionString('mongodb://jeff:123@localhost/?' +
-                           'authMechanism=PLAIN')             | asList(createPlainCredential('jeff', 'admin', '123'.toCharArray()))
+                           'authMechanism=PLAIN')             | createPlainCredential('jeff', 'admin', '123'.toCharArray())
         new ConnectionString('mongodb://jeff@localhost/?' +
-                           'authMechanism=MONGODB-X509')      | asList(createMongoX509Credential('jeff'))
+                           'authMechanism=MONGODB-X509')      | createMongoX509Credential('jeff')
         new ConnectionString('mongodb://localhost/?' +
-                           'authMechanism=MONGODB-X509')      | asList(createMongoX509Credential())
+                           'authMechanism=MONGODB-X509')      | createMongoX509Credential()
         new ConnectionString('mongodb://jeff@localhost/?' +
                            'authMechanism=GSSAPI' +
-                           '&gssapiServiceName=foo')          | asList(createGSSAPICredential('jeff')
-                                                                            .withMechanismProperty('SERVICE_NAME', 'foo'))
+                           '&gssapiServiceName=foo')          | createGSSAPICredential('jeff')
+                                                                            .withMechanismProperty('SERVICE_NAME', 'foo')
         new ConnectionString('mongodb://jeff@localhost/?' +
                              'authMechanism=GSSAPI' +
                              '&authMechanismProperties=' +
-                             'SERVICE_NAME:foo')              | asList(createGSSAPICredential('jeff')
-                                                                            .withMechanismProperty('SERVICE_NAME', 'foo'))
+                             'SERVICE_NAME:foo')              | createGSSAPICredential('jeff')
+                                                                            .withMechanismProperty('SERVICE_NAME', 'foo')
         new ConnectionString('mongodb://jeff@localhost/?' +
                              'authMechanism=GSSAPI' +
                              '&authMechanismProperties=' +
-                             'SERVICE_NAME :foo')              | asList(createGSSAPICredential('jeff')
-                                                                            .withMechanismProperty('SERVICE_NAME', 'foo'))
+                             'SERVICE_NAME :foo')              | createGSSAPICredential('jeff')
+                                                                            .withMechanismProperty('SERVICE_NAME', 'foo')
         new ConnectionString('mongodb://jeff@localhost/?' +
                              'authMechanism=GSSAPI' +
                              '&authMechanismProperties=' +
                              'SERVICE_NAME:foo,' +
                              'CANONICALIZE_HOST_NAME:true,' +
-                             'SERVICE_REALM:AWESOME')        | asList(createGSSAPICredential('jeff')
+                             'SERVICE_REALM:AWESOME')        | createGSSAPICredential('jeff')
                                                                           .withMechanismProperty('SERVICE_NAME', 'foo')
                                                                           .withMechanismProperty('CANONICALIZE_HOST_NAME', true)
-                                                                          .withMechanismProperty('SERVICE_REALM', 'AWESOME'))
+                                                                          .withMechanismProperty('SERVICE_REALM', 'AWESOME')
     }
 
     def 'should ignore authSource if there is no credential'() {

--- a/driver-core/src/test/unit/com/mongodb/ConnectionStringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/ConnectionStringTest.java
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-package com.mongodb.client;
+package com.mongodb;
 
-import com.mongodb.AuthenticationMechanism;
-import com.mongodb.ConnectionString;
-import com.mongodb.MongoCredential;
 import junit.framework.TestCase;
 import org.bson.BsonDocument;
 import org.bson.BsonValue;
@@ -125,7 +122,7 @@ public class ConnectionStringTest extends TestCase {
         for (Map.Entry<String, BsonValue> option : definition.getDocument("options").entrySet()) {
             if (option.getKey().equals("authmechanism")) {
                 String expected = option.getValue().asString().getValue();
-                String actual = connectionString.getCredentialList().get(0).getAuthenticationMechanism().getMechanismName();
+                String actual = connectionString.getCredential().getAuthenticationMechanism().getMechanismName();
                 assertEquals(expected, actual);
             } else if (option.getKey().equals("replicaset")) {
                 String expected = option.getValue().asString().getValue();
@@ -161,9 +158,8 @@ public class ConnectionStringTest extends TestCase {
         if (connectionString.getPassword() != null) {
             password = new String(connectionString.getPassword());
         }
-        List<MongoCredential> credentials = connectionString.getCredentialList();
-        if (credentials.size() > 0) {
-            AuthenticationMechanism mechanism = credentials.get(0).getAuthenticationMechanism();
+        if (connectionString.getCredential() != null) {
+            AuthenticationMechanism mechanism = connectionString.getCredential().getAuthenticationMechanism();
             if (mechanism == null) {
                 assertString("auth.password", password);
             } else {

--- a/driver/src/main/com/mongodb/MongoClient.java
+++ b/driver/src/main/com/mongodb/MongoClient.java
@@ -36,6 +36,7 @@ import java.util.List;
 
 import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 
 /**
@@ -47,7 +48,7 @@ import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
  * MongoClient mongoClient1 = new MongoClient("localhost");
  * MongoClient mongoClient2 = new MongoClient("localhost", 27017);
  * MongoClient mongoClient4 = new MongoClient(new ServerAddress("localhost"));
- * MongoClient mongoClient5 = new MongoClient(new ServerAddress("localhost"), new MongoClientOptions.Builder().build());
+ * MongoClient mongoClient5 = new MongoClient(new ServerAddress("localhost"), MongoClientOptions.builder().build());
  * </pre>
  * <p>You can connect to a <a href="http://www.mongodb.org/display/DOCS/Replica+Sets">replica set</a> using the Java driver by passing a
  * ServerAddress list to the MongoClient constructor. For example:</p>
@@ -171,9 +172,11 @@ public class MongoClient extends Mongo implements Closeable {
      * @param credentialsList the list of credentials used to authenticate all connections
      * @see com.mongodb.ServerAddress
      * @since 2.11.0
+     * @deprecated Prefer {@link #MongoClient(ServerAddress, MongoCredential, MongoClientOptions)}
      */
+    @Deprecated
     public MongoClient(final ServerAddress addr, final List<MongoCredential> credentialsList) {
-        this(addr, credentialsList, new MongoClientOptions.Builder().build());
+        this(addr, credentialsList, MongoClientOptions.builder().build());
     }
 
     /**
@@ -195,9 +198,24 @@ public class MongoClient extends Mongo implements Closeable {
      * @param options         default options
      * @see com.mongodb.ServerAddress
      * @since 2.11.0
+     * @deprecated Prefer {@link #MongoClient(ServerAddress, MongoCredential, MongoClientOptions)}
      */
+    @Deprecated
     public MongoClient(final ServerAddress addr, final List<MongoCredential> credentialsList, final MongoClientOptions options) {
         super(addr, credentialsList, options);
+    }
+
+    /**
+     * Creates a Mongo instance based on a (single) mongo node using a given server address, credential, and options
+     *
+     * @param addr            the database address
+     * @param credential      the credential used to authenticate all connections
+     * @param options         default options
+     * @see com.mongodb.ServerAddress
+     * @since 3.6.0
+     */
+    public MongoClient(final ServerAddress addr, final MongoCredential credential, final MongoClientOptions options) {
+        super(addr, singletonList(credential), options);
     }
 
     /**
@@ -234,7 +252,9 @@ public class MongoClient extends Mongo implements Closeable {
      * @param credentialsList the list of credentials used to authenticate all connections
      * @see MongoClientOptions#getLocalThreshold()
      * @since 2.11.0
+     * @deprecated Prefer {@link #MongoClient(List, MongoCredential, MongoClientOptions)}
      */
+    @Deprecated
     public MongoClient(final List<ServerAddress> seeds, final List<MongoCredential> credentialsList) {
         this(seeds, credentialsList, new MongoClientOptions.Builder().build());
     }
@@ -276,9 +296,33 @@ public class MongoClient extends Mongo implements Closeable {
      * @param options         the options
      * @see MongoClientOptions#getLocalThreshold()
      * @since 2.11.0
+     * @deprecated Prefer {@link #MongoClient(List, MongoCredential, MongoClientOptions)}
      */
+    @Deprecated
     public MongoClient(final List<ServerAddress> seeds, final List<MongoCredential> credentialsList, final MongoClientOptions options) {
         super(seeds, credentialsList, options);
+    }
+
+    /**
+     * <p>Creates an instance based on a list of replica set members or mongos servers. For a replica set it will discover all members.
+     * For a list with a single seed, the driver will still discover all members of the replica set.  For a direct
+     * connection to a replica set member, with no discovery, use the {@link #MongoClient(ServerAddress, List, MongoClientOptions)}
+     * constructor instead.</p>
+     *
+     * <p>When there is more than one server to choose from based on the type of request (read or write) and the read preference (if it's a
+     * read request), the driver will randomly select a server to send a request. This applies to both replica sets and sharded clusters.
+     * The servers to randomly select from are further limited by the local threshold.  See
+     * {@link MongoClientOptions#getLocalThreshold()}</p>
+     *
+     * @param seeds Put as many servers as you can in the list and the system will figure out the rest.  This can either be a list of mongod
+     *              servers in the same replica set or a list of mongos servers in the same sharded cluster.
+     * @param credential the credential used to authenticate all connections
+     * @param options         the options
+     * @see MongoClientOptions#getLocalThreshold()
+     * @since 3.6.0
+     */
+    public MongoClient(final List<ServerAddress> seeds, final MongoCredential credential, final MongoClientOptions options) {
+        super(seeds, singletonList(credential), options);
     }
 
     /**
@@ -317,10 +361,29 @@ public class MongoClient extends Mongo implements Closeable {
      * @param mongoDriverInformation any driver information to associate with the MongoClient
      * @see com.mongodb.ServerAddress
      * @since 3.4
+     * @deprecated Prefer {@link #MongoClient(ServerAddress, MongoCredential, MongoClientOptions, MongoDriverInformation)}
      */
+    @Deprecated
     public MongoClient(final ServerAddress addr, final List<MongoCredential> credentialsList, final MongoClientOptions options,
                        final MongoDriverInformation mongoDriverInformation) {
         super(addr, credentialsList, options, mongoDriverInformation);
+    }
+
+    /**
+     * Creates a MongoClient to a single node using a given ServerAddress.
+     *
+     * <p>Note: Intended for driver and library authors to associate extra driver metadata with the connections.</p>
+     *
+     * @param addr            the database address
+     * @param credential      the credential used to authenticate all connections
+     * @param options         default options
+     * @param mongoDriverInformation any driver information to associate with the MongoClient
+     * @see com.mongodb.ServerAddress
+     * @since 3.6
+     */
+    public MongoClient(final ServerAddress addr, final MongoCredential credential, final MongoClientOptions options,
+                       final MongoDriverInformation mongoDriverInformation) {
+        super(addr, singletonList(credential), options, mongoDriverInformation);
     }
 
     /**
@@ -334,10 +397,29 @@ public class MongoClient extends Mongo implements Closeable {
      * @param options         the options
      * @param mongoDriverInformation any driver information to associate with the MongoClient
      * @since 3.4
+     * @deprecated Prefer {@link #MongoClient(List, MongoCredential, MongoClientOptions, MongoDriverInformation)}
      */
+    @Deprecated
     public MongoClient(final List<ServerAddress> seeds, final List<MongoCredential> credentialsList, final MongoClientOptions options,
                        final MongoDriverInformation mongoDriverInformation) {
         super(seeds, credentialsList, options, mongoDriverInformation);
+    }
+
+    /**
+     * Creates a MongoClient
+     *
+     * <p>Note: Intended for driver and library authors to associate extra driver metadata with the connections.</p>
+     *
+     * @param seeds Put as many servers as you can in the list and the system will figure out the rest.  This can either be a list of mongod
+     *              servers in the same replica set or a list of mongos servers in the same sharded cluster.
+     * @param credential      the credential used to authenticate all connections
+     * @param options         the options
+     * @param mongoDriverInformation any driver information to associate with the MongoClient
+     * @since 3.6
+     */
+    public MongoClient(final List<ServerAddress> seeds, final MongoCredential credential, final MongoClientOptions options,
+                       final MongoDriverInformation mongoDriverInformation) {
+        super(seeds, singletonList(credential), options, mongoDriverInformation);
     }
 
     /**

--- a/driver/src/main/com/mongodb/MongoClientURI.java
+++ b/driver/src/main/com/mongodb/MongoClientURI.java
@@ -272,11 +272,7 @@ public class MongoClientURI {
      * @return the credentials
      */
     public MongoCredential getCredentials() {
-        if (proxied.getCredentialList().isEmpty()) {
-            return null;
-        } else {
-            return proxied.getCredentialList().get(0);
-        }
+        return proxied.getCredential();
     }
 
     /**

--- a/driver/src/test/unit/com/mongodb/MongoConstructorsTest.java
+++ b/driver/src/test/unit/com/mongodb/MongoConstructorsTest.java
@@ -21,7 +21,6 @@ import org.junit.Test;
 
 import java.net.UnknownHostException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -72,13 +71,6 @@ public class MongoConstructorsTest {
     }
 
     @Test
-    public void shouldUseGivenCredentials() throws UnknownHostException {
-        Mongo mongo = new MongoClient(new ServerAddress(),
-                                      Arrays.asList(MongoCredential.createMongoCRCredential("user", "admin", "pwd".toCharArray())));
-        mongo.close();
-    }
-
-    @Test
     public void shouldDefaultToPrimaryReadPreference() throws UnknownHostException {
         Mongo mongo = new MongoClient();
         try {
@@ -93,8 +85,7 @@ public class MongoConstructorsTest {
         Mongo mongo = new MongoClient("localhost", MongoClientOptions.builder().requiredReplicaSetName("test").build());
         mongo.close();
 
-        mongo = new MongoClient(new ServerAddress(), Collections.<MongoCredential>emptyList(),
-                                MongoClientOptions.builder().requiredReplicaSetName("test").build());
+        mongo = new MongoClient(new ServerAddress(), MongoClientOptions.builder().requiredReplicaSetName("test").build());
         mongo.close();
 
         mongo = new MongoClient(new MongoClientURI("mongodb://localhost/?setName=test"));


### PR DESCRIPTION
This turned out to touch more places than I realized.  I think I found them all, though I didn't bother with DefaultClusterFactory