### PR TITLE
Make change stream test more robust

### DIFF
--- a/driver-core/src/test/functional/com/mongodb/operation/ChangeStreamOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ChangeStreamOperationSpecification.groovy
@@ -367,7 +367,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
 
         operation.resumeAfter(result.head().getDocument('_id'))
         cursor = execute(operation, async)
-        result = tryNextAndClean(cursor, async)
+        result = nextAndClean(cursor, async)
 
         then:
         result == expected.tail()


### PR DESCRIPTION
... by not assuming that the result will arrive in the first batch.

Necessary because in 3.6.0-rc7 sharded cluster the result doesn't come until the first getMore.  Changing from tryNext to next hides that difference and allows the test to pass in a sharded cluster.

https://evergreen.mongodb.com/version/5a1f8a8ce3c3315c9101cce7