### PR TITLE
JAVA-2682: Don't retry writes unless all writes in the list are retryable

### DIFF
--- a/driver-core/src/main/com/mongodb/operation/BulkWriteBatch.java
+++ b/driver-core/src/main/com/mongodb/operation/BulkWriteBatch.java
@@ -31,13 +31,13 @@ import com.mongodb.bulk.WriteRequest;
 import com.mongodb.connection.BulkWriteBatchCombiner;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.connection.ServerDescription;
-import com.mongodb.session.SessionContext;
 import com.mongodb.connection.SplittablePayload;
 import com.mongodb.internal.connection.IndexMap;
 import com.mongodb.internal.validator.CollectibleDocumentFieldNameValidator;
 import com.mongodb.internal.validator.MappedFieldNameValidator;
 import com.mongodb.internal.validator.NoOpFieldNameValidator;
 import com.mongodb.internal.validator.UpdateFieldNameValidator;
+import com.mongodb.session.SessionContext;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
@@ -101,7 +101,7 @@ final class BulkWriteBatch {
         boolean writeRequestsAreRetryable = true;
         for (int i = 0; i < writeRequests.size(); i++) {
             WriteRequest writeRequest = writeRequests.get(i);
-            writeRequestsAreRetryable = isRetryable(writeRequest);
+            writeRequestsAreRetryable = writeRequestsAreRetryable && isRetryable(writeRequest);
             writeRequestsWithIndex.add(new WriteRequestWithIndex(writeRequest, i));
         }
         if (canRetryWrites && !writeRequestsAreRetryable) {


### PR DESCRIPTION
The fix is easy but I'm not too happy with just having a unit test of BulkWriteBatch.  Is there a straightforward way to write an integration test for this?

https://evergreen.mongodb.com/version/5a1f36b0e3c3315c9101b860