### PR TITLE
JAVA-2665: Update doc links to use dochub.mongodb.org

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,7 @@ configure(subprojects.findAll { it.name != 'util' }) {
         options.links 'http://docs.oracle.com/javase/7/docs/api/'
         options.tagletPath single(project(':util').sourceSets.main.output.classesDirs)
         options.taglets 'ManualTaglet'
+        options.taglets 'DochubTaglet'
         options.taglets 'ServerReleaseTaglet'
         options.encoding = 'UTF-8'
         options.charSet 'UTF-8'

--- a/docs/reference/content/driver-async/tutorials/change-streams.md
+++ b/docs/reference/content/driver-async/tutorials/change-streams.md
@@ -10,7 +10,7 @@ title = "Change Streams"
 
 ## Change Streams - Draft
 
-MongoDB 3.6 introduces a new [`$changeStream`](https://docs.mongodb.com/manual/operator/aggregation/changeStream) aggregation pipeline
+MongoDB 3.6 introduces a new [`$changeStream`](http://dochub.mongodb.org/core/changestreams) aggregation pipeline
 operator.
 
 Change streams provide a way to watch changes to documents in a collection. To improve the usability of this new stage, the 
@@ -86,7 +86,7 @@ collection.watch().forEach(printBlock, callbackWhenFinished);
 
 The `watch` method can also be passed a list of [aggregation stages]({{< docsref "meta/aggregation-quick-reference" >}}), that can modify 
 the data returned by the `$changeStream` operator. Note: not all aggregation operators are supported. See the 
-[`$changeStream`](https://docs.mongodb.com/manual/operator/aggregation/changeStream) documentation for more information.
+[`$changeStream`](http://dochub.mongodb.org/core/changestreams) documentation for more information.
 
 In the following example the change stream prints out all changes it observes, for `insert`, `update`, `replace` and `delete` operations:
 

--- a/docs/reference/content/driver/tutorials/change-streams.md
+++ b/docs/reference/content/driver/tutorials/change-streams.md
@@ -10,7 +10,7 @@ title = "Change Streams"
 
 ## Change Streams - Draft
 
-MongoDB 3.6 introduces a new [`$changeStream`](https://docs.mongodb.com/manual/operator/aggregation/changeStream) aggregation pipeline
+MongoDB 3.6 introduces a new [`$changeStream`](http://dochub.mongodb.org/core/changestreams) aggregation pipeline
 operator.
 
 Change streams provide a way to watch changes to documents in a collection. To improve the usability of this new stage, the 
@@ -74,7 +74,7 @@ collection.watch().forEach(printBlock);
 
 The `watch` method can also be passed a list of [aggregation stages]({{< docsref "meta/aggregation-quick-reference" >}}), that can modify 
 the data returned by the `$changeStream` operator. Note: not all aggregation operators are supported. See the 
-[`$changeStream`](https://docs.mongodb.com/manual/operator/aggregation/changeStream) documentation for more information.
+[`$changeStream`](http://dochub.mongodb.org/core/changestreams) documentation for more information.
 
 In the following example the change stream prints out all changes it observes, for `insert`, `update`, `replace` and `delete` operations:
 

--- a/docs/reference/content/whats-new.md
+++ b/docs/reference/content/whats-new.md
@@ -13,7 +13,7 @@ Key new features of the 3.6 Java driver release:
 
 ### Change Stream support
 
-The 3.6 release adds support for [change streams](https://docs.mongodb.com/manual/operator/aggregation/changeStream).
+The 3.6 release adds support for [change streams](http://dochub.mongodb.org/core/changestreams).
 
 * [Change Stream Quick Start]({{<ref "driver/tutorials/change-streams.md">}}) 
 * [Change Stream Quick Start (Async)]({{<ref "driver-async/tutorials/change-streams.md">}})
@@ -31,8 +31,9 @@ The 3.6 release adds support for compression of messages to and from appropriate
 * [Compression Tutorial (Async)]({{<ref "driver-async/tutorials/compression.md">}})
 
 ### Causal consistency
-
-The 3.6 release adds support for causally consistency.
+              
+The 3.6 release adds support for [causally consistency](http://dochub.mongodb.org/core/causal-consistency) via the new
+[`ClientSession`]({{<apiref "com/mongodb/session/ClientSession">}}) API. 
 
 ### Application-configured server selection
 

--- a/driver-async/src/main/com/mongodb/async/client/MongoCollection.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoCollection.java
@@ -262,7 +262,7 @@ public interface MongoCollection<TDocument> {
      * Creates a change stream for this collection.
      *
      * @return the change stream iterable
-     * @mongodb.driver.manual reference/operator/aggregation/changeStream $changeStream
+     * @mongodb.driver.dochub core/changestreams Change Streams
      * @since 3.6
      */
     ChangeStreamIterable<TDocument> watch();
@@ -273,7 +273,7 @@ public interface MongoCollection<TDocument> {
      * @param resultClass the class to decode each document into
      * @param <TResult>   the target document type of the iterable.
      * @return the change stream iterable
-     * @mongodb.driver.manual reference/operator/aggregation/changeStream $changeStream
+     * @mongodb.driver.dochub core/changestreams Change Streams
      * @since 3.6
      */
     <TResult> ChangeStreamIterable<TResult> watch(Class<TResult> resultClass);
@@ -283,7 +283,7 @@ public interface MongoCollection<TDocument> {
      *
      * @param pipeline the aggregation pipeline to apply to the change stream
      * @return the change stream iterable
-     * @mongodb.driver.manual reference/operator/aggregation/changeStream $changeStream
+     * @mongodb.driver.dochub core/changestreams Change Streams
      * @since 3.6
      */
     ChangeStreamIterable<TDocument> watch(List<? extends Bson> pipeline);
@@ -295,7 +295,7 @@ public interface MongoCollection<TDocument> {
      * @param resultClass the class to decode each document into
      * @param <TResult>   the target document type of the iterable.
      * @return the change stream iterable
-     * @mongodb.driver.manual reference/operator/aggregation/changeStream $changeStream
+     * @mongodb.driver.dochub core/changestreams Change Streams
      * @since 3.6
      */
     <TResult> ChangeStreamIterable<TResult> watch(List<? extends Bson> pipeline, Class<TResult> resultClass);

--- a/driver-core/src/main/com/mongodb/ClientSessionOptions.java
+++ b/driver-core/src/main/com/mongodb/ClientSessionOptions.java
@@ -26,6 +26,7 @@ import com.mongodb.session.ClientSession;
  * @mongodb.server.release 3.6
  * @since 3.6
  * @see ClientSession
+ * @mongodb.driver.dochub core/causal-consistency Causal Consistency
  */
 @Immutable
 public final class ClientSessionOptions {
@@ -37,6 +38,7 @@ public final class ClientSessionOptions {
      *
      * @return whether operations using the session should be causally consistent.  A null value indicates to use the the global default,
      * which is currently true.
+     * @mongodb.driver.dochub core/causal-consistency Causal Consistency
      */
     public Boolean isCausallyConsistent() {
         return causallyConsistent;
@@ -63,6 +65,7 @@ public final class ClientSessionOptions {
          *
          * @param causallyConsistent whether operations using the session should be causally consistent
          * @return this
+         * @mongodb.driver.dochub core/causal-consistency Causal Consistency
          */
         public Builder causallyConsistent(final boolean causallyConsistent) {
             this.causallyConsistent = causallyConsistent;

--- a/driver-core/src/main/com/mongodb/MongoChangeStreamException.java
+++ b/driver-core/src/main/com/mongodb/MongoChangeStreamException.java
@@ -19,7 +19,7 @@ package com.mongodb;
 /**
  * An exception indicating that a failure occurred when running a {@code $changeStream}.
  *
- * @mongodb.driver.manual reference/operator/aggregation/changeStream $changeStream
+ * @mongodb.driver.dochub core/changestreams Change Streams
  * @since 3.6
  */
 public class MongoChangeStreamException extends MongoException {

--- a/driver-core/src/main/com/mongodb/session/ClientSession.java
+++ b/driver-core/src/main/com/mongodb/session/ClientSession.java
@@ -28,6 +28,7 @@ import java.io.Closeable;
  *
  * @mongodb.server.release 3.6
  * @since 3.6
+ * @see ClientSessionOptions
  */
 @NotThreadSafe
 public interface ClientSession extends Closeable {

--- a/driver/src/main/com/mongodb/client/MongoCollection.java
+++ b/driver/src/main/com/mongodb/client/MongoCollection.java
@@ -16,7 +16,6 @@
 
 package com.mongodb.client;
 
-import com.mongodb.session.ClientSession;
 import com.mongodb.MongoNamespace;
 import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
@@ -38,6 +37,7 @@ import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.WriteModel;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
+import com.mongodb.session.ClientSession;
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
@@ -398,7 +398,7 @@ public interface MongoCollection<TDocument> {
      * Creates a change stream for this collection.
      *
      * @return the change stream iterable
-     * @mongodb.driver.manual reference/operator/aggregation/changeStream $changeStream
+     * @mongodb.driver.dochub core/changestreams Change Streams
      * @since 3.6
      */
     ChangeStreamIterable<TDocument> watch();
@@ -409,7 +409,7 @@ public interface MongoCollection<TDocument> {
      * @param resultClass the class to decode each document into
      * @param <TResult>   the target document type of the iterable.
      * @return the change stream iterable
-     * @mongodb.driver.manual reference/operator/aggregation/changeStream $changeStream
+     * @mongodb.driver.dochub core/changestreams Change Streams
      * @since 3.6
      */
     <TResult> ChangeStreamIterable<TResult> watch(Class<TResult> resultClass);
@@ -419,7 +419,7 @@ public interface MongoCollection<TDocument> {
      *
      * @param pipeline the aggregation pipeline to apply to the change stream.
      * @return the change stream iterable
-     * @mongodb.driver.manual reference/operator/aggregation/changeStream $changeStream
+     * @mongodb.driver.dochub core/changestreams Change Streams
      * @since 3.6
      */
     ChangeStreamIterable<TDocument> watch(List<? extends Bson> pipeline);
@@ -431,7 +431,7 @@ public interface MongoCollection<TDocument> {
      * @param resultClass the class to decode each document into
      * @param <TResult>   the target document type of the iterable.
      * @return the change stream iterable
-     * @mongodb.driver.manual reference/operator/aggregation/changeStream $changeStream
+     * @mongodb.driver.dochub core/changestreams Change Streams
      * @since 3.6
      */
     <TResult> ChangeStreamIterable<TResult> watch(List<? extends Bson> pipeline, Class<TResult> resultClass);
@@ -443,7 +443,7 @@ public interface MongoCollection<TDocument> {
      * @return the change stream iterable
      * @since 3.6
      * @mongodb.server.release 3.6
-     * @mongodb.driver.manual reference/operator/aggregation/changeStream $changeStream
+     * @mongodb.driver.dochub core/changestreams Change Streams
      */
     ChangeStreamIterable<TDocument> watch(ClientSession clientSession);
 
@@ -456,7 +456,7 @@ public interface MongoCollection<TDocument> {
      * @return the change stream iterable
      * @since 3.6
      * @mongodb.server.release 3.6
-     * @mongodb.driver.manual reference/operator/aggregation/changeStream $changeStream
+     * @mongodb.driver.dochub core/changestreams Change Streams
      */
     <TResult> ChangeStreamIterable<TResult> watch(ClientSession clientSession, Class<TResult> resultClass);
 
@@ -468,7 +468,7 @@ public interface MongoCollection<TDocument> {
      * @return the change stream iterable
      * @since 3.6
      * @mongodb.server.release 3.6
-     * @mongodb.driver.manual reference/operator/aggregation/changeStream $changeStream
+     * @mongodb.driver.dochub core/changestreams Change Streams
      */
     ChangeStreamIterable<TDocument> watch(ClientSession clientSession, List<? extends Bson> pipeline);
 
@@ -482,7 +482,7 @@ public interface MongoCollection<TDocument> {
      * @return the change stream iterable
      * @since 3.6
      * @mongodb.server.release 3.6
-     * @mongodb.driver.manual reference/operator/aggregation/changeStream $changeStream
+     * @mongodb.driver.dochub core/changestreams Change Streams
      */
     <TResult> ChangeStreamIterable<TResult> watch(ClientSession clientSession, List<? extends Bson> pipeline, Class<TResult> resultClass);
 

--- a/util/src/main/DochubTaglet.java
+++ b/util/src/main/DochubTaglet.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.sun.tools.doclets.Taglet;
+
+import java.util.Map;
+
+public class DochubTaglet extends DocTaglet {
+
+    public static void register(final Map<String, Taglet> tagletMap) {
+        DochubTaglet t = new DochubTaglet();
+        tagletMap.put(t.getName(), t);
+    }
+
+    public String getName() {
+        return "mongodb.driver.dochub";
+    }
+
+    @Override
+    protected String getHeader() {
+        return "MongoDB documentation";
+    }
+
+    @Override
+    protected String getBaseDocURI() {
+        return "http://dochub.mongodb.org/";
+    }
+
+}


### PR DESCRIPTION
I needed a new Taglet for this but otherwise just docs changes.

Docs are published here: http://jyemin.github.io/mongo-java-driver/3.6/