### PR TITLE
JAVA-2668: Update Netty to 4.1.17.Final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'eclipse'
 apply plugin: 'idea'
 
 def configDir = new File(rootDir, 'config')
-ext.nettyVersion = '4.1.5.Final'
+ext.nettyVersion = '4.1.17.Final'
 ext.snappyVersion = '1.1.4'
 
 buildscript {


### PR DESCRIPTION
 (which fixes an SSL-related failure in the async tests when running on Java 9)