### PR TITLE
JAVA-2701:

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/ClientMetadataHelper.java
+++ b/driver-core/src/main/com/mongodb/connection/ClientMetadataHelper.java
@@ -114,9 +114,14 @@ final class ClientMetadataHelper {
                 if (jarUrl != null) {
                     JarURLConnection jarURLConnection = (JarURLConnection) jarUrl.openConnection();
                     Manifest manifest = jarURLConnection.getManifest();
-                    String version = (String) manifest.getMainAttributes().get(new Attributes.Name("Build-Version"));
-                    if (version != null) {
-                        driverVersion = version;
+                    if (manifest != null) {
+                        Attributes mainAttributes = manifest.getMainAttributes();
+                        if (mainAttributes != null) {
+                            String version = (String) mainAttributes.get(new Attributes.Name("Build-Version"));
+                            if (version != null) {
+                                driverVersion = version;
+                            }
+                        }
                     }
                 }
             } catch (IOException e) {


### PR DESCRIPTION
Add more defensive checks when looking for the driver version to avoid NullPointerException in cases where the driver has been re-packaged without a manifest.