### PR TITLE
JAVA-2697

### DIFF
--- a/bson/src/main/org/bson/BsonDocument.java
+++ b/bson/src/main/org/bson/BsonDocument.java
@@ -782,6 +782,17 @@ public class BsonDocument extends BsonValue implements Map<String, BsonValue>, C
         return keySet().iterator().next();
     }
 
+    /**
+     * Gets the first value in the document
+     *
+     * @return the first value in the document
+     * @throws java.util.NoSuchElementException if the document is empty
+     * @since 3.7
+     */
+    public BsonValue getFirstValue() {
+        return values().iterator().next();
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {

--- a/bson/src/main/org/bson/RawBsonDocument.java
+++ b/bson/src/main/org/bson/RawBsonDocument.java
@@ -260,6 +260,22 @@ public final class RawBsonDocument extends BsonDocument {
     }
 
     @Override
+    public BsonValue getFirstValue() {
+        BsonBinaryReader bsonReader = createReader();
+        try {
+            bsonReader.readStartDocument();
+            try {
+                bsonReader.skipName();
+                return deserializeBsonValue(bsonReader);
+            } catch (BsonInvalidOperationException e) {
+                throw new NoSuchElementException();
+            }
+        } finally {
+            bsonReader.close();
+        }
+    }
+
+    @Override
     public boolean containsKey(final Object key) {
         if (key == null) {
             throw new IllegalArgumentException("key can not be null");

--- a/bson/src/test/unit/org/bson/BsonDocumentSpecification.groovy
+++ b/bson/src/test/unit/org/bson/BsonDocumentSpecification.groovy
@@ -343,6 +343,25 @@ class BsonDocumentSpecification extends Specification {
         thrown(NoSuchElementException)
     }
 
+    def 'should get first value'() {
+        given:
+        def document = new BsonDocument('i', new BsonInt32(2))
+
+        expect:
+        document.getFirstValue() == document.get('i')
+    }
+
+    def 'getFirstValue should throw NoSuchElementException if the document is empty'() {
+        given:
+        def document = new BsonDocument()
+
+        when:
+        document.getFirstValue()
+
+        then:
+        thrown(NoSuchElementException)
+    }
+
     def 'should serialize and deserialize'() {
         given:
         def document = new BsonDocument('d', new BsonDocument().append('i2', new BsonInt32(1)))

--- a/bson/src/test/unit/org/bson/RawBsonDocumentSpecification.groovy
+++ b/bson/src/test/unit/org/bson/RawBsonDocumentSpecification.groovy
@@ -266,6 +266,22 @@ class RawBsonDocumentSpecification extends Specification {
         thrown(NoSuchElementException)
     }
 
+    def 'should get first value'() {
+        expect:
+        document.getFirstValue() == new BsonInt32(1)
+
+        where:
+        rawDocument << createRawDocumentVariants()
+    }
+
+    def 'getFirstValue should throw NoSuchElementException if the document is empty'() {
+        when:
+        emptyRawDocument.getFirstValue()
+
+        then:
+        thrown(NoSuchElementException)
+    }
+
     def 'toJson should return equivalent JSON'() {
         expect:
         new RawBsonDocumentCodec().decode(new JsonReader(rawDocument.toJson()), DecoderContext.builder().build()) == document

--- a/driver-core/src/main/com/mongodb/connection/AbstractByteBufBsonDocument.java
+++ b/driver-core/src/main/com/mongodb/connection/AbstractByteBufBsonDocument.java
@@ -25,6 +25,7 @@ import org.bson.codecs.configuration.CodecRegistry;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
 
 import static org.bson.codecs.BsonValueCodecProvider.getClassForBsonType;
@@ -190,7 +191,23 @@ abstract class AbstractByteBufBsonDocument extends BsonDocument {
 
             @Override
             public String notFound() {
-                return null;
+                throw new NoSuchElementException();
+            }
+        });
+    }
+
+    @Override
+    public BsonValue getFirstValue() {
+        return findInDocument(new Finder<BsonValue>() {
+            @Override
+            public BsonValue find(final BsonReader bsonReader) {
+                bsonReader.skipName();
+                return deserializeBsonValue(bsonReader);
+            }
+
+            @Override
+            public BsonValue notFound() {
+                throw new NoSuchElementException();
             }
         });
     }

--- a/driver-core/src/main/com/mongodb/connection/CommandEventSender.java
+++ b/driver-core/src/main/com/mongodb/connection/CommandEventSender.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.connection;
+
+interface CommandEventSender {
+    void sendStartedEvent();
+
+    void sendFailedEvent(Throwable t);
+
+    void sendSucceededEvent(ResponseBuffers responseBuffers);
+
+    void sendSucceededEventForOneWayCommand();
+}

--- a/driver-core/src/main/com/mongodb/connection/CommandMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/CommandMessage.java
@@ -105,6 +105,10 @@ final class CommandMessage extends RequestMessage {
         return calculateIsResponseExpected();
     }
 
+    MongoNamespace getNamespace() {
+        return namespace;
+    }
+
     ReadPreference getReadPreference() {
         return readPreference;
     }

--- a/driver-core/src/main/com/mongodb/connection/GetMoreProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/GetMoreProtocol.java
@@ -96,7 +96,7 @@ class GetMoreProtocol<T> implements LegacyProtocol<QueryResult<T>> {
                 if (commandListener != null) {
                     sendCommandSucceededEvent(message, COMMAND_NAME,
                                               asGetMoreCommandResponseDocument(queryResult, responseBuffers), connection.getDescription(),
-                                              startTimeNanos, commandListener);
+                                              System.nanoTime() - startTimeNanos, commandListener);
                 }
             } finally {
                 responseBuffers.close();
@@ -105,7 +105,8 @@ class GetMoreProtocol<T> implements LegacyProtocol<QueryResult<T>> {
             return queryResult;
         } catch (RuntimeException e) {
             if (commandListener != null) {
-                sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), startTimeNanos, e, commandListener);
+                sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), System.nanoTime() - startTimeNanos, e,
+                        commandListener);
             }
             throw e;
         }
