### PR TITLE
JAVA-2692

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/InternalStreamConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/InternalStreamConnection.java
@@ -681,8 +681,10 @@ class InternalStreamConnection implements InternalConnection {
 
                 BsonDocument commandDocumentForEvent = (SECURITY_SENSITIVE_COMMANDS.contains(commandName))
                                                                ? new BsonDocument() : commandDocument;
-                sendCommandStartedEvent(message, new MongoNamespace(message.getCollectionName()).getDatabaseName(), commandName,
-                        commandDocumentForEvent, getDescription(), commandListener);
+                if (commandListener != null && opened()) {
+                    sendCommandStartedEvent(message, new MongoNamespace(message.getCollectionName()).getDatabaseName(), commandName,
+                            commandDocumentForEvent, getDescription(), commandListener);
+                }
             }
         }
 


### PR DESCRIPTION
Only attempt to send command started event when there is a command listener and the connection handshake is complete

I don't see a way to test this as the NPE doesn't leak out of ProtocolHelper#sendCommandStartedEvent

Patch build: https://evergreen.mongodb.com/version/5a2862f8e3c33168db000417