### PR TITLE
JAVA-2660: Improve error messages for MongoIncompatibleDriverException

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/ClusterDescription.java
+++ b/driver-core/src/main/com/mongodb/connection/ClusterDescription.java
@@ -101,17 +101,47 @@ public class ClusterDescription {
     }
 
     /**
-     * Return whether the cluster is compatible with the driver.
+     * Return whether all servers in the cluster are compatible with the driver.
      *
-     * @return true if the cluster is compatible with the driver.
+     * @return true if all servers in the cluster are compatible with the driver
      */
     public boolean isCompatibleWithDriver() {
-        for (final ServerDescription cur : serverDescriptions) {
+        for (ServerDescription cur : serverDescriptions) {
             if (!cur.isCompatibleWithDriver()) {
                 return false;
             }
         }
         return true;
+    }
+
+    /**
+     * Return a server in the cluster that is incompatibly older than the driver.
+     *
+     * @return a server in the cluster that is incompatibly older than the driver, or null if there are none
+     * @since 3.6
+     */
+    public ServerDescription findServerIncompatiblyOlderThanDriver() {
+        for (ServerDescription cur : serverDescriptions) {
+            if (cur.isIncompatiblyOlderThanDriver()) {
+                return cur;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Return a server in the cluster that is incompatibly newer than the driver.
+     *
+     * @return a server in the cluster that is incompatibly newer than the driver, or null if there are none
+     * @since 3.6
+     */
+    public ServerDescription findServerIncompatiblyNewerThanDriver() {
+        for (ServerDescription cur : serverDescriptions) {
+            if (cur.isIncompatiblyNewerThanDriver()) {
+                return cur;
+            }
+        }
+        return null;
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/connection/ServerDescription.java
+++ b/driver-core/src/main/com/mongodb/connection/ServerDescription.java
@@ -46,6 +46,7 @@ import static com.mongodb.connection.ServerType.UNKNOWN;
 @Immutable
 public class ServerDescription {
 
+    static final String MIN_DRIVER_SERVER_VERSION = "2.6";
     static final int MIN_DRIVER_WIRE_VERSION = 1;
     static final int MAX_DRIVER_WIRE_VERSION = 6;
 
@@ -429,19 +430,37 @@ public class ServerDescription {
      * @return true if the server is compatible with the driver.
      */
     public boolean isCompatibleWithDriver() {
-        if (!ok) {
-            return true;
-        }
-
-        if (minWireVersion > MAX_DRIVER_WIRE_VERSION) {
+        if (isIncompatiblyOlderThanDriver()) {
             return false;
         }
 
-        if (maxWireVersion < MIN_DRIVER_WIRE_VERSION) {
+        if (isIncompatiblyNewerThanDriver()) {
             return false;
         }
 
         return true;
+    }
+
+    /**
+     * Return whether the server is compatible with the driver. An incompatible server is one that has a min wire version greater that the
+     * driver's max wire version or a max wire version less than the driver's min wire version.
+     *
+     * @return true if the server is compatible with the driver.
+     * @since 3.6
+     */
+    public boolean isIncompatiblyNewerThanDriver() {
+        return ok && minWireVersion > MAX_DRIVER_WIRE_VERSION;
+    }
+
+    /**
+     * Return whether the server is compatible with the driver. An incompatible server is one that has a min wire version greater that the
+     * driver's max wire version or a max wire version less than the driver's min wire version.
+     *
+     * @return true if the server is compatible with the driver.
+     * @since 3.6
+     */
+    public boolean isIncompatiblyOlderThanDriver() {
+        return ok && maxWireVersion < MIN_DRIVER_WIRE_VERSION;
     }
 
     /**

--- a/driver-core/src/test/unit/com/mongodb/connection/ClusterDescriptionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ClusterDescriptionTest.java
@@ -264,7 +264,7 @@ public class ClusterDescriptionTest {
                         .address(new ServerAddress("loc:27018"))
                         .build()
         ));
-        assertEquals(new Integer(5), description.getLogicalSessionTimeoutMinutes());
+        assertEquals(Integer.valueOf(5), description.getLogicalSessionTimeoutMinutes());
 
         description = new ClusterDescription(MULTIPLE, REPLICA_SET, asList(
                 builder().state(CONNECTED)
@@ -281,7 +281,7 @@ public class ClusterDescriptionTest {
                         .address(new ServerAddress("loc:27017"))
                         .build()
         ));
-        assertEquals(new Integer(3), description.getLogicalSessionTimeoutMinutes());
+        assertEquals(Integer.valueOf(3), description.getLogicalSessionTimeoutMinutes());
 
         description = new ClusterDescription(MULTIPLE, REPLICA_SET, asList(
                 builder().state(CONNECTED)
@@ -298,7 +298,7 @@ public class ClusterDescriptionTest {
                         .address(new ServerAddress("loc:27017"))
                         .build()
         ));
-        assertEquals(new Integer(3), description.getLogicalSessionTimeoutMinutes());
+        assertEquals(Integer.valueOf(3), description.getLogicalSessionTimeoutMinutes());
     }
 
     @Test

--- a/driver-core/src/test/unit/com/mongodb/connection/ServerDescriptionTest.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/ServerDescriptionTest.java
@@ -437,63 +437,69 @@ public class ServerDescriptionTest {
 
     @Test
     public void notOkServerShouldBeCompatible() throws UnknownHostException {
-        assertTrue(builder()
-                                    .address(new ServerAddress())
-                                    .state(CONNECTING)
-                                    .ok(false)
-                                    .build()
-                                    .isCompatibleWithDriver());
+        ServerDescription serverDescription = builder()
+                .address(new ServerAddress())
+                .state(CONNECTING)
+                .ok(false)
+                .build();
+        assertTrue(serverDescription.isCompatibleWithDriver());
+        assertFalse(serverDescription.isIncompatiblyNewerThanDriver());
+        assertFalse(serverDescription.isIncompatiblyOlderThanDriver());
     }
 
     @Test
     public void serverWithMinWireVersionEqualToDriverMaxWireVersionShouldBeCompatible() throws UnknownHostException {
-        assertTrue(builder()
-                                    .address(new ServerAddress())
-                                    .state(CONNECTING)
-                                    .ok(true)
-                                    .minWireVersion(MAX_DRIVER_WIRE_VERSION)
-                                    .maxWireVersion(MAX_DRIVER_WIRE_VERSION + 1)
-                                    .build()
-                                    .isCompatibleWithDriver());
-
+        ServerDescription serverDescription = builder()
+                .address(new ServerAddress())
+                .state(CONNECTING)
+                .ok(true)
+                .minWireVersion(MAX_DRIVER_WIRE_VERSION)
+                .maxWireVersion(MAX_DRIVER_WIRE_VERSION + 1)
+                .build();
+        assertTrue(serverDescription.isCompatibleWithDriver());
+        assertFalse(serverDescription.isIncompatiblyNewerThanDriver());
+        assertFalse(serverDescription.isIncompatiblyOlderThanDriver());
     }
 
     @Test
     public void serverWithMaxWireVersionEqualToDriverMinWireVersionShouldBeCompatible() throws UnknownHostException {
-        assertTrue(builder()
-                                    .address(new ServerAddress())
-                                    .state(CONNECTING)
-                                    .ok(true)
-                                    .minWireVersion(MIN_DRIVER_WIRE_VERSION - 1)
-                                    .maxWireVersion(MIN_DRIVER_WIRE_VERSION)
-                                    .build()
-                                    .isCompatibleWithDriver());
-
+        ServerDescription serverDescription = builder()
+                .address(new ServerAddress())
+                .state(CONNECTING)
+                .ok(true)
+                .minWireVersion(MIN_DRIVER_WIRE_VERSION - 1)
+                .maxWireVersion(MIN_DRIVER_WIRE_VERSION)
+                .build();
+        assertTrue(serverDescription.isCompatibleWithDriver());
+        assertFalse(serverDescription.isIncompatiblyNewerThanDriver());
+        assertFalse(serverDescription.isIncompatiblyOlderThanDriver());
     }
 
     @Test
     public void serverWithMinWireVersionGreaterThanDriverMaxWireVersionShouldBeIncompatible() throws UnknownHostException {
-        assertFalse(builder()
-                                     .address(new ServerAddress())
-                                     .state(CONNECTING)
-                                     .ok(true)
-                                     .minWireVersion(MAX_DRIVER_WIRE_VERSION + 1)
-                                     .maxWireVersion(MAX_DRIVER_WIRE_VERSION + 1)
-                                     .build()
-                                     .isCompatibleWithDriver());
-
+        ServerDescription serverDescription = builder()
+                .address(new ServerAddress())
+                .state(CONNECTING)
+                .ok(true)
+                .minWireVersion(MAX_DRIVER_WIRE_VERSION + 1)
+                .maxWireVersion(MAX_DRIVER_WIRE_VERSION + 1)
+                .build();
+        assertFalse(serverDescription.isCompatibleWithDriver());
+        assertTrue(serverDescription.isIncompatiblyNewerThanDriver());
+        assertFalse(serverDescription.isIncompatiblyOlderThanDriver());
     }
 
     @Test
     public void serverWithMaxWireVersionLessThanDriverMinWireVersionShouldBeIncompatible() throws UnknownHostException {
-        assertFalse(builder()
-                                     .address(new ServerAddress())
-                                     .state(CONNECTING)
-                                     .ok(true)
-                                     .minWireVersion(MIN_DRIVER_WIRE_VERSION - 1)
-                                     .maxWireVersion(MIN_DRIVER_WIRE_VERSION - 1)
-                                     .build()
-                                     .isCompatibleWithDriver());
-
+        ServerDescription serverDescription = builder()
+                .address(new ServerAddress())
+                .state(CONNECTING)
+                .ok(true)
+                .minWireVersion(MIN_DRIVER_WIRE_VERSION - 1)
+                .maxWireVersion(MIN_DRIVER_WIRE_VERSION - 1)
+                .build();
+        assertFalse(serverDescription.isCompatibleWithDriver());
+        assertFalse(serverDescription.isIncompatiblyNewerThanDriver());
+        assertTrue(serverDescription.isIncompatiblyOlderThanDriver());
     }
 }


### PR DESCRIPTION
Improve error messages for MongoIncompatibleDriverException

https://jira.mongodb.org/browse/JAVA-2660

Patch build: https://evergreen.mongodb.com/version/5a0b288ae3c3315e3b000618