@@ -142,7 +143,7 @@ class GetMoreProtocol<T> implements LegacyProtocol<QueryResult<T>> {
                                                 startTimeNanos, commandListener, callback, receiveCallback));
         } catch (Throwable t) {
             if (sentStartedEvent) {
-                sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), startTimeNanos, t,
+                sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), System.nanoTime() - startTimeNanos, t,
                         commandListener);
             }
             callback.onResult(null, t);
@@ -230,7 +231,7 @@ class GetMoreProtocol<T> implements LegacyProtocol<QueryResult<T>> {
                     if (commandListener != null) {
                         sendCommandSucceededEvent(message, COMMAND_NAME,
                                 asGetMoreCommandResponseDocument(result, responseBuffers), connectionDescription,
-                                startTimeNanos, commandListener);
+                                System.nanoTime() - startTimeNanos, commandListener);
                     }
 
                     if (LOGGER.isDebugEnabled()) {
@@ -242,7 +243,7 @@ class GetMoreProtocol<T> implements LegacyProtocol<QueryResult<T>> {
                 }
             } catch (Throwable t) {
                 if (commandListener != null) {
-                    sendCommandFailedEvent(message, COMMAND_NAME, connectionDescription, startTimeNanos, t,
+                    sendCommandFailedEvent(message, COMMAND_NAME, connectionDescription, System.nanoTime() - startTimeNanos, t,
                             commandListener);
                 }
                 callback.onResult(null, t);

--- a/driver-core/src/main/com/mongodb/connection/InternalStreamConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/InternalStreamConnection.java
@@ -17,7 +17,6 @@
 package com.mongodb.connection;
 
 import com.mongodb.MongoClientException;
-import com.mongodb.MongoCommandException;
 import com.mongodb.MongoCompressor;
 import com.mongodb.MongoException;
 import com.mongodb.MongoInternalException;
@@ -34,13 +33,9 @@ import com.mongodb.diagnostics.logging.Loggers;
 import com.mongodb.event.CommandListener;
 import com.mongodb.session.SessionContext;
 import org.bson.BsonBinaryReader;
-import org.bson.BsonDocument;
-import org.bson.BsonInt32;
-import org.bson.BsonValue;
 import org.bson.ByteBuf;
 import org.bson.codecs.BsonDocumentCodec;
 import org.bson.codecs.Decoder;
-import org.bson.codecs.RawBsonDocumentCodec;
 import org.bson.io.ByteBufferBsonInput;
 
 import java.io.IOException;
@@ -63,9 +58,6 @@ import static com.mongodb.connection.ProtocolHelper.getCommandFailureException;
 import static com.mongodb.connection.ProtocolHelper.getMessageSettings;
 import static com.mongodb.connection.ProtocolHelper.getOperationTime;
 import static com.mongodb.connection.ProtocolHelper.isCommandOk;
-import static com.mongodb.connection.ProtocolHelper.sendCommandFailedEvent;
-import static com.mongodb.connection.ProtocolHelper.sendCommandStartedEvent;
-import static com.mongodb.connection.ProtocolHelper.sendCommandSucceededEvent;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -239,7 +231,7 @@ class InternalStreamConnection implements InternalConnection {
     public <T> T sendAndReceive(final CommandMessage message, final Decoder<T> decoder, final SessionContext sessionContext) {
         ByteBufferBsonOutput bsonOutput = new ByteBufferBsonOutput(this);
         LazyCommandDocument lazyCommandDocument = new LazyCommandDocument(message, bsonOutput);
-        CommandEventSender commandEventSender = new CommandEventSender(message, lazyCommandDocument);
+        CommandEventSender commandEventSender = createCommandEventSender(message, lazyCommandDocument);
 
         try {
             message.encode(bsonOutput, sessionContext);
@@ -262,7 +254,6 @@ class InternalStreamConnection implements InternalConnection {
             throw e;
         }
     }
-
     private void sendCommandMessage(final CommandMessage message, final LazyCommandDocument lazyCommandDocument,
                                     final ByteBufferBsonOutput bsonOutput, final SessionContext sessionContext) {
         try {
@@ -292,7 +283,7 @@ class InternalStreamConnection implements InternalConnection {
             updateSessionContext(sessionContext, responseBuffers);
 
             if (!isCommandOk(responseBuffers)) {
-                throw getCommandFailureException(getResponseDocument(responseBuffers, message.getId(), new BsonDocumentCodec()),
+                throw getCommandFailureException(responseBuffers.getResponseDocument(message.getId(), new BsonDocumentCodec()),
                         description.getServerAddress());
             }
 
@@ -320,7 +311,7 @@ class InternalStreamConnection implements InternalConnection {
         try {
             message.encode(bsonOutput, sessionContext);
             LazyCommandDocument lazyCommandDocument = new LazyCommandDocument(message, bsonOutput);
-            CommandEventSender commandEventSender = new CommandEventSender(message, lazyCommandDocument);
+            CommandEventSender commandEventSender = createCommandEventSender(message, lazyCommandDocument);
             commandEventSender.sendStartedEvent();
 
             if (sendCompressor == null || SECURITY_SENSITIVE_COMMANDS.contains(lazyCommandDocument.getName())) {
@@ -370,8 +361,9 @@ class InternalStreamConnection implements InternalConnection {
                                         isCommandOk(new BsonBinaryReader(new ByteBufferBsonInput(responseBuffers.getBodyByteBuffer())));
                                 responseBuffers.reset();
                                 if (!commandOk) {
-                                    MongoException commandFailureException = getCommandFailureException(getResponseDocument(responseBuffers,
-                                            messageId, new BsonDocumentCodec()), description.getServerAddress());
+                                    MongoException commandFailureException = getCommandFailureException(
+                                            responseBuffers.getResponseDocument(messageId, new BsonDocumentCodec()),
+                                            description.getServerAddress());
                                     commandEventSender.sendFailedEvent(commandFailureException);
                                     throw commandFailureException;
                                 }
@@ -583,13 +575,6 @@ class InternalStreamConnection implements InternalConnection {
         return stream.getBuffer(size);
     }
 
-    private static <T extends BsonDocument> T getResponseDocument(final ResponseBuffers responseBuffers,
-                                                                  final int messageId, final Decoder<T> decoder) {
-        ReplyMessage<T> replyMessage = new ReplyMessage<T>(responseBuffers, decoder, messageId);
-        responseBuffers.reset();
-        return replyMessage.getDocuments().get(0);
-    }
-
     private class MessageHeaderCallback implements SingleResultCallback<ByteBuf> {
         private final SingleResultCallback<ResponseBuffers> callback;
 
@@ -656,156 +641,12 @@ class InternalStreamConnection implements InternalConnection {
         }
     }
 
-    private static final Logger COMMAND_LOGGER = Loggers.getLogger("protocol.command");
-
-    private class CommandEventSender {
-        private final long startTimeNanos;
-        private final CommandMessage message;
-        private final LazyCommandDocument lazyCommandDocument;
-
-        CommandEventSender(final CommandMessage message, final LazyCommandDocument lazyCommandDocument) {
-            this.startTimeNanos = System.nanoTime();
-            this.message = message;
-            this.lazyCommandDocument = lazyCommandDocument;
-        }
-
-        public void sendStartedEvent() {
-            if (sendRequired()) {
-                BsonDocument commandDocumentForEvent = (SECURITY_SENSITIVE_COMMANDS.contains(lazyCommandDocument.getName()))
-                        ? new BsonDocument() : lazyCommandDocument.getDocument();
-
-                if (loggingRequired()) {
-                    COMMAND_LOGGER.debug(
-                            format("Sending command {%s : %s, ...} with request id %d to database %s on connection [%s] to server %s",
-                                    lazyCommandDocument.getName(), lazyCommandDocument.getFirstValue(), message.getId(),
-                                    message.getNamespace().getDatabaseName(), description.getConnectionId(),
-                                    description.getServerAddress()));
-                }
-
-                if (eventRequired()) {
-                    sendCommandStartedEvent(message, message.getNamespace().getDatabaseName(),
-                            lazyCommandDocument.getName(), commandDocumentForEvent, getDescription(), commandListener);
-                }
-            }
-        }
-
-        public void sendFailedEvent(final Throwable t) {
-            if (sendRequired()) {
-                Throwable commandEventException = t;
-                if (t instanceof MongoCommandException && (SECURITY_SENSITIVE_COMMANDS.contains(lazyCommandDocument.getName()))) {
-                    commandEventException = new MongoCommandException(new BsonDocument(), description.getServerAddress());
-                }
-                long elapsedTimeNanos = System.nanoTime() - startTimeNanos;
-
-                if (loggingRequired()) {
-                    COMMAND_LOGGER.debug(
-                            format("Execution of command with request id %d failed to complete successfully in %.2f ms on connection [%s] "
-                                            + "to server %s",
-                                    message.getId(), nanosToMillis(elapsedTimeNanos), description.getConnectionId(),
-                                    description.getServerAddress()),
-                            commandEventException);
-                }
-
-                if (eventRequired()) {
-                    sendCommandFailedEvent(message, lazyCommandDocument.getName(), description, elapsedTimeNanos, commandEventException,
-                            commandListener);
-                }
-            }
-        }
-
-        public void sendSucceededEvent(final ResponseBuffers responseBuffers) {
-            if (sendRequired()) {
-                BsonDocument responseDocumentForEvent = (SECURITY_SENSITIVE_COMMANDS.contains(lazyCommandDocument.getName()))
-                        ? new BsonDocument()
-                        : getResponseDocument(responseBuffers, message.getId(),
-                        new RawBsonDocumentCodec());
-                long elapsedTimeNanos = System.nanoTime() - startTimeNanos;
-
-                if (loggingRequired()) {
-                    COMMAND_LOGGER.debug(
-                            format("Execution of command with request id %d completed successfully in %.2f ms on connection [%s] "
-                                            + "to server %s",
-                                    message.getId(), nanosToMillis(elapsedTimeNanos), description.getConnectionId(),
-                                    description.getServerAddress()));
-                }
-
-                if (eventRequired()) {
-                    sendCommandSucceededEvent(message, lazyCommandDocument.getName(), responseDocumentForEvent, description,
-                            elapsedTimeNanos, commandListener);
-                }
-            }
-        }
-
-        public void sendSucceededEventForOneWayCommand() {
-            if (sendRequired()) {
-                BsonDocument responseDocumentForEvent = new BsonDocument("ok", new BsonInt32(1));
-                long elapsedTimeNanos = System.nanoTime() - startTimeNanos;
-
-                if (loggingRequired()) {
-                    COMMAND_LOGGER.debug(
-                            format("Execution of one-way command with request id %d completed successfully in %.2f ms on connection [%s] "
-                                            + "to server %s",
-                                    message.getId(), nanosToMillis(elapsedTimeNanos), description.getConnectionId(),
-                                    description.getServerAddress()));
-                }
-
-                if (eventRequired()) {
-                    sendCommandSucceededEvent(message, lazyCommandDocument.getName(), responseDocumentForEvent, description,
-                            elapsedTimeNanos, commandListener);
-                }
-            }
-        }
-
-        private boolean sendRequired() {
-            return (eventRequired() || loggingRequired()) && opened();
-        }
-
-        private boolean loggingRequired() {
-            return COMMAND_LOGGER.isDebugEnabled();
-        }
-
-        private boolean eventRequired() {
-            return commandListener != null;
-        }
-
-        private double nanosToMillis(final long elapsedTimeNanos) {
-            return elapsedTimeNanos / 1000000.0;
-        }
-    }
-
-    // Lazily determine the command document and command name, since they're only needed if either a command listener or compression
-    // is enabled
-    private static final class LazyCommandDocument {
-        private final CommandMessage commandMessage;
-        private final ByteBufferBsonOutput bsonOutput;
-        private BsonDocument commandDocument;
-        private String commandName;
-        private BsonValue firstValue;
-
-        private LazyCommandDocument(final CommandMessage commandMessage, final ByteBufferBsonOutput bsonOutput) {
-            this.commandMessage = commandMessage;
-            this.bsonOutput = bsonOutput;
-        }
-
-        public String getName() {
-            if (commandName == null) {
-                commandName = getDocument().getFirstKey();
-            }
-            return commandName;
-        }
-
-        public BsonValue getFirstValue() {
-            if (firstValue == null) {
-                firstValue = getDocument().getFirstValue();
-            }
-            return firstValue;
-        }
-
-        private BsonDocument getDocument() {
-            if (commandDocument == null) {
-                commandDocument = commandMessage.getCommandDocument(bsonOutput);
-            }
-            return commandDocument;
+    private CommandEventSender createCommandEventSender(final CommandMessage message,
+                                                               final LazyCommandDocument lazyCommandDocument) {
+        if (opened() && LoggingCommandEventSender.isRequired(commandListener)) {
+            return new LoggingCommandEventSender(SECURITY_SENSITIVE_COMMANDS, description, commandListener, message, lazyCommandDocument);
+        } else {
+            return new NoOpCommandEventSender();
         }
     }
 }

--- a/driver-core/src/main/com/mongodb/connection/KillCursorProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/KillCursorProtocol.java
@@ -74,12 +74,13 @@ class KillCursorProtocol implements LegacyProtocol<Void> {
             if (commandListener != null && namespace != null) {
                 sendCommandSucceededEvent(message, COMMAND_NAME, asCommandResponseDocument(),
                                           connection.getDescription(),
-                                          startTimeNanos, commandListener);
+                                          System.nanoTime() - startTimeNanos, commandListener);
             }
             return null;
         } catch (RuntimeException e) {
             if (commandListener != null && namespace != null) {
-                sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), startTimeNanos, e, commandListener);
+                sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), System.nanoTime() - startTimeNanos, e,
+                        commandListener);
             }
             throw e;
         }
@@ -112,11 +113,12 @@ class KillCursorProtocol implements LegacyProtocol<Void> {
                 public void onResult(final Void result, final Throwable t) {
                     if (commandListener != null && namespace != null) {
                         if (t != null) {
-                            sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), startTimeNanos, t, commandListener);
+                            sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(),
+                                    System.nanoTime() - startTimeNanos, t, commandListener);
                         } else {
                             sendCommandSucceededEvent(message, COMMAND_NAME, asCommandResponseDocument(),
                                     connection.getDescription(),
-                                    startTimeNanos, commandListener);
+                                    System.nanoTime() - startTimeNanos, commandListener);
                         }
                     }
 
@@ -126,7 +128,8 @@ class KillCursorProtocol implements LegacyProtocol<Void> {
             });
         } catch (Throwable t) {
             if (startEventSent) {
-                sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), startTimeNanos, t, commandListener);
+                sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), System.nanoTime() - startTimeNanos,
+                        t, commandListener);
             }
             callback.onResult(null, t);
         }

--- a/driver-core/src/main/com/mongodb/connection/LazyCommandDocument.java
+++ b/driver-core/src/main/com/mongodb/connection/LazyCommandDocument.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.connection;
+
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+
+// Lazily determine the command document and command name, since they're only needed if either a command listener or compression
+// is enabled
+final class LazyCommandDocument {
+    private final CommandMessage commandMessage;
+    private final ByteBufferBsonOutput bsonOutput;
+    private BsonDocument commandDocument;
+    private String commandName;
+    private BsonValue firstValue;
+
+    LazyCommandDocument(final CommandMessage commandMessage, final ByteBufferBsonOutput bsonOutput) {
+        this.commandMessage = commandMessage;
+        this.bsonOutput = bsonOutput;
+    }
+
+    String getName() {
+        if (commandName == null) {
+            commandName = getDocument().getFirstKey();
+        }
+        return commandName;
+    }
+
+    BsonValue getFirstValue() {
+        if (firstValue == null) {
+            firstValue = getDocument().getFirstValue();
+        }
+        return firstValue;
+    }
+
+    BsonDocument getDocument() {
+        if (commandDocument == null) {
+            commandDocument = commandMessage.getCommandDocument(bsonOutput);
+        }
+        return commandDocument;
+    }
+}

--- a/driver-core/src/main/com/mongodb/connection/LoggingCommandEventSender.java
+++ b/driver-core/src/main/com/mongodb/connection/LoggingCommandEventSender.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.connection;
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.diagnostics.logging.Logger;
+import com.mongodb.diagnostics.logging.Loggers;
+import com.mongodb.event.CommandListener;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.codecs.RawBsonDocumentCodec;
+
+import java.util.Set;
+
+import static com.mongodb.connection.ProtocolHelper.sendCommandFailedEvent;
+import static com.mongodb.connection.ProtocolHelper.sendCommandStartedEvent;
+import static com.mongodb.connection.ProtocolHelper.sendCommandSucceededEvent;
+import static java.lang.String.format;
+
+class LoggingCommandEventSender implements CommandEventSender {
+    private static final Logger LOGGER = Loggers.getLogger("protocol.command");
+
+    private final Set<String> securitySensitiveCommands;
+    private final ConnectionDescription description;
+    private final CommandListener commandListener;
+    private final long startTimeNanos;
+    private final CommandMessage message;
+    private final LazyCommandDocument lazyCommandDocument;
+
+    static boolean isRequired(final CommandListener commandListener) {
+        return commandListener != null || LOGGER.isDebugEnabled();
+    }
+
+    LoggingCommandEventSender(final Set<String> securitySensitiveCommands, final ConnectionDescription description,
+                              final CommandListener commandListener, final CommandMessage message,
+                              final LazyCommandDocument lazyCommandDocument) {
+        this.securitySensitiveCommands = securitySensitiveCommands;
+        this.description = description;
+        this.commandListener = commandListener;
+        this.startTimeNanos = System.nanoTime();
+        this.message = message;
+        this.lazyCommandDocument = lazyCommandDocument;
+    }
+
+    @Override
+    public void sendStartedEvent() {
+        if (loggingRequired()) {
+            LOGGER.debug(
+                    format("Sending command {%s : %s, ...} with request id %d to database %s on connection [%s] to server %s",
+                            lazyCommandDocument.getName(), lazyCommandDocument.getFirstValue(), message.getId(),
+                            message.getNamespace().getDatabaseName(), description.getConnectionId(), description.getServerAddress()));
+        }
+
+        if (eventRequired()) {
+            BsonDocument commandDocumentForEvent = (securitySensitiveCommands.contains(lazyCommandDocument.getName()))
+                    ? new BsonDocument() : lazyCommandDocument.getDocument();
+
+            sendCommandStartedEvent(message, message.getNamespace().getDatabaseName(),
+                    lazyCommandDocument.getName(), commandDocumentForEvent, description, commandListener);
+        }
+    }
+
+    @Override
+    public void sendFailedEvent(final Throwable t) {
+        Throwable commandEventException = t;
+        if (t instanceof MongoCommandException && (securitySensitiveCommands.contains(lazyCommandDocument.getName()))) {
+            commandEventException = new MongoCommandException(new BsonDocument(), description.getServerAddress());
+        }
+        long elapsedTimeNanos = System.nanoTime() - startTimeNanos;
+
+        if (loggingRequired()) {
+            LOGGER.debug(
+                    format("Execution of command with request id %d failed to complete successfully in %.2f ms on connection [%s] "
+                                    + "to server %s",
+                            message.getId(), nanosToMillis(elapsedTimeNanos), description.getConnectionId(),
+                            description.getServerAddress()),
+                    commandEventException);
+        }
+
+        if (eventRequired()) {
+            sendCommandFailedEvent(message, lazyCommandDocument.getName(), description, elapsedTimeNanos, commandEventException,
+                    commandListener);
+        }
+    }
+
+    @Override
+    public void sendSucceededEvent(final ResponseBuffers responseBuffers) {
+        long elapsedTimeNanos = System.nanoTime() - startTimeNanos;
+
+        if (loggingRequired()) {
+            LOGGER.debug(
+                    format("Execution of command with request id %d completed successfully in %.2f ms on connection [%s] to server %s",
+                            message.getId(), nanosToMillis(elapsedTimeNanos), description.getConnectionId(),
+                            description.getServerAddress()));
+        }
+
+        if (eventRequired()) {
+            BsonDocument responseDocumentForEvent = (securitySensitiveCommands.contains(lazyCommandDocument.getName()))
+                    ? new BsonDocument()
+                    : responseBuffers.getResponseDocument(message.getId(), new RawBsonDocumentCodec());
+            sendCommandSucceededEvent(message, lazyCommandDocument.getName(), responseDocumentForEvent, description,
+                    elapsedTimeNanos, commandListener);
+        }
+    }
+
+    @Override
+    public void sendSucceededEventForOneWayCommand() {
+        long elapsedTimeNanos = System.nanoTime() - startTimeNanos;
+
+        if (loggingRequired()) {
+            LOGGER.debug(
+                    format("Execution of one-way command with request id %d completed successfully in %.2f ms on connection [%s] "
+                                    + "to server %s",
+                            message.getId(), nanosToMillis(elapsedTimeNanos), description.getConnectionId(),
+                            description.getServerAddress()));
+        }
+
+        if (eventRequired()) {
+            BsonDocument responseDocumentForEvent = new BsonDocument("ok", new BsonInt32(1));
+            sendCommandSucceededEvent(message, lazyCommandDocument.getName(), responseDocumentForEvent, description,
+                    elapsedTimeNanos, commandListener);
+        }
+    }
+
+    private boolean loggingRequired() {
+        return LOGGER.isDebugEnabled();
+    }
+
+    private boolean eventRequired() {
+        return commandListener != null;
+    }
+
+    private double nanosToMillis(final long elapsedTimeNanos) {
+        return elapsedTimeNanos / 1000000.0;
+    }
+}

--- a/driver-core/src/main/com/mongodb/connection/NoOpCommandEventSender.java
+++ b/driver-core/src/main/com/mongodb/connection/NoOpCommandEventSender.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.connection;
+
+class NoOpCommandEventSender implements CommandEventSender {
+    @Override
+    public void sendStartedEvent() {
+    }
+
+    @Override
+    public void sendFailedEvent(final Throwable t) {
+    }
+
+    @Override
+    public void sendSucceededEvent(final ResponseBuffers responseBuffers) {
+    }
+
+    @Override
+    public void sendSucceededEventForOneWayCommand() {
+    }
+}

--- a/driver-core/src/main/com/mongodb/connection/ProtocolHelper.java
+++ b/driver-core/src/main/com/mongodb/connection/ProtocolHelper.java
@@ -260,12 +260,11 @@ final class ProtocolHelper {
     }
 
     static void sendCommandSucceededEvent(final RequestMessage message, final String commandName, final BsonDocument response,
-                                          final ConnectionDescription connectionDescription, final long startTimeNanos,
+                                          final ConnectionDescription connectionDescription, final long elapsedTimeNanos,
                                           final CommandListener commandListener) {
         try {
-            commandListener.commandSucceeded(new CommandSucceededEvent(message.getId(), connectionDescription,
-                                                                       commandName,
-                                                                       response, System.nanoTime() - startTimeNanos));
+            commandListener.commandSucceeded(new CommandSucceededEvent(message.getId(), connectionDescription, commandName, response,
+                    elapsedTimeNanos));
         } catch (Exception e) {
             if (PROTOCOL_EVENT_LOGGER.isWarnEnabled()) {
                 PROTOCOL_EVENT_LOGGER.warn(format("Exception thrown raising command succeeded event to listener %s", commandListener), e);
@@ -274,11 +273,11 @@ final class ProtocolHelper {
     }
 
     static void sendCommandFailedEvent(final RequestMessage message, final String commandName,
-                                       final ConnectionDescription connectionDescription, final long startTimeNanos,
+                                       final ConnectionDescription connectionDescription, final long elapsedTimeNanos,
                                        final Throwable throwable, final CommandListener commandListener) {
         try {
-            commandListener.commandFailed(new CommandFailedEvent(message.getId(), connectionDescription, commandName,
-                                                                 System.nanoTime() - startTimeNanos, throwable));
+            commandListener.commandFailed(new CommandFailedEvent(message.getId(), connectionDescription, commandName, elapsedTimeNanos,
+                    throwable));
         } catch (Exception e) {
             if (PROTOCOL_EVENT_LOGGER.isWarnEnabled()) {
                 PROTOCOL_EVENT_LOGGER.warn(format("Exception thrown raising command failed event to listener %s", commandListener), e);

--- a/driver-core/src/main/com/mongodb/connection/QueryProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/QueryProtocol.java
@@ -299,7 +299,8 @@ class QueryProtocol<T> implements LegacyProtocol<QueryResult<T>> {
 
         } catch (RuntimeException e) {
             if (commandListener != null) {
-                sendCommandFailedEvent(message, FIND_COMMAND_NAME, connection.getDescription(), startTimeNanos, e, commandListener);
+                sendCommandFailedEvent(message, FIND_COMMAND_NAME, connection.getDescription(), System.nanoTime() - startTimeNanos, e,
+                        commandListener);
             }
             throw e;
         }
@@ -327,8 +328,9 @@ class QueryProtocol<T> implements LegacyProtocol<QueryResult<T>> {
                                                 getCommandName(isExplainEvent), startTimeNanos, commandListener, callback,
                                                 receiveCallback));
         } catch (Throwable t) {
-            if (commandListener != null && sentStartedEvent) {
-                sendCommandFailedEvent(message, FIND_COMMAND_NAME, connection.getDescription(), startTimeNanos, t, commandListener);
+            if (commandListener != null) {
+                sendCommandFailedEvent(message, FIND_COMMAND_NAME, connection.getDescription(), System.nanoTime() - startTimeNanos, t,
+                        commandListener);
             }
             callback.onResult(null, t);
         }
@@ -359,7 +361,7 @@ class QueryProtocol<T> implements LegacyProtocol<QueryResult<T>> {
         if (commandListener != null) {
             BsonDocument response = asFindCommandResponseDocument(responseBuffers, queryResult, isExplainEvent);
             sendCommandSucceededEvent(message, getCommandName(isExplainEvent), response, connectionDescription,
-                                      startTimeNanos, commandListener);
+                    System.nanoTime() - startTimeNanos, commandListener);
         }
     }
 
@@ -534,7 +536,7 @@ class QueryProtocol<T> implements LegacyProtocol<QueryResult<T>> {
                 }
             } catch (Throwable t) {
                 if (commandListener != null) {
-                    sendCommandFailedEvent(message, FIND_COMMAND_NAME, connectionDescription, startTimeNanos, t,
+                    sendCommandFailedEvent(message, FIND_COMMAND_NAME, connectionDescription, System.nanoTime() - startTimeNanos, t,
                             commandListener);
                 }
                 callback.onResult(null, t);

--- a/driver-core/src/main/com/mongodb/connection/RequestMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/RequestMessage.java
@@ -117,15 +117,6 @@ abstract class RequestMessage {
     }
 
     /**
-     * Gets the collection namespace to send the message to.
-     *
-     * @return the namespace, which may be null for some message types
-     */
-    public String getNamespace() {
-        return getCollectionName();
-    }
-
-    /**
      * Gets the message settings.
      *
      * @return the message settings

--- a/driver-core/src/main/com/mongodb/connection/ResponseBuffers.java
+++ b/driver-core/src/main/com/mongodb/connection/ResponseBuffers.java
@@ -16,7 +16,9 @@
 
 package com.mongodb.connection;
 
+import org.bson.BsonDocument;
 import org.bson.ByteBuf;
+import org.bson.codecs.Decoder;
 
 import java.io.Closeable;
 
@@ -39,6 +41,12 @@ class ResponseBuffers implements Closeable {
      */
     public ReplyHeader getReplyHeader() {
         return replyHeader;
+    }
+
+    <T extends BsonDocument> T getResponseDocument(final int messageId, final Decoder<T> decoder) {
+        ReplyMessage<T> replyMessage = new ReplyMessage<T>(this, decoder, messageId);
+        reset();
+        return replyMessage.getDocuments().get(0);
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/connection/SendMessageCallback.java
+++ b/driver-core/src/main/com/mongodb/connection/SendMessageCallback.java
@@ -58,7 +58,8 @@ class SendMessageCallback<T> implements SingleResultCallback<Void> {
         buffer.close();
         if (t != null) {
             if (commandListener != null){
-                sendCommandFailedEvent(message, commandName, connection.getDescription(), startTimeNanos, t, commandListener);
+                sendCommandFailedEvent(message, commandName, connection.getDescription(), System.nanoTime() - startTimeNanos, t,
+                        commandListener);
             }
             callback.onResult(null, t);
         } else {

--- a/driver-core/src/main/com/mongodb/connection/WriteProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/WriteProtocol.java
@@ -148,15 +148,16 @@ abstract class WriteProtocol implements LegacyProtocol<WriteConcernResult> {
     private void sendSucceededEvent(final InternalConnection connection, final RequestMessage message,
                                     final BsonDocument responseDocument, final long startTimeNanos) {
         if (commandListener != null) {
-            sendCommandSucceededEvent(message, getCommandName(message), responseDocument, connection.getDescription(), startTimeNanos,
-                    commandListener);
+            sendCommandSucceededEvent(message, getCommandName(message), responseDocument, connection.getDescription(),
+                    System.nanoTime() - startTimeNanos, commandListener);
         }
     }
 
     private void sendFailedEvent(final InternalConnection connection, final RequestMessage message,
                                  final boolean sentCommandStartedEvent, final Throwable t, final long startTimeNanos) {
         if (commandListener != null && sentCommandStartedEvent) {
-            sendCommandFailedEvent(message, getCommandName(message), connection.getDescription(), startTimeNanos, t, commandListener);
+            sendCommandFailedEvent(message, getCommandName(message), connection.getDescription(), System.nanoTime() - startTimeNanos, t,
+                    commandListener);
         }
     }
 

--- a/driver-core/src/test/unit/com/mongodb/connection/ByteBufBsonDocumentSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/ByteBufBsonDocumentSpecification.groovy
@@ -201,8 +201,30 @@ class ByteBufBsonDocumentSpecification extends Specification {
     def 'should get first key'() {
         expect:
         byteBufDocument.getFirstKey() == document.keySet().iterator().next()
-        emptyByteBufDocument.getFirstKey() == null
         documentByteBuf.referenceCount == 1
+    }
+
+    def 'getFirstKey should throw NoSuchElementException if the document is empty'() {
+        when:
+        emptyByteBufDocument.getFirstKey()
+
+        then:
+        thrown(NoSuchElementException)
+        emptyDocumentByteBuf.referenceCount == 1
+    }
+
+    def 'should get first value'() {
+        expect:
+        byteBufDocument.getFirstValue() == document.values().iterator().next()
+        documentByteBuf.referenceCount == 1
+    }
+
+    def 'getFirstValue should throw NoSuchElementException if the document is empty'() {
+        when:
+        emptyByteBufDocument.getFirstValue()
+
+        then:
+        thrown(NoSuchElementException)
         emptyDocumentByteBuf.referenceCount == 1
     }
 


### PR DESCRIPTION
Log successful and failed command events, including elapsed time and request id.

Logs now look like this (against a 3.6 server)

```
   13:26:15.356 [main] DEBUG org.mongodb.driver.protocol.command - Sending command {insert : BsonString{value='test'}, ...} with request id 8 to database test on connection [connectionId{localValue:2, serverValue:694}] to server 127.0.0.1:27017
   13:26:15.356 [main] DEBUG org.mongodb.driver.protocol.command - Execution of one-way command with request id 8 completed successfully in 2.04 ms on connection [connectionId{localValue:2, serverValue:694}] to server 127.0.0.1:27017

   13:26:15.363 [main] DEBUG org.mongodb.driver.protocol.command - Sending command {ping : BsonInt32{value=1}, ...} with request id 9 to database admin on connection [connectionId{localValue:2, serverValue:694}] to server 127.0.0.1:27017
   13:26:15.364 [main] DEBUG org.mongodb.driver.protocol.command - Execution of command with request id 9 completed successfully in 1.32 ms on connection [connectionId{localValue:2, serverValue:694}] to server 127.0.0.1:27017

   13:26:15.366 [main] DEBUG org.mongodb.driver.protocol.command - Sending command {unknown : BsonInt32{value=1}, ...} with request id 10 to database admin on connection [connectionId{localValue:2, serverValue:694}] to server 127.0.0.1:27017
   13:26:15.397 [main] DEBUG org.mongodb.driver.protocol.command - Execution of command with request id 10 failed to complete successfully in 23.17 ms on connection [connectionId{localValue:2, serverValue:694}] to server 127.0.0.1:27017
com.mongodb.MongoCommandException: Command failed with error 59: 'no such command: 'unknown', bad cmd: '{ unknown: 1, $db: "admin", lsid: { id: UUID("9c1f42d0-a4f9-493e-bbcd-29a10a1fdc5a") } }'' on server 127.0.0.1:27017. The full response is { "operationTime" : { "$timestamp" : { "t" : 1514485379, "i" : 1 } }, "ok" : 0.0, "errmsg" : "no such command: 'unknown', bad cmd: '{ unknown: 1, $db: \"admin\", lsid: { id: UUID(\"9c1f42d0-a4f9-493e-bbcd-29a10a1fdc5a\") } }'", "code" : 59, "codeName" : "CommandNotFound" }
    at com.mongodb.connection.ProtocolHelper.getCommandFailureException...
    ...

```

There are two commits.  The first makes the behavioral change.  The second refactors InternalStreamConnection to extract the CommandEventSender into a top-level class.

Patch build: https://evergreen.mongodb.com/version/5a453f91e3c33137e1005fe4