### PR TITLE
JAVA-2666: Application-configured server selector

### DIFF
--- a/driver-core/src/main/com/mongodb/selector/ServerSelector.java
+++ b/driver-core/src/main/com/mongodb/selector/ServerSelector.java
@@ -23,7 +23,7 @@ import com.mongodb.connection.ServerDescription;
 import java.util.List;
 
 /**
- * <p>An interface for selecting a server from a cluster according some preference.</p>
+ * <p>An interface for selecting a server from a cluster according to some preference.</p>
  *
  * <p>Implementations of this interface should ensure that their equals and hashCode methods compare equal preferences as equal, as users of
  * this interface may rely on that behavior to efficiently consolidate handling of multiple requests waiting on a server that can satisfy

--- a/driver/src/main/com/mongodb/MongoClientOptions.java
+++ b/driver/src/main/com/mongodb/MongoClientOptions.java
@@ -18,6 +18,7 @@ package com.mongodb;
 
 import com.mongodb.annotations.Immutable;
 import com.mongodb.annotations.NotThreadSafe;
+import com.mongodb.connection.ClusterDescription;
 import com.mongodb.connection.ConnectionPoolSettings;
 import com.mongodb.connection.ServerSettings;
 import com.mongodb.connection.SocketSettings;
@@ -27,6 +28,7 @@ import com.mongodb.event.CommandListener;
 import com.mongodb.event.ConnectionPoolListener;
 import com.mongodb.event.ServerListener;
 import com.mongodb.event.ServerMonitorListener;
+import com.mongodb.selector.ServerSelector;
 import org.bson.codecs.configuration.CodecRegistry;
 
 import javax.net.SocketFactory;
@@ -65,6 +67,7 @@ public class MongoClientOptions {
     private final boolean retryWrites;
     private final ReadConcern readConcern;
     private final CodecRegistry codecRegistry;
+    private final ServerSelector serverSelector;
 
     private final int minConnectionsPerHost;
     private final int maxConnectionsPerHost;
@@ -121,6 +124,7 @@ public class MongoClientOptions {
         retryWrites = builder.retryWrites;
         readConcern = builder.readConcern;
         codecRegistry = builder.codecRegistry;
+        serverSelector = builder.serverSelector;
         sslEnabled = builder.sslEnabled;
         sslInvalidHostNameAllowed = builder.sslInvalidHostNameAllowed;
         sslContext = builder.sslContext;
@@ -565,6 +569,34 @@ public class MongoClientOptions {
     }
 
     /**
+     * Gets the server selector.
+     *
+     * <p>The server selector augments the normal server selection rules applied by the driver when determining
+     * which server to send an operation to.  At the point that it's called by the driver, the
+     * {@link com.mongodb.connection.ClusterDescription} which is passed to it contains a list of
+     * {@link com.mongodb.connection.ServerDescription} instances which satisfy either the configured {@link ReadPreference} for any
+     * read operation or ones that can take writes (e.g. a standalone, mongos, or replica set primary).</p>
+     * <p>The server selector can then filter the {@code ServerDescription} list using whatever criteria that is required by the
+     * application.</p>
+     * <p>After this selector executes, two additional selectors are applied by the driver:</p>
+     * <ul>
+     * <li>select from within the latency window</li>
+     * <li>select a random server from those remaining</li>
+     * </ul>
+     * <p>To skip the latency window selector, an application can:</p>
+     * <ul>
+     * <li>configure the local threshold to a sufficiently high value so that it doesn't exclude any servers</li>
+     * <li>return a list containing a single server from this selector (which will also make the random member selector a no-op)</li>
+     * </ul>
+     *
+     * @return the server selector, which may be null
+     * @since 3.6
+     */
+    public ServerSelector getServerSelector() {
+        return serverSelector;
+    }
+
+    /**
      * Gets the list of added {@code ClusterListener}. The default is an empty list.
      *
      * @return the unmodifiable list of cluster listeners
@@ -799,6 +831,9 @@ public class MongoClientOptions {
         if (!codecRegistry.equals(that.codecRegistry)) {
             return false;
         }
+        if (serverSelector != null ? !serverSelector.equals(that.serverSelector) : that.serverSelector != null) {
+            return false;
+        }
         if (!clusterListeners.equals(that.clusterListeners)) {
             return false;
         }
@@ -828,6 +863,7 @@ public class MongoClientOptions {
         result = 31 * result + (retryWrites ? 1 : 0);
         result = 31 * result + (readConcern != null ? readConcern.hashCode() : 0);
         result = 31 * result + codecRegistry.hashCode();
+        result = 31 * result + (serverSelector != null ? serverSelector.hashCode() : 0);
         result = 31 * result + clusterListeners.hashCode();
         result = 31 * result + commandListeners.hashCode();
         result = 31 * result + minConnectionsPerHost;
@@ -869,6 +905,7 @@ public class MongoClientOptions {
                + ", retryWrites=" + retryWrites
                + ", readConcern=" + readConcern
                + ", codecRegistry=" + codecRegistry
+               + ", serverSelector=" + serverSelector
                + ", clusterListeners=" + clusterListeners
                + ", commandListeners=" + commandListeners
                + ", minConnectionsPerHost=" + minConnectionsPerHost
@@ -923,7 +960,7 @@ public class MongoClientOptions {
         private boolean retryWrites = false;
         private ReadConcern readConcern = ReadConcern.DEFAULT;
         private CodecRegistry codecRegistry = MongoClient.getDefaultCodecRegistry();
-
+        private ServerSelector serverSelector;
         private int minConnectionsPerHost;
         private int maxConnectionsPerHost = 100;
         private int threadsAllowedToBlockForConnectionMultiplier = 5;
@@ -987,6 +1024,7 @@ public class MongoClientOptions {
             retryWrites = options.getRetryWrites();
             readConcern = options.getReadConcern();
             codecRegistry = options.getCodecRegistry();
+            serverSelector = options.getServerSelector();
             sslEnabled = options.isSslEnabled();
             sslInvalidHostNameAllowed = options.isSslInvalidHostNameAllowed();
             sslContext = options.getSslContext();
@@ -1313,6 +1351,38 @@ public class MongoClientOptions {
             return this;
         }
 
+        /**
+         * Sets the server selector.
+         *
+         * <p>The server selector augments the normal server selection rules applied by the driver when determining
+         * which server to send an operation to.  At the point that it's called by the driver, the
+         * {@link com.mongodb.connection.ClusterDescription} which is passed to it contains a list of
+         * {@link com.mongodb.connection.ServerDescription} instances which satisfy either the configured {@link ReadPreference} for any
+         * read operation or ones that can take writes (e.g. a standalone, mongos, or replica set primary).</p>
+         * <p>The server selector can then filter the {@code ServerDescription} list using whatever criteria that is required by the
+         * application.</p>
+         * <p>After this selector executes, two additional selectors are applied by the driver:</p>
+         * <ul>
+         * <li>select from within the latency window</li>
+         * <li>select a random server from those remaining</li>
+         * </ul>
+         * <p>To skip the latency window selector, an application can:</p>
+         * <ul>
+         * <li>configure the local threshold to a sufficiently high value so that it doesn't exclude any servers</li>
+         * <li>return a list containing a single server from this selector (which will also make the random member selector a no-op)</li>
+         * </ul>
+         *
+         * @param serverSelector the server selector
+         * @return this
+         * @since 3.6
+         * @see ReadPreference
+         * @see ClusterDescription#getServerDescriptions()
+         * @see #getLocalThreshold()
+         */
+        public Builder serverSelector(final ServerSelector serverSelector) {
+            this.serverSelector = serverSelector;
+            return this;
+        }
         /**
          * Adds the given command listener.
          *

--- a/driver/src/main/com/mongodb/MongoClientOptions.java
+++ b/driver/src/main/com/mongodb/MongoClientOptions.java
@@ -18,7 +18,6 @@ package com.mongodb;
 
 import com.mongodb.annotations.Immutable;
 import com.mongodb.annotations.NotThreadSafe;
-import com.mongodb.connection.ClusterDescription;
 import com.mongodb.connection.ConnectionPoolSettings;
 import com.mongodb.connection.ServerSettings;
 import com.mongodb.connection.SocketSettings;
@@ -1352,32 +1351,13 @@ public class MongoClientOptions {
         }
 
         /**
-         * Sets the server selector.
-         *
-         * <p>The server selector augments the normal server selection rules applied by the driver when determining
-         * which server to send an operation to.  At the point that it's called by the driver, the
-         * {@link com.mongodb.connection.ClusterDescription} which is passed to it contains a list of
-         * {@link com.mongodb.connection.ServerDescription} instances which satisfy either the configured {@link ReadPreference} for any
-         * read operation or ones that can take writes (e.g. a standalone, mongos, or replica set primary).</p>
-         * <p>The server selector can then filter the {@code ServerDescription} list using whatever criteria that is required by the
-         * application.</p>
-         * <p>After this selector executes, two additional selectors are applied by the driver:</p>
-         * <ul>
-         * <li>select from within the latency window</li>
-         * <li>select a random server from those remaining</li>
-         * </ul>
-         * <p>To skip the latency window selector, an application can:</p>
-         * <ul>
-         * <li>configure the local threshold to a sufficiently high value so that it doesn't exclude any servers</li>
-         * <li>return a list containing a single server from this selector (which will also make the random member selector a no-op)</li>
-         * </ul>
+         * Sets a server selector that augments the normal server selection rules applied by the driver when determining
+         * which server to send an operation to.  See {@link #getServerSelector()} for further details.
          *
          * @param serverSelector the server selector
          * @return this
          * @since 3.6
-         * @see ReadPreference
-         * @see ClusterDescription#getServerDescriptions()
-         * @see #getLocalThreshold()
+         * @see #getServerSelector()
          */
         public Builder serverSelector(final ServerSelector serverSelector) {
             this.serverSelector = serverSelector;

--- a/driver/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/MongoClientOptionsSpecification.groovy
@@ -25,6 +25,7 @@ import com.mongodb.event.CommandListener
 import com.mongodb.event.ConnectionPoolListener
 import com.mongodb.event.ServerListener
 import com.mongodb.event.ServerMonitorListener
+import com.mongodb.selector.ServerSelector
 import spock.lang.IgnoreIf
 import spock.lang.Specification
 
@@ -56,6 +57,7 @@ class MongoClientOptionsSpecification extends Specification {
         options.getConnectionsPerHost() == 100
         options.getConnectTimeout() == 10000
         options.getReadPreference() == ReadPreference.primary()
+        options.getServerSelector() == null;
         options.getThreadsAllowedToBlockForConnectionMultiplier() == 5
         options.isSocketKeepAlive()
         !options.isSslEnabled()
@@ -157,6 +159,7 @@ class MongoClientOptionsSpecification extends Specification {
         given:
         def encoderFactory = new MyDBEncoderFactory()
         def socketFactory = SSLSocketFactory.getDefault()
+        def serverSelector = Mock(ServerSelector)
         def options = MongoClientOptions.builder()
                                         .description('test')
                                         .applicationName('appName')
@@ -167,6 +170,7 @@ class MongoClientOptionsSpecification extends Specification {
                                         .connectionsPerHost(500)
                                         .connectTimeout(100)
                                         .socketTimeout(700)
+                                        .serverSelector(serverSelector)
                                         .serverSelectionTimeout(150)
                                         .maxWaitTime(200)
                                         .maxConnectionIdleTime(300)
@@ -194,6 +198,7 @@ class MongoClientOptionsSpecification extends Specification {
         options.getApplicationName() == 'appName'
         options.getReadPreference() == ReadPreference.secondary()
         options.getWriteConcern() == WriteConcern.JOURNALED
+        options.getServerSelector() == serverSelector
         options.getRetryWrites()
         options.getServerSelectionTimeout() == 150
         options.getMaxWaitTime() == 200
@@ -656,8 +661,8 @@ class MongoClientOptionsSpecification extends Specification {
                         'description', 'heartbeatConnectTimeout', 'heartbeatFrequency', 'heartbeatSocketTimeout', 'localThreshold',
                         'maxConnectionIdleTime', 'maxConnectionLifeTime', 'maxConnectionsPerHost', 'maxWaitTime', 'minConnectionsPerHost',
                         'minHeartbeatFrequency', 'readConcern', 'readPreference', 'requiredReplicaSetName', 'retryWrites',
-                        'serverListeners', 'serverMonitorListeners', 'serverSelectionTimeout', 'socketFactory', 'socketKeepAlive',
-                        'socketTimeout', 'sslContext', 'sslEnabled', 'sslInvalidHostNameAllowed',
+                        'serverListeners', 'serverMonitorListeners', 'serverSelectionTimeout', 'serverSelector', 'socketFactory',
+                        'socketKeepAlive', 'socketTimeout', 'sslContext', 'sslEnabled', 'sslInvalidHostNameAllowed',
                         'threadsAllowedToBlockForConnectionMultiplier', 'writeConcern']
 
         then:


### PR DESCRIPTION
Allow an application to register a server selector that is applied after the suitable servers are selected and before servers within the latency window are selected.

It bothers me that there are no integration tests that the latency window is being applied, either with or without the customer server selector.  I welcome any ideas on how best to do that. 