### PR TITLE
JAVA-2722: Fix AbstractByteBufBsonDocument#getFirstKey

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/AbstractByteBufBsonDocument.java
+++ b/driver-core/src/main/com/mongodb/connection/AbstractByteBufBsonDocument.java
@@ -25,6 +25,7 @@ import org.bson.codecs.configuration.CodecRegistry;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
 
 import static org.bson.codecs.BsonValueCodecProvider.getClassForBsonType;
@@ -190,7 +191,7 @@ abstract class AbstractByteBufBsonDocument extends BsonDocument {
 
             @Override
             public String notFound() {
-                return null;
+                throw new NoSuchElementException();
             }
         });
     }

--- a/driver-core/src/test/unit/com/mongodb/connection/ByteBufBsonDocumentSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/ByteBufBsonDocumentSpecification.groovy
@@ -201,8 +201,15 @@ class ByteBufBsonDocumentSpecification extends Specification {
     def 'should get first key'() {
         expect:
         byteBufDocument.getFirstKey() == document.keySet().iterator().next()
-        emptyByteBufDocument.getFirstKey() == null
         documentByteBuf.referenceCount == 1
+    }
+
+    def 'getFirstKey should throw NoSuchElementException if the document is empty'() {
+        when:
+        emptyByteBufDocument.getFirstKey()
+
+        then:
+        thrown(NoSuchElementException)
         emptyDocumentByteBuf.referenceCount == 1
     }
 


### PR DESCRIPTION
Fix AbstractByteBufBsonDocument#getFirstKey to throw NoSuchElementException if the document is empty, as per specification of the method in BsonDocument