### PR TITLE
JAVA-2560

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -457,6 +457,10 @@ axes:
   - id: jdk
     display_name: JDK
     values:
+      - id: "jdk9"
+        display_name: JDK9
+        variables:
+           JDK: "jdk9"
       - id: "jdk8"
         display_name: JDK8 
         variables:

--- a/.evergreen/compile.sh
+++ b/.evergreen/compile.sh
@@ -7,9 +7,9 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #            Main Program                  #
 ############################################
 
-echo "Compiling java driver with jdk8"
+echo "Compiling java driver with jdk9"
 
 # We always compile with the latest version of java
-export JAVA_HOME="/opt/java/jdk8"
+export JAVA_HOME="/opt/java/jdk9"
 ./gradlew -version
 ./gradlew -PxmlReports.enabled=true --info -x test clean check jar testClasses javadoc

--- a/.evergreen/publish.sh
+++ b/.evergreen/publish.sh
@@ -12,9 +12,9 @@ echo ${RING_FILE_GPG_BASE64} | base64 -d > ${PROJECT_DIRECTORY}/secring.gpg
 
 trap "rm ${PROJECT_DIRECTORY}/secring.gpg; exit" EXIT HUP
 
-echo "Publishing snapshot with jdk8"
+echo "Publishing snapshot with jdk9"
 
-export JAVA_HOME="/opt/java/jdk8"
+export JAVA_HOME="/opt/java/jdk9"
 
 export ORG_GRADLE_PROJECT_nexusUsername=${NEXUS_USERNAME}
 export ORG_GRADLE_PROJECT_nexusPassword=${NEXUS_PASSWORD}

--- a/.evergreen/run-gssapi-auth-test.sh
+++ b/.evergreen/run-gssapi-auth-test.sh
@@ -31,10 +31,10 @@ com.sun.security.jgss.krb5.initiate {
 };
 EOF
 
-echo "Compiling java driver with jdk8"
+echo "Compiling java driver with jdk9"
 
 # We always compile with the latest version of java
-export JAVA_HOME="/opt/java/jdk8"
+export JAVA_HOME="/opt/java/jdk9"
 
 echo "Running tests with ${JDK}"
 ./gradlew -version

--- a/.evergreen/run-plain-auth-test.sh
+++ b/.evergreen/run-plain-auth-test.sh
@@ -9,16 +9,16 @@ set -o errexit  # Exit the script with error if any of the commands fail
 #                               "jdk5", "jdk6", "jdk7", "jdk8"
 
 JDK=${JDK:-jdk}
-JAVA_HOME="/opt/java/${JDK}"
 
 ############################################
 #            Main Program                  #
 ############################################
 
 echo "Running PLAIN authentication tests"
+echo "Compiling java driver with jdk9"
 
 # We always compile with the latest version of java
-export JAVA_HOME="/opt/java/jdk8"
+export JAVA_HOME="/opt/java/jdk9"
 
 echo "Running tests with ${JDK}"
 ./gradlew -version

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -17,7 +17,6 @@ AUTH=${AUTH:-noauth}
 SSL=${SSL:-nossl}
 MONGODB_URI=${MONGODB_URI:-}
 JDK=${JDK:-jdk}
-JAVA_HOME="/opt/java/${JDK}"
 TOPOLOGY=${TOPOLOGY:-server}
 COMPRESSOR=${COMPRESSOR:-}
 
@@ -40,7 +39,7 @@ provision_ssl () {
     openssl pkcs12 -CAfile ${DRIVERS_TOOLS}/.evergreen/x509gen/ca.pem -export -in ${DRIVERS_TOOLS}/.evergreen/x509gen/client.pem -out client.pkc -password pass:bithere
   fi
   if [ ! -f mongo-truststore ]; then
-    echo "y" | ${JAVA_HOME}/bin/keytool -importcert -trustcacerts -file ${DRIVERS_TOOLS}/.evergreen/x509gen/ca.pem -keystore mongo-truststore -storepass hithere
+    echo "y" | /opt/java/${JDK}/bin/keytool -importcert -trustcacerts -file ${DRIVERS_TOOLS}/.evergreen/x509gen/ca.pem -keystore mongo-truststore -storepass hithere
   fi
 
   # We add extra gradle arguments for SSL
@@ -83,7 +82,7 @@ fi
 echo "Running $AUTH tests over $SSL for $TOPOLOGY and connecting to $MONGODB_URI"
 
 # We always compile with the latest version of java
-export JAVA_HOME="/opt/java/jdk8"
+export JAVA_HOME="/opt/java/jdk9"
 
 echo "Running tests with ${JDK}"
 ./gradlew -version

--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ configure(subprojects.findAll { it.name != 'util' }) {
 
         options.author = true
         options.version = true
-        options.links 'http://docs.oracle.com/javase/7/docs/api/'
+        options.links 'http://docs.oracle.com/javase/9/docs/api/'
         options.tagletPath single(project(':util').sourceSets.main.output.classesDirs)
         options.taglets 'ManualTaglet'
         options.taglets 'DochubTaglet'
@@ -304,7 +304,6 @@ configure(subprojects.findAll { it.name != 'util' && it.name != 'mongo-java-driv
 
 task docs(type: Javadoc) {
     source subprojects.grep({ it.name != 'util' }).collect {project -> project.sourceSets.main.allJava }
-//    options = subprojects.first().javadoc.options
     dependsOn = subprojects.first().javadoc.dependsOn
     excludes =  subprojects.first().javadoc.excludes
     classpath = files(subprojects.collect {project -> project.sourceSets.main.compileClasspath})

--- a/util/src/main/DocTaglet.java
+++ b/util/src/main/DocTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2014 MongoDB, Inc.
+ * Copyright 20017 MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,69 +14,66 @@
  * limitations under the License.
  */
 
-import com.sun.javadoc.Tag;
-import com.sun.tools.doclets.Taglet;
+
+import com.sun.source.doctree.DocTree;
+import jdk.javadoc.doclet.Taglet;
+
+import javax.lang.model.element.Element;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public abstract class DocTaglet implements Taglet {
 
-    public boolean inConstructor() {
-        return true;
-    }
-
-    public boolean inField() {
-        return true;
-    }
-
-    public boolean inMethod() {
-        return true;
-    }
-
-    public boolean inOverview() {
-        return true;
-    }
-
-    public boolean inPackage() {
-        return true;
-    }
-
-    public boolean inType() {
-        return true;
+    @Override
+    public Set<Location> getAllowedLocations() {
+        return new HashSet<Location>(Arrays.asList(
+                Location.CONSTRUCTOR,
+                Location.METHOD,
+                Location.FIELD,
+                Location.OVERVIEW,
+                Location.PACKAGE,
+                Location.TYPE));
     }
 
     public boolean isInlineTag() {
         return false;
     }
 
-    public String toString(final Tag[] tags) {
-        if (tags.length == 0) {
-            return null;
+    @Override
+    public String toString(final List<? extends DocTree> docTreeList, final Element ignored) {
+        StringBuilder buf = new StringBuilder();
+        buf.append("<dl>\n");
+        buf.append(String.format("   <dt><span class=\"strong\">%s</span></dt>\n", getHeader()));
+        for (DocTree t : docTreeList) {
+            buf.append("   <dd>").append(genLink(t.toString())).append("</dd>\n");
         }
-
-        StringBuilder buf = new StringBuilder(String.format("\n<dl><dt><span class=\"strong\">%s</span></dt>\n", getHeader()));
-        for (Tag t : tags) {
-            buf.append("   <dd>").append(genLink(t.text())).append("</dd>\n");
-        }
+        buf.append("</dl>\n");
         return buf.toString();
     }
 
     protected abstract String getHeader();
 
-    public String toString(final Tag tag) {
-        return toString(new Tag[]{tag});
-    }
+    protected abstract String getBaseDocURI();
 
-    protected String genLink(final String text) {
-        String relativePath = text;
-        String display = text;
+    // Generate link from strings like:
+    //    @mongodb.server.release 3.6
+    //    @mongodb.driver.manual reference/mongodb-extended-json/ MongoDB Extended JSON
+    private String genLink(final String text) {
+        String relativePath;
+        String display;
 
         int firstSpace = text.indexOf(' ');
-        if (firstSpace != -1) {
-            relativePath = text.substring(0, firstSpace);
-            display = text.substring(firstSpace, text.length()).trim();
+        int secondSpace = text.indexOf(' ', firstSpace + 1);
+        if (secondSpace != -1 && secondSpace != firstSpace) {
+            relativePath = text.substring(firstSpace, secondSpace).trim();
+            display = text.substring(secondSpace, text.length()).trim();
+        } else {
+            relativePath = text.substring(firstSpace).trim();
+            display = relativePath;
         }
 
         return String.format("<a href='%s%s'>%s</a>", getBaseDocURI(), relativePath, display);
     }
-
-    protected abstract String getBaseDocURI();
 }

--- a/util/src/main/DochubTaglet.java
+++ b/util/src/main/DochubTaglet.java
@@ -14,16 +14,7 @@
  * limitations under the License.
  */
 
-import com.sun.tools.doclets.Taglet;
-
-import java.util.Map;
-
 public class DochubTaglet extends DocTaglet {
-
-    public static void register(final Map<String, Taglet> tagletMap) {
-        DochubTaglet t = new DochubTaglet();
-        tagletMap.put(t.getName(), t);
-    }
 
     public String getName() {
         return "mongodb.driver.dochub";

--- a/util/src/main/ManualTaglet.java
+++ b/util/src/main/ManualTaglet.java
@@ -14,16 +14,7 @@
  * limitations under the License.
  */
 
-import com.sun.tools.doclets.Taglet;
-
-import java.util.Map;
-
 public class ManualTaglet extends DocTaglet {
-
-    public static void register(final Map<String, Taglet> tagletMap) {
-        ManualTaglet t = new ManualTaglet();
-        tagletMap.put(t.getName(), t);
-    }
 
     public String getName() {
         return "mongodb.driver.manual";

--- a/util/src/main/ServerReleaseTaglet.java
+++ b/util/src/main/ServerReleaseTaglet.java
@@ -14,16 +14,7 @@
  * limitations under the License.
  */
 
-import com.sun.tools.doclets.Taglet;
-
-import java.util.Map;
-
 public class ServerReleaseTaglet extends DocTaglet {
-
-    public static void register(final Map<String, Taglet> tagletMap) {
-        Taglet t = new ServerReleaseTaglet();
-        tagletMap.put(t.getName(), t);
-    }
 
     @Override
     public String getName() {


### PR DESCRIPTION
Replace use of com.sun.source.doctree package with jdk.javadoc.doclet package.

Since this package is new to Java 9, once this is committed you will have to use Java 9+ to build the javadoc.  It also means the project will no longer load in IntelliJ without Java 9.

I think it's ok to do this now as we're going to need Java 9 APIs soon anyway in order to implement https://jira.mongodb.org/browse/JAVA-2512.