### PR TITLE
JAVA-2691

### DIFF
--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -61,7 +61,6 @@ import org.bson.codecs.BsonDocumentCodec;
 import org.bson.codecs.DocumentCodec;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -147,25 +146,9 @@ public final class ClusterFixture {
         return versionList;
     }
 
-    public static Document getBuildInfo() {
-        return new CommandWriteOperation<Document>("admin", new BsonDocument("buildInfo", new BsonInt32(1)), new DocumentCodec())
-                .execute(getBinding());
-    }
-
     public static Document getServerStatus() {
         return new CommandWriteOperation<Document>("admin", new BsonDocument("serverStatus", new BsonInt32(1)), new DocumentCodec())
                .execute(getBinding());
-    }
-
-    @SuppressWarnings("unchecked")
-    public static boolean isEnterpriseServer() {
-        Document buildInfo = getBuildInfo();
-        List<String> modules = Collections.emptyList();
-        if (buildInfo.containsKey("modules")) {
-            modules = (List<String>) buildInfo.get("modules");
-        }
-
-        return modules.contains("enterprise");
     }
 
     public static boolean supportsFsync() {
@@ -400,19 +383,19 @@ public final class ClusterFixture {
         }
     }
 
-    public static <T> T executeSync(final WriteOperation<T> op) throws Throwable {
+    public static <T> T executeSync(final WriteOperation<T> op) {
         return executeSync(op, getBinding());
     }
 
-    public static <T> T executeSync(final WriteOperation<T> op, final ReadWriteBinding binding) throws Throwable {
+    public static <T> T executeSync(final WriteOperation<T> op, final ReadWriteBinding binding) {
         return op.execute(binding);
     }
 
-    public static <T> T executeSync(final ReadOperation<T> op) throws Throwable {
+    public static <T> T executeSync(final ReadOperation<T> op) {
         return executeSync(op, getBinding());
     }
 
-    public static <T> T executeSync(final ReadOperation<T> op, final ReadWriteBinding binding) throws Throwable {
+    public static <T> T executeSync(final ReadOperation<T> op, final ReadWriteBinding binding) {
         return op.execute(binding);
     }
 
@@ -490,7 +473,7 @@ public final class ClusterFixture {
         return results;
     }
 
-    public static <T> List<T> collectCursorResults(final BatchCursor<T> batchCursor) throws Throwable {
+    public static <T> List<T> collectCursorResults(final BatchCursor<T> batchCursor) {
         List<T> results = new ArrayList<T>();
         while (batchCursor.hasNext()) {
             results.addAll(batchCursor.next());

--- a/driver-core/src/test/functional/com/mongodb/binding/AsyncSessionBinding.java
+++ b/driver-core/src/test/functional/com/mongodb/binding/AsyncSessionBinding.java
@@ -29,7 +29,7 @@ public final class AsyncSessionBinding implements AsyncReadWriteBinding {
     private final AsyncReadWriteBinding wrapped;
     private final SessionContext sessionContext;
 
-    AsyncSessionBinding(final AsyncReadWriteBinding wrapped) {
+    public AsyncSessionBinding(final AsyncReadWriteBinding wrapped) {
         this.wrapped = notNull("wrapped", wrapped);
         this.sessionContext = new SimpleSessionContext();
     }

--- a/driver-core/src/test/functional/com/mongodb/binding/SessionBinding.java
+++ b/driver-core/src/test/functional/com/mongodb/binding/SessionBinding.java
@@ -23,11 +23,11 @@ import com.mongodb.session.SessionContext;
 
 import static org.bson.assertions.Assertions.notNull;
 
-class SessionBinding implements ReadWriteBinding {
+public class SessionBinding implements ReadWriteBinding {
     private final ReadWriteBinding wrapped;
     private final SessionContext sessionContext;
 
-    SessionBinding(final ReadWriteBinding wrapped) {
+    public SessionBinding(final ReadWriteBinding wrapped) {
         this.wrapped = notNull("wrapped", wrapped);
         this.sessionContext = new SimpleSessionContext();
     }

--- a/driver-core/src/test/functional/com/mongodb/operation/AsyncQueryBatchCursorFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/AsyncQueryBatchCursorFunctionalSpecification.groovy
@@ -365,10 +365,9 @@ class AsyncQueryBatchCursorFunctionalSpecification extends OperationFunctionalSp
             }
 
             def futureResultCallback = new FutureResultCallback<BsonDocument>();
-            connection.commandAsync(getDatabaseName(), findCommand,
-                    NO_OP_FIELD_NAME_VALIDATOR, ReadPreference.secondaryPreferred(),
-                    CommandResultDocumentCodec.create(new DocumentCodec(), 'firstBatch'), binding.sessionContext,
-                    futureResultCallback)
+            connection.commandAsync(getDatabaseName(), findCommand, NO_OP_FIELD_NAME_VALIDATOR, ReadPreference.primary(),
+                    CommandResultDocumentCodec.create(new DocumentCodec(), 'firstBatch'),
+                    connectionSource.sessionContext, futureResultCallback)
             def response = futureResultCallback.get(60, SECONDS)
             cursorDocumentToQueryResult(response.getDocument('cursor'), connection.getDescription().getServerAddress())
         } else {


### PR DESCRIPTION
Enable sessions in driver-core tests.

Patch build: https://evergreen.mongodb.com/version/5a282913e3c33129d001bbd4

The failures on "latest" with auth enabled are explained by https://jira.mongodb.org/browse/SERVER-32169, since in this case the tests uses OP_KILL_CURSORS to kill the cursor, which can't be passed an lsid.