### PR TITLE
JAVA-2716:

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/BsonWriterHelper.java
+++ b/driver-core/src/main/com/mongodb/connection/BsonWriterHelper.java
@@ -45,17 +45,17 @@ final class BsonWriterHelper {
     }
 
     static void writePayloadArray(final BsonWriter writer, final BsonOutput bsonOutput, final MessageSettings settings,
-                                  final int commandStartPosition, final SplittablePayload payload) {
+                                  final int messageStartPosition, final SplittablePayload payload) {
         writer.writeStartArray(payload.getPayloadName());
-        writePayload(writer, bsonOutput, getDocumentMessageSettings(settings), commandStartPosition, payload);
+        writePayload(writer, bsonOutput, getDocumentMessageSettings(settings), messageStartPosition, payload);
         writer.writeEndArray();
     }
 
     static void writePayload(final BsonWriter writer, final BsonOutput bsonOutput, final MessageSettings settings,
-                             final int commandStartPosition, final SplittablePayload payload) {
+                             final int messageStartPosition, final SplittablePayload payload) {
         MessageSettings payloadSettings = getPayloadMessageSettings(payload.getPayloadType(), settings);
         for (int i = 0; i < payload.getPayload().size(); i++) {
-            if (writeDocument(writer, bsonOutput, payloadSettings, payload.getPayload().get(i), commandStartPosition, i + 1)) {
+            if (writeDocument(writer, bsonOutput, payloadSettings, payload.getPayload().get(i), messageStartPosition, i + 1)) {
                 payload.setPosition(i + 1);
             } else {
                 break;
@@ -69,10 +69,10 @@ final class BsonWriterHelper {
     }
 
     private static boolean writeDocument(final BsonWriter writer, final BsonOutput bsonOutput, final MessageSettings settings,
-                                         final BsonDocument document, final int startPosition, final int batchItemCount) {
+                                         final BsonDocument document, final int messageStartPosition, final int batchItemCount) {
         int currentPosition = bsonOutput.getPosition();
         getCodec(document).encode(writer, document, ENCODER_CONTEXT);
-        int messageSize = bsonOutput.getPosition() - startPosition;
+        int messageSize = bsonOutput.getPosition() - messageStartPosition;
         int documentSize = bsonOutput.getPosition() - currentPosition;
         if (exceedsLimits(settings, messageSize, documentSize, batchItemCount)) {
             bsonOutput.truncateToPosition(currentPosition);

--- a/driver-core/src/main/com/mongodb/connection/CommandMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/CommandMessage.java
@@ -113,6 +113,7 @@ final class CommandMessage extends RequestMessage {
     protected EncodingMetadata encodeMessageBodyWithMetadata(final BsonOutput bsonOutput, final SessionContext sessionContext) {
         int commandStartPosition;
         if (useOpMsg()) {
+            int startPosition = bsonOutput.getPosition() - MESSAGE_PROLOGUE_LENGTH;
             int flagPosition = bsonOutput.getPosition();
             bsonOutput.writeInt32(0);   // flag bits
             bsonOutput.writeByte(0);    // payload type
@@ -126,7 +127,7 @@ final class CommandMessage extends RequestMessage {
                 bsonOutput.writeInt32(0);         // size
                 bsonOutput.writeCString(payload.getPayloadName());
                 writePayload(new BsonBinaryWriter(bsonOutput, payloadFieldNameValidator), bsonOutput, getSettings(),
-                        commandStartPosition, payload);
+                        startPosition, payload);
 
                 int payloadLength = bsonOutput.getPosition() - payloadPosition;
                 bsonOutput.writeInt32(payloadPosition, payloadLength);

--- a/driver-core/src/main/com/mongodb/connection/RequestMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/RequestMessage.java
@@ -44,6 +44,8 @@ abstract class RequestMessage {
 
     static final AtomicInteger REQUEST_ID = new AtomicInteger(1);
 
+    static final int MESSAGE_PROLOGUE_LENGTH = 16;
+
     // Allow an extra 16K to the maximum allowed size of a query or command document, so that, for example,
     // a 16M document can be upserted via findAndModify
     private static final int DOCUMENT_HEADROOM = 16 * 1024;

--- a/driver-core/src/main/com/mongodb/connection/SplittablePayloadBsonWriter.java
+++ b/driver-core/src/main/com/mongodb/connection/SplittablePayloadBsonWriter.java
@@ -28,13 +28,14 @@ class SplittablePayloadBsonWriter extends LevelCountingBsonWriter {
     private final BsonOutput bsonOutput;
     private final SplittablePayload payload;
     private final MessageSettings settings;
-    private int commandStartPosition;
+    private final int messageStartPosition;
 
-    SplittablePayloadBsonWriter(final BsonBinaryWriter writer, final BsonOutput bsonOutput, final MessageSettings settings,
-                                final SplittablePayload payload) {
+    SplittablePayloadBsonWriter(final BsonBinaryWriter writer, final BsonOutput bsonOutput, final int messageStartPosition,
+                                final MessageSettings settings, final SplittablePayload payload) {
         super(writer);
         this.writer = writer;
         this.bsonOutput = bsonOutput;
+        this.messageStartPosition = messageStartPosition;
         this.settings = settings;
         this.payload = payload;
     }
@@ -42,15 +43,12 @@ class SplittablePayloadBsonWriter extends LevelCountingBsonWriter {
     @Override
     public void writeStartDocument() {
         super.writeStartDocument();
-        if (getCurrentLevel() == 0) {
-            commandStartPosition = bsonOutput.getPosition();
-        }
     }
 
     @Override
     public void writeEndDocument() {
         if (getCurrentLevel() == 0 && payload.getPayload().size() > 0) {
-            writePayloadArray(writer, bsonOutput, settings, commandStartPosition, payload);
+            writePayloadArray(writer, bsonOutput, settings, messageStartPosition, payload);
         }
         super.writeEndDocument();
     }


### PR DESCRIPTION
Use the message start position, rather that the command start position, as the basis for determining whether the max message size has been exceeded.

Add unit and integration tests that would have caught the regression

Patch build: https://evergreen.mongodb.com/version/5a42bb50e3c33137e1004562
