### PR TITLE
JAVA-2663: Exclude arbiters and ghosts from session-support determination

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/ClusterDescription.java
+++ b/driver-core/src/main/com/mongodb/connection/ClusterDescription.java
@@ -178,7 +178,7 @@ public class ClusterDescription {
         for (ServerDescription cur : getServersByPredicate(new Predicate() {
             @Override
             public boolean apply(final ServerDescription serverDescription) {
-                return serverDescription.isOk();
+                return serverDescription.isPrimary() || serverDescription.isSecondary();
             }
         })) {
             if (cur.getLogicalSessionTimeoutMinutes() == null) {

--- a/driver-core/src/test/resources/server-discovery-and-monitoring/rs/ls_timeout.json
+++ b/driver-core/src/test/resources/server-discovery-and-monitoring/rs/ls_timeout.json
@@ -11,14 +11,127 @@
             "ismaster": true,
             "hosts": [
               "a:27017",
-              "b:27017"
+              "b:27017",
+              "c:27017",
+              "d:27017",
+              "e:27017"
             ],
             "setName": "rs",
-            "logicalSessionTimeoutMinutes": 1,
+            "logicalSessionTimeoutMinutes": 3,
             "minWireVersion": 0,
             "maxWireVersion": 6
           }
-        ],
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          },
+          "c:27017": {
+            "type": "Unknown"
+          },
+          "d:27017": {
+            "type": "Unknown"
+          },
+          "e:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": 3,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "d:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "isreplicaset": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          },
+          "c:27017": {
+            "type": "Unknown"
+          },
+          "d:27017": {
+            "type": "RSGhost"
+          },
+          "e:27017": {
+            "type": "Unknown"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": 3,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
+        [
+          "e:27017",
+          {
+            "ok": 1,
+            "ismaster": false,
+            "hosts": [
+              "a:27017",
+              "b:27017",
+              "c:27017",
+              "d:27017",
+              "e:27017"
+            ],
+            "setName": "rs",
+            "arbiterOnly": true,
+            "minWireVersion": 0,
+            "maxWireVersion": 6
+          }
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "Unknown"
+          },
+          "c:27017": {
+            "type": "Unknown"
+          },
+          "d:27017": {
+            "type": "RSGhost"
+          },
+          "e:27017": {
+            "type": "RSArbiter",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": 3,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
         [
           "b:27017",
           {
@@ -27,7 +140,10 @@
             "secondary": true,
             "hosts": [
               "a:27017",
-              "b:27017"
+              "b:27017",
+              "c:27017",
+              "d:27017",
+              "e:27017"
             ],
             "setName": "rs",
             "logicalSessionTimeoutMinutes": 2,
@@ -45,30 +161,67 @@
           "b:27017": {
             "type": "RSSecondary",
             "setName": "rs"
+          },
+          "c:27017": {
+            "type": "Unknown"
+          },
+          "d:27017": {
+            "type": "RSGhost"
+          },
+          "e:27017": {
+            "type": "RSArbiter",
+            "setName": "rs"
           }
         },
         "topologyType": "ReplicaSetWithPrimary",
-        "logicalSessionTimeoutMinutes": 1,
+        "logicalSessionTimeoutMinutes": 2,
         "setName": "rs"
       }
     },
     {
       "responses": [
         [
-          "a:27017",
+          "c:27017",
           {
             "ok": 1,
-            "ismaster": true,
-            "hosts": [
-              "a:27017",
-              "b:27017"
-            ],
+            "ismaster": false,
             "setName": "rs",
+            "hidden": true,
             "logicalSessionTimeoutMinutes": 1,
             "minWireVersion": 0,
             "maxWireVersion": 6
           }
-        ],
+        ]
+      ],
+      "outcome": {
+        "servers": {
+          "a:27017": {
+            "type": "RSPrimary",
+            "setName": "rs"
+          },
+          "b:27017": {
+            "type": "RSSecondary",
+            "setName": "rs"
+          },
+          "c:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "d:27017": {
+            "type": "RSGhost"
+          },
+          "e:27017": {
+            "type": "RSArbiter",
+            "setName": "rs"
+          }
+        },
+        "topologyType": "ReplicaSetWithPrimary",
+        "logicalSessionTimeoutMinutes": 2,
+        "setName": "rs"
+      }
+    },
+    {
+      "responses": [
         [
           "b:27017",
           {
@@ -77,7 +230,10 @@
             "secondary": true,
             "hosts": [
               "a:27017",
-              "b:27017"
+              "b:27017",
+              "c:27017",
+              "d:27017",
+              "e:27017"
             ],
             "setName": "rs",
             "logicalSessionTimeoutMinutes": null,
@@ -94,6 +250,17 @@
           },
           "b:27017": {
             "type": "RSSecondary",
+            "setName": "rs"
+          },
+          "c:27017": {
+            "type": "RSOther",
+            "setName": "rs"
+          },
+          "d:27017": {
+            "type": "RSGhost"
+          },
+          "e:27017": {
+            "type": "RSArbiter",
             "setName": "rs"
           }
         },

--- a/driver-core/src/test/unit/com/mongodb/connection/ClusterDescriptionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ClusterDescriptionTest.java
@@ -31,7 +31,10 @@ import java.util.Iterator;
 import java.util.List;
 
 import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE;
+import static com.mongodb.connection.ClusterConnectionMode.SINGLE;
 import static com.mongodb.connection.ClusterType.REPLICA_SET;
+import static com.mongodb.connection.ClusterType.SHARDED;
+import static com.mongodb.connection.ClusterType.STANDALONE;
 import static com.mongodb.connection.ClusterType.UNKNOWN;
 import static com.mongodb.connection.ServerConnectionState.CONNECTED;
 import static com.mongodb.connection.ServerConnectionState.CONNECTING;
@@ -254,10 +257,60 @@ public class ClusterDescriptionTest {
         ));
         assertEquals(null, description.getLogicalSessionTimeoutMinutes());
 
+        description = new ClusterDescription(SINGLE, STANDALONE, asList(
+                builder().state(CONNECTED)
+                        .ok(true)
+                        .address(new ServerAddress("loc:27017"))
+                        .type(ServerType.STANDALONE)
+                        .logicalSessionTimeoutMinutes(5)
+                        .build()
+        ));
+        assertEquals(new Integer(5), description.getLogicalSessionTimeoutMinutes());
+
+        description = new ClusterDescription(SINGLE, SHARDED, asList(
+                builder().state(CONNECTED)
+                        .ok(true)
+                        .address(new ServerAddress("loc:27017"))
+                        .type(ServerType.SHARD_ROUTER)
+                        .logicalSessionTimeoutMinutes(5)
+                        .build()
+        ));
+        assertEquals(new Integer(5), description.getLogicalSessionTimeoutMinutes());
+
+        description = new ClusterDescription(MULTIPLE, SHARDED, asList(
+                builder().state(CONNECTED)
+                        .ok(true)
+                        .address(new ServerAddress("loc:27017"))
+                        .type(ServerType.SHARD_ROUTER)
+                        .logicalSessionTimeoutMinutes(5)
+                        .build(),
+                builder().state(CONNECTING)
+                        .address(new ServerAddress("loc:27018"))
+                        .build()
+        ));
+        assertEquals(new Integer(5), description.getLogicalSessionTimeoutMinutes());
+
+        description = new ClusterDescription(MULTIPLE, SHARDED, asList(
+                builder().state(CONNECTED)
+                        .ok(true)
+                        .address(new ServerAddress("loc:27017"))
+                        .type(ServerType.SHARD_ROUTER)
+                        .logicalSessionTimeoutMinutes(5)
+                        .build(),
+                builder().state(CONNECTED)
+                        .ok(true)
+                        .address(new ServerAddress("loc:27018"))
+                        .type(ServerType.SHARD_ROUTER)
+                        .logicalSessionTimeoutMinutes(3)
+                        .build()
+        ));
+        assertEquals(new Integer(3), description.getLogicalSessionTimeoutMinutes());
+
         description = new ClusterDescription(MULTIPLE, REPLICA_SET, asList(
                 builder().state(CONNECTED)
                         .ok(true)
                         .address(new ServerAddress("loc:27017"))
+                        .type(ServerType.REPLICA_SET_PRIMARY)
                         .logicalSessionTimeoutMinutes(5)
                         .build(),
                 builder().state(CONNECTING)
@@ -270,15 +323,17 @@ public class ClusterDescriptionTest {
                 builder().state(CONNECTED)
                         .ok(true)
                         .address(new ServerAddress("loc:27017"))
+                        .type(REPLICA_SET_PRIMARY)
                         .logicalSessionTimeoutMinutes(5)
                         .build(),
                 builder().state(CONNECTED)
                         .ok(true)
                         .address(new ServerAddress("loc:27018"))
+                        .type(REPLICA_SET_SECONDARY)
                         .logicalSessionTimeoutMinutes(3)
                         .build(),
                 builder().state(CONNECTING)
-                        .address(new ServerAddress("loc:27017"))
+                        .address(new ServerAddress("loc:27019"))
                         .build()
         ));
         assertEquals(new Integer(3), description.getLogicalSessionTimeoutMinutes());
@@ -287,15 +342,17 @@ public class ClusterDescriptionTest {
                 builder().state(CONNECTED)
                         .ok(true)
                         .address(new ServerAddress("loc:27017"))
+                        .type(REPLICA_SET_PRIMARY)
                         .logicalSessionTimeoutMinutes(3)
                         .build(),
                 builder().state(CONNECTED)
                         .ok(true)
                         .address(new ServerAddress("loc:27018"))
+                        .type(REPLICA_SET_SECONDARY)
                         .logicalSessionTimeoutMinutes(5)
                         .build(),
                 builder().state(CONNECTING)
-                        .address(new ServerAddress("loc:27017"))
+                        .address(new ServerAddress("loc:27019"))
                         .build()
         ));
         assertEquals(new Integer(3), description.getLogicalSessionTimeoutMinutes());

--- a/driver/src/main/com/mongodb/Mongo.java
+++ b/driver/src/main/com/mongodb/Mongo.java
@@ -864,19 +864,27 @@ public class Mongo {
         }
     }
 
-    @SuppressWarnings("deprecation")
     private ClusterDescription getConnectedClusterDescription() {
         ClusterDescription clusterDescription = cluster.getDescription();
-        if (clusterDescription.getAny().isEmpty()) {
+        if (getServerDescriptionListToConsiderForSessionSupport(clusterDescription).isEmpty()) {
             cluster.selectServer(new ServerSelector() {
                 @Override
                 public List<ServerDescription> select(final ClusterDescription clusterDescription) {
-                    return clusterDescription.getAny();
+                    return getServerDescriptionListToConsiderForSessionSupport(clusterDescription);
                 }
             });
             clusterDescription = cluster.getDescription();
         }
         return clusterDescription;
+    }
+
+    @SuppressWarnings("deprecation")
+    private List<ServerDescription> getServerDescriptionListToConsiderForSessionSupport(final ClusterDescription clusterDescription) {
+        if (clusterDescription.getConnectionMode() == ClusterConnectionMode.SINGLE) {
+            return clusterDescription.getAny();
+        } else {
+            return clusterDescription.getAnyPrimaryOrSecondary();
+        }
     }
 
     static class ClientSessionImpl implements ClientSession {


### PR DESCRIPTION
Consider only data-bearing servers (Mongos, Standalone, Primary, and Secondary) when determining whether sessions are supported.

This excludes, in particular, arbiters and "ghosts" 

Patch build: https://evergreen.mongodb.com/version/5a0afde1e3c331553d015b47
Spec change: https://github.com/mongodb/specifications/commit/096ee19b251319bf59f3cf8b9411541c91beba80