### PR TITLE
JAVA-2697, JAVA-2698: Improve command logging

### DIFF
--- a/bson/src/main/org/bson/AbstractBsonReader.java
+++ b/bson/src/main/org/bson/AbstractBsonReader.java
@@ -19,8 +19,6 @@ package org.bson;
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
 
-import java.io.Closeable;
-
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
@@ -29,7 +27,7 @@ import static java.util.Arrays.asList;
  *
  * @since 3.0
  */
-public abstract class AbstractBsonReader implements Closeable, BsonReader {
+public abstract class AbstractBsonReader implements BsonReader {
     private State state;
     private Context context;
     private BsonType currentBsonType;

--- a/bson/src/main/org/bson/AbstractBsonWriter.java
+++ b/bson/src/main/org/bson/AbstractBsonWriter.java
@@ -782,12 +782,26 @@ public abstract class AbstractBsonWriter implements BsonWriter, Closeable {
         }
     }
 
+    /**
+     * Return true if the current execution of the pipe method should be aborted.
+     *
+     * @return true if the current execution of the pipe method should be aborted.
+     *
+     * @since 3.7
+     */
+    protected boolean abortPipe() {
+        return false;
+    }
+
     private void pipeDocument(final BsonReader reader, final List<BsonElement> extraElements) {
         reader.readStartDocument();
         writeStartDocument();
         while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
             writeName(reader.readName());
             pipeValue(reader);
+            if (abortPipe()) {
+                return;
+            }
         }
         reader.readEndDocument();
         if (extraElements != null) {
@@ -889,6 +903,9 @@ public abstract class AbstractBsonWriter implements BsonWriter, Closeable {
         writeStartArray();
         while (reader.readBsonType() != BsonType.END_OF_DOCUMENT) {
             pipeValue(reader);
+            if (abortPipe()) {
+                return;
+            }
         }
         reader.readEndArray();
         writeEndArray();

--- a/bson/src/main/org/bson/BsonDocument.java
+++ b/bson/src/main/org/bson/BsonDocument.java
@@ -782,6 +782,17 @@ public class BsonDocument extends BsonValue implements Map<String, BsonValue>, C
         return keySet().iterator().next();
     }
 
+    /**
+     * Gets the first value in the document
+     *
+     * @return the first value in the document
+     * @throws java.util.NoSuchElementException if the document is empty
+     * @since 3.7
+     */
+    public BsonReader asBsonReader() {
+        return new BsonDocumentReader(this);
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {

--- a/bson/src/main/org/bson/BsonReader.java
+++ b/bson/src/main/org/bson/BsonReader.java
@@ -19,12 +19,14 @@ package org.bson;
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
 
+import java.io.Closeable;
+
 /**
  * An interface for reading a logical BSON document using a pull-oriented API.
  *
  * @since 3.0
  */
-public interface BsonReader {
+public interface BsonReader extends Closeable {
     /**
      * @return The current BsonType.
      */
@@ -403,4 +405,7 @@ public interface BsonReader {
      * @throws org.bson.BSONException if no mark has been set
      */
     void reset();
+
+    @Override
+    void close();
 }

--- a/bson/src/main/org/bson/json/JsonWriter.java
+++ b/bson/src/main/org/bson/json/JsonWriter.java
@@ -241,9 +241,20 @@ public class JsonWriter extends AbstractBsonWriter {
         strictJsonWriter.flush();
     }
 
+    /**
+     * Return true if the output has been truncated due to exceeding the length specified in {@link JsonWriterSettings#maxLength}.
+     *
+     * @return true if the output has been truncated
+     * @since 3.7
+     * @see JsonWriterSettings#maxLength
+     */
+    public boolean isTruncated() {
+        return strictJsonWriter.isTruncated();
+    }
+
     @Override
     protected boolean abortPipe() {
-        return settings.getMaxLength() != 0 && strictJsonWriter.getCurrentLength() == settings.getMaxLength();
+        return strictJsonWriter.isTruncated();
     }
 
     /**

--- a/bson/src/main/org/bson/json/JsonWriter.java
+++ b/bson/src/main/org/bson/json/JsonWriter.java
@@ -241,6 +241,11 @@ public class JsonWriter extends AbstractBsonWriter {
         strictJsonWriter.flush();
     }
 
+    @Override
+    protected boolean abortPipe() {
+        return settings.getMaxLength() != 0 && strictJsonWriter.getCurrentLength() == settings.getMaxLength();
+    }
+
     /**
      * The context for the writer, inheriting all the values from {@link org.bson.AbstractBsonWriter.Context}, and additionally providing
      * settings for the indentation level and whether there are any child elements at this level.

--- a/bson/src/main/org/bson/json/JsonWriter.java
+++ b/bson/src/main/org/bson/json/JsonWriter.java
@@ -59,7 +59,9 @@ public class JsonWriter extends AbstractBsonWriter {
         strictJsonWriter = new StrictCharacterStreamJsonWriter(writer, StrictCharacterStreamJsonWriterSettings.builder()
                                                                                .indent(settings.isIndent())
                                                                                .newLineCharacters(settings.getNewLineCharacters())
-                                                                               .indentCharacters(settings.getIndentCharacters()).build());
+                                                                               .indentCharacters(settings.getIndentCharacters())
+                                                                               .maxLength(settings.getMaxLength())
+                                                                               .build());
     }
 
     /**

--- a/bson/src/main/org/bson/json/JsonWriterSettings.java
+++ b/bson/src/main/org/bson/json/JsonWriterSettings.java
@@ -27,6 +27,7 @@ import org.bson.BsonWriterSettings;
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
 
+import static org.bson.assertions.Assertions.isTrueArgument;
 import static org.bson.assertions.Assertions.notNull;
 
 /**
@@ -80,6 +81,7 @@ public class JsonWriterSettings extends BsonWriterSettings {
     private final boolean indent;
     private final String newLineCharacters;
     private final String indentCharacters;
+    private final int maxLength;
     private final JsonMode outputMode;
     private final Converter<BsonNull> nullConverter;
     private final Converter<String> stringConverter;
@@ -191,6 +193,7 @@ public class JsonWriterSettings extends BsonWriterSettings {
         newLineCharacters = builder.newLineCharacters != null ? builder.newLineCharacters : System.getProperty("line.separator");
         indentCharacters = builder.indentCharacters;
         outputMode = builder.outputMode;
+        maxLength = builder.maxLength;
 
         if (builder.nullConverter != null) {
             nullConverter = builder.nullConverter;
@@ -367,6 +370,16 @@ public class JsonWriterSettings extends BsonWriterSettings {
      */
     public JsonMode getOutputMode() {
         return outputMode;
+    }
+
+    /**
+     * The maximum length of the JSON string.  The string will be truncated at this length.
+     *
+     * @return the maximum length of the JSON string
+     * @since 3.7
+     */
+    public int getMaxLength() {
+        return maxLength;
     }
 
     /**
@@ -550,6 +563,7 @@ public class JsonWriterSettings extends BsonWriterSettings {
         private String newLineCharacters = System.getProperty("line.separator");
         private String indentCharacters = "  ";
         private JsonMode outputMode = JsonMode.RELAXED;
+        private int maxLength;
         private Converter<BsonNull> nullConverter;
         private Converter<String> stringConverter;
         private Converter<Long> dateTimeConverter;
@@ -622,6 +636,19 @@ public class JsonWriterSettings extends BsonWriterSettings {
         public Builder outputMode(final JsonMode outputMode) {
             notNull("outputMode", outputMode);
             this.outputMode = outputMode;
+            return this;
+        }
+
+        /**
+         * Sets the maximum length of the JSON string.  The string will be truncated at this length.
+         *
+         * @param maxLength the maximum length, which must be &gt;= 0 where 0 indicate no maximum length
+         * @return the maximum length of the JSON string
+         * @since 3.7
+         */
+        public Builder maxLength(final int maxLength) {
+            isTrueArgument("maxLength >= 0", maxLength >= 0);
+            this.maxLength = maxLength;
             return this;
         }
 

--- a/bson/src/main/org/bson/json/StrictCharacterStreamJsonWriter.java
+++ b/bson/src/main/org/bson/json/StrictCharacterStreamJsonWriter.java
@@ -62,6 +62,7 @@ public final class StrictCharacterStreamJsonWriter implements StrictJsonWriter {
     private StrictJsonContext context = new StrictJsonContext(null, JsonContextType.TOP_LEVEL, "");
     private State state = State.INITIAL;
     private int curLength;
+    private boolean isTruncated;
 
     /**
      * Construct an instance.
@@ -249,6 +250,18 @@ public final class StrictCharacterStreamJsonWriter implements StrictJsonWriter {
         }
     }
 
+    /**
+     * Return true if the output has been truncated due to exceeding the length specified in
+     * {@link StrictCharacterStreamJsonWriterSettings#maxLength}.
+     *
+     * @return true if the output has been truncated
+     * @since 3.7
+     * @see StrictCharacterStreamJsonWriterSettings#maxLength
+     */
+    public boolean isTruncated() {
+        return isTruncated;
+    }
+
     void flush() {
         try {
             writer.flush();
@@ -349,6 +362,7 @@ public final class StrictCharacterStreamJsonWriter implements StrictJsonWriter {
             } else {
                 writer.write(str.substring(0, settings.getMaxLength() - curLength));
                 curLength = settings.getMaxLength();
+                isTruncated = true;
             }
         } catch (IOException e) {
             throwBSONException(e);
@@ -360,6 +374,8 @@ public final class StrictCharacterStreamJsonWriter implements StrictJsonWriter {
             if (settings.getMaxLength() == 0 || curLength < settings.getMaxLength()) {
                 writer.write(c);
                 curLength++;
+            } else {
+                isTruncated = true;
             }
         } catch (IOException e) {
             throwBSONException(e);

--- a/bson/src/main/org/bson/json/StrictCharacterStreamJsonWriterSettings.java
+++ b/bson/src/main/org/bson/json/StrictCharacterStreamJsonWriterSettings.java
@@ -30,6 +30,7 @@ public final class StrictCharacterStreamJsonWriterSettings {
     private final boolean indent;
     private final String newLineCharacters;
     private final String indentCharacters;
+    private final int maxLength;
 
     /**
      * Create a builder for StrictCharacterStreamJsonWriterSettings, which are immutable.
@@ -44,6 +45,7 @@ public final class StrictCharacterStreamJsonWriterSettings {
         indent = builder.indent;
         newLineCharacters = builder.newLineCharacters != null ? builder.newLineCharacters : System.getProperty("line.separator");
         indentCharacters = builder.indentCharacters;
+        maxLength = builder.maxLength;
     }
 
     /**
@@ -75,6 +77,16 @@ public final class StrictCharacterStreamJsonWriterSettings {
     }
 
     /**
+     * The maximum length of the JSON string.  The string will be truncated at this length.
+     *
+     * @return the maximum length of the JSON string
+     * @since 3.7
+     */
+    public int getMaxLength() {
+        return maxLength;
+    }
+
+    /**
      * A builder for StrictCharacterStreamJsonWriterSettings
      *
      * @since 3.4
@@ -83,6 +95,7 @@ public final class StrictCharacterStreamJsonWriterSettings {
         private boolean indent;
         private String newLineCharacters = System.getProperty("line.separator");
         private String indentCharacters = "  ";
+        private int maxLength;
 
         /**
          * Build a JsonWriterSettings instance.
@@ -125,6 +138,18 @@ public final class StrictCharacterStreamJsonWriterSettings {
         public Builder indentCharacters(final String indentCharacters) {
             notNull("indentCharacters", indentCharacters);
             this.indentCharacters = indentCharacters;
+            return this;
+        }
+
+        /**
+         * Sets the maximum length of the JSON string.  The string will be truncated at this length.
+         *
+         * @param maxLength the maximum length, which must be &gt;= 0 where 0 indicate no maximum length
+         * @return the maximum length of the JSON string
+         * @since 3.7
+         */
+        public Builder maxLength(final int maxLength) {
+            this.maxLength = maxLength;
             return this;
         }
 

--- a/bson/src/main/org/bson/json/StrictJsonWriter.java
+++ b/bson/src/main/org/bson/json/StrictJsonWriter.java
@@ -174,4 +174,12 @@ public interface StrictJsonWriter {
      * @throws org.bson.BSONException if the underlying Writer throws an IOException
      */
     void writeEndObject();
+
+    /**
+     * Return true if the output has been truncated due to exceeding any maximum length specified in settings.
+     *
+     * @return true if the output has been truncated
+     * @since 3.7
+     */
+    boolean isTruncated();
 }

--- a/bson/src/test/unit/org/bson/BsonDocumentSpecification.groovy
+++ b/bson/src/test/unit/org/bson/BsonDocumentSpecification.groovy
@@ -16,9 +16,13 @@
 
 package org.bson
 
+import org.bson.codecs.BsonDocumentCodec
+import org.bson.codecs.DecoderContext
 import org.bson.types.Decimal128
 import org.bson.types.ObjectId
 import spock.lang.Specification
+
+import static org.bson.BsonHelper.documentWithValuesOfEveryType
 
 class BsonDocumentSpecification extends Specification {
 
@@ -341,6 +345,20 @@ class BsonDocumentSpecification extends Specification {
 
         then:
         thrown(NoSuchElementException)
+    }
+
+    def 'should create BsonReader'() {
+        given:
+        def document = documentWithValuesOfEveryType()
+
+        when:
+        def reader = document.asBsonReader()
+
+        then:
+        new BsonDocumentCodec().decode(reader, DecoderContext.builder().build()) == document
+
+        cleanup:
+        reader.close()
     }
 
     def 'should serialize and deserialize'() {

--- a/bson/src/test/unit/org/bson/RawBsonDocumentSpecification.groovy
+++ b/bson/src/test/unit/org/bson/RawBsonDocumentSpecification.groovy
@@ -266,6 +266,17 @@ class RawBsonDocumentSpecification extends Specification {
         thrown(NoSuchElementException)
     }
 
+    def 'should create BsonReader'() {
+        when:
+        def reader = document.asBsonReader()
+
+        then:
+        new BsonDocumentCodec().decode(reader, DecoderContext.builder().build()) == document
+
+        cleanup:
+        reader.close()
+    }
+
     def 'toJson should return equivalent JSON'() {
         expect:
         new RawBsonDocumentCodec().decode(new JsonReader(rawDocument.toJson()), DecoderContext.builder().build()) == document

--- a/bson/src/test/unit/org/bson/json/JsonWriterSettingsSpecification.groovy
+++ b/bson/src/test/unit/org/bson/json/JsonWriterSettingsSpecification.groovy
@@ -35,6 +35,7 @@ class JsonWriterSettingsSpecification extends Specification {
         then:
         !settings.isIndent()
         settings.getOutputMode() == JsonMode.RELAXED
+        settings.getMaxLength() == 0
     }
 
 
@@ -66,6 +67,15 @@ class JsonWriterSettingsSpecification extends Specification {
         settings.getNewLineCharacters() == '\r\n'
     }
 
+    def 'test max length setting'() {
+        when:
+        def settings = JsonWriterSettings.builder()
+                .maxLength(100).build()
+
+        then:
+        settings.getMaxLength() == 100
+    }
+
     def 'test constructors'() {
         when:
         def settings = new JsonWriterSettings()
@@ -73,6 +83,7 @@ class JsonWriterSettingsSpecification extends Specification {
         then:
         !settings.isIndent()
         settings.getOutputMode() == JsonMode.STRICT
+        settings.getMaxLength() == 0
 
         when:
         settings = new JsonWriterSettings(JsonMode.SHELL)

--- a/bson/src/test/unit/org/bson/json/JsonWriterSpecification.groovy
+++ b/bson/src/test/unit/org/bson/json/JsonWriterSpecification.groovy
@@ -54,7 +54,9 @@ class JsonWriterSpecification extends Specification {
         writer.pipe(reader)
 
         then:
-        stringWriter.toString() == jsonWithValuesOfEveryType[0..Math.min(maxLength, jsonWithValuesOfEveryType.length()) - 1]
+        stringWriter.toString() == ((maxLength == 0) ?
+                jsonWithValuesOfEveryType : jsonWithValuesOfEveryType[0..<Math.min(maxLength, jsonWithValuesOfEveryType.length())])
+        writer.isTruncated() || maxLength == 0 || jsonWithValuesOfEveryType.length() <= maxLength
 
         where:
         maxLength << (0..1000)

--- a/bson/src/test/unit/org/bson/json/JsonWriterSpecification.groovy
+++ b/bson/src/test/unit/org/bson/json/JsonWriterSpecification.groovy
@@ -32,6 +32,7 @@ class JsonWriterSpecification extends Specification {
 
     def stringWriter = new StringWriter();
     def writer = new JsonWriter(stringWriter)
+    def jsonWithValuesOfEveryType = documentWithValuesOfEveryType().toJson(JsonWriterSettings.builder().build())
 
     def 'should pipe all types'() {
         given:
@@ -42,6 +43,21 @@ class JsonWriterSpecification extends Specification {
 
         then:
         stringWriter.toString() == documentWithValuesOfEveryType().toJson()
+    }
+
+    def 'should pipe all types with capped length'() {
+        given:
+        def reader = new BsonDocumentReader(documentWithValuesOfEveryType())
+        def writer = new JsonWriter(stringWriter, JsonWriterSettings.builder().maxLength(maxLength).build())
+
+        when:
+        writer.pipe(reader)
+
+        then:
+        stringWriter.toString() == jsonWithValuesOfEveryType[0..Math.min(maxLength, jsonWithValuesOfEveryType.length()) - 1]
+
+        where:
+        maxLength << (0..1000)
     }
 
     def shouldThrowAnExceptionWhenWritingNullName() {

--- a/bson/src/test/unit/org/bson/json/StrictCharacterStreamJsonWriterSpecification.groovy
+++ b/bson/src/test/unit/org/bson/json/StrictCharacterStreamJsonWriterSpecification.groovy
@@ -493,8 +493,9 @@ class StrictCharacterStreamJsonWriterSpecification extends Specification {
         writer.writeEndObject()
 
         then:
-        stringWriter.toString() == fullJsonText[0..Math.min(maxLength, fullJsonText.length()) - 1]
+        stringWriter.toString() == fullJsonText[0..<Math.min(maxLength, fullJsonText.length())]
         writer.getCurrentLength() == Math.min(maxLength, fullJsonText.length())
+        writer.isTruncated() || fullJsonText.length() <= maxLength
 
         where:
         maxLength << (1..20)

--- a/bson/src/test/unit/org/bson/json/StrictCharacterStreamJsonWriterSpecification.groovy
+++ b/bson/src/test/unit/org/bson/json/StrictCharacterStreamJsonWriterSpecification.groovy
@@ -480,4 +480,23 @@ class StrictCharacterStreamJsonWriterSpecification extends Specification {
         thrown(IllegalArgumentException)
 
     }
+
+    def shouldStopAtMaxLength() {
+        given:
+        def fullJsonText = '{ "n" : null }'
+        writer = new StrictCharacterStreamJsonWriter(stringWriter,
+                StrictCharacterStreamJsonWriterSettings.builder().maxLength(maxLength).build())
+
+        when:
+        writer.writeStartObject()
+        writer.writeNull('n')
+        writer.writeEndObject()
+
+        then:
+        stringWriter.toString() == fullJsonText[0..Math.min(maxLength, fullJsonText.length()) - 1]
+        writer.getCurrentLength() == Math.min(maxLength, fullJsonText.length())
+
+        where:
+        maxLength << (1..20)
+    }
 }

--- a/config/clirr-exclude.yml
+++ b/config/clirr-exclude.yml
@@ -18,6 +18,7 @@ members:
   - readDecimal128(java.lang.String)
   - peekBinarySize()
   - getMark()
+  - close()
   org.bson.BsonWriter:
   - writeDecimal128(org.bson.types.Decimal128)
   - writeDecimal128(java.lang.String,org.bson.types.Decimal128)

--- a/driver-core/src/main/com/mongodb/connection/ByteBufBsonDocument.java
+++ b/driver-core/src/main/com/mongodb/connection/ByteBufBsonDocument.java
@@ -20,6 +20,7 @@ package com.mongodb.connection;
 
 import org.bson.BsonBinaryReader;
 import org.bson.BsonDocument;
+import org.bson.BsonReader;
 import org.bson.BsonType;
 import org.bson.ByteBuf;
 import org.bson.RawBsonDocument;
@@ -111,6 +112,11 @@ class ByteBufBsonDocument extends AbstractByteBufBsonDocument {
             duplicate.release();
             reader.close();
         }
+    }
+
+    @Override
+    public BsonReader asBsonReader() {
+        return new BsonBinaryReader(new ByteBufferBsonInput(byteBuf.duplicate()));
     }
 
     <T> T findInDocument(final Finder<T> finder) {

--- a/driver-core/src/main/com/mongodb/connection/CommandEventSender.java
+++ b/driver-core/src/main/com/mongodb/connection/CommandEventSender.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.connection;
+
+interface CommandEventSender {
+    void sendStartedEvent();
+
+    void sendFailedEvent(Throwable t);
+
+    void sendSucceededEvent(ResponseBuffers responseBuffers);
+
+    void sendSucceededEventForOneWayCommand();
+}

--- a/driver-core/src/main/com/mongodb/connection/CommandMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/CommandMessage.java
@@ -105,6 +105,10 @@ final class CommandMessage extends RequestMessage {
         return calculateIsResponseExpected();
     }
 
+    MongoNamespace getNamespace() {
+        return namespace;
+    }
+
     ReadPreference getReadPreference() {
         return readPreference;
     }

--- a/driver-core/src/main/com/mongodb/connection/GetMoreProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/GetMoreProtocol.java
@@ -96,7 +96,7 @@ class GetMoreProtocol<T> implements LegacyProtocol<QueryResult<T>> {
                 if (commandListener != null) {
                     sendCommandSucceededEvent(message, COMMAND_NAME,
                                               asGetMoreCommandResponseDocument(queryResult, responseBuffers), connection.getDescription(),
-                                              startTimeNanos, commandListener);
+                                              System.nanoTime() - startTimeNanos, commandListener);
                 }
             } finally {
                 responseBuffers.close();
@@ -105,7 +105,8 @@ class GetMoreProtocol<T> implements LegacyProtocol<QueryResult<T>> {
             return queryResult;
         } catch (RuntimeException e) {
             if (commandListener != null) {
-                sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), startTimeNanos, e, commandListener);
+                sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), System.nanoTime() - startTimeNanos, e,
+                        commandListener);
             }
             throw e;
         }
@@ -142,7 +143,7 @@ class GetMoreProtocol<T> implements LegacyProtocol<QueryResult<T>> {
                                                 startTimeNanos, commandListener, callback, receiveCallback));
         } catch (Throwable t) {
             if (sentStartedEvent) {
-                sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), startTimeNanos, t,
+                sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), System.nanoTime() - startTimeNanos, t,
                         commandListener);
             }
             callback.onResult(null, t);
@@ -230,7 +231,7 @@ class GetMoreProtocol<T> implements LegacyProtocol<QueryResult<T>> {
                     if (commandListener != null) {
                         sendCommandSucceededEvent(message, COMMAND_NAME,
                                 asGetMoreCommandResponseDocument(result, responseBuffers), connectionDescription,
-                                startTimeNanos, commandListener);
+                                System.nanoTime() - startTimeNanos, commandListener);
                     }
 
                     if (LOGGER.isDebugEnabled()) {
@@ -242,7 +243,7 @@ class GetMoreProtocol<T> implements LegacyProtocol<QueryResult<T>> {
                 }
             } catch (Throwable t) {
                 if (commandListener != null) {
-                    sendCommandFailedEvent(message, COMMAND_NAME, connectionDescription, startTimeNanos, t,
+                    sendCommandFailedEvent(message, COMMAND_NAME, connectionDescription, System.nanoTime() - startTimeNanos, t,
                             commandListener);
                 }
                 callback.onResult(null, t);

--- a/driver-core/src/main/com/mongodb/connection/KillCursorProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/KillCursorProtocol.java
@@ -74,12 +74,13 @@ class KillCursorProtocol implements LegacyProtocol<Void> {
             if (commandListener != null && namespace != null) {
                 sendCommandSucceededEvent(message, COMMAND_NAME, asCommandResponseDocument(),
                                           connection.getDescription(),
-                                          startTimeNanos, commandListener);
+                                          System.nanoTime() - startTimeNanos, commandListener);
             }
             return null;
         } catch (RuntimeException e) {
             if (commandListener != null && namespace != null) {
-                sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), startTimeNanos, e, commandListener);
+                sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), System.nanoTime() - startTimeNanos, e,
+                        commandListener);
             }
             throw e;
         }
@@ -112,11 +113,12 @@ class KillCursorProtocol implements LegacyProtocol<Void> {
                 public void onResult(final Void result, final Throwable t) {
                     if (commandListener != null && namespace != null) {
                         if (t != null) {
-                            sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), startTimeNanos, t, commandListener);
+                            sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(),
+                                    System.nanoTime() - startTimeNanos, t, commandListener);
                         } else {
                             sendCommandSucceededEvent(message, COMMAND_NAME, asCommandResponseDocument(),
                                     connection.getDescription(),
-                                    startTimeNanos, commandListener);
+                                    System.nanoTime() - startTimeNanos, commandListener);
                         }
                     }
 
@@ -126,7 +128,8 @@ class KillCursorProtocol implements LegacyProtocol<Void> {
             });
         } catch (Throwable t) {
             if (startEventSent) {
-                sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), startTimeNanos, t, commandListener);
+                sendCommandFailedEvent(message, COMMAND_NAME, connection.getDescription(), System.nanoTime() - startTimeNanos,
+                        t, commandListener);
             }
             callback.onResult(null, t);
         }

--- a/driver-core/src/main/com/mongodb/connection/LoggingCommandEventSender.java
+++ b/driver-core/src/main/com/mongodb/connection/LoggingCommandEventSender.java
@@ -64,7 +64,7 @@ class LoggingCommandEventSender implements CommandEventSender {
     public void sendStartedEvent() {
         if (loggingRequired()) {
             logger.debug(
-                    format("Sending command '%s ...' with request id %d to database %s on connection [%s] to server %s",
+                    format("Sending command '%s' with request id %d to database %s on connection [%s] to server %s",
                             getTruncatedJsonCommand(), message.getId(),
                             message.getNamespace().getDatabaseName(), description.getConnectionId(), description.getServerAddress()));
         }
@@ -90,6 +90,10 @@ class LoggingCommandEventSender implements CommandEventSender {
                     JsonWriterSettings.builder().outputMode(JsonMode.RELAXED).maxLength(MAX_COMMAND_DOCUMENT_LENGTH_TO_LOG).build());
 
             jsonWriter.pipe(bsonReader);
+
+            if (jsonWriter.isTruncated()) {
+                writer.append(" ...");
+            }
 
             return writer.toString();
         } finally {

--- a/driver-core/src/main/com/mongodb/connection/LoggingCommandEventSender.java
+++ b/driver-core/src/main/com/mongodb/connection/LoggingCommandEventSender.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.connection;
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.diagnostics.logging.Logger;
+import com.mongodb.event.CommandListener;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonReader;
+import org.bson.codecs.RawBsonDocumentCodec;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriter;
+import org.bson.json.JsonWriterSettings;
+
+import java.io.StringWriter;
+import java.util.Set;
+
+import static com.mongodb.connection.ProtocolHelper.sendCommandFailedEvent;
+import static com.mongodb.connection.ProtocolHelper.sendCommandStartedEvent;
+import static com.mongodb.connection.ProtocolHelper.sendCommandSucceededEvent;
+import static java.lang.String.format;
+
+class LoggingCommandEventSender implements CommandEventSender {
+    private static final int MAX_COMMAND_DOCUMENT_LENGTH_TO_LOG = 1000;
+
+    private final Set<String> securitySensitiveCommands;
+    private final ConnectionDescription description;
+    private final CommandListener commandListener;
+    private final Logger logger;
+    private final long startTimeNanos;
+    private final CommandMessage message;
+    private final String commandName;
+    private volatile BsonDocument commandDocument;
+
+    LoggingCommandEventSender(final Set<String> securitySensitiveCommands, final ConnectionDescription description,
+                              final CommandListener commandListener, final CommandMessage message,
+                              final ByteBufferBsonOutput bsonOutput, final Logger logger) {
+        this.securitySensitiveCommands = securitySensitiveCommands;
+        this.description = description;
+        this.commandListener = commandListener;
+        this.logger = logger;
+        this.startTimeNanos = System.nanoTime();
+        this.message = message;
+        this.commandDocument = message.getCommandDocument(bsonOutput);
+        this.commandName = commandDocument.getFirstKey();
+    }
+
+    @Override
+    public void sendStartedEvent() {
+        if (loggingRequired()) {
+            logger.debug(
+                    format("Sending command '%s ...' with request id %d to database %s on connection [%s] to server %s",
+                            getTruncatedJsonCommand(), message.getId(),
+                            message.getNamespace().getDatabaseName(), description.getConnectionId(), description.getServerAddress()));
+        }
+
+        if (eventRequired()) {
+            BsonDocument commandDocumentForEvent = (securitySensitiveCommands.contains(commandName))
+                    ? new BsonDocument() : commandDocument;
+
+            sendCommandStartedEvent(message, message.getNamespace().getDatabaseName(),
+                    commandName, commandDocumentForEvent, description, commandListener);
+        }
+        // the buffer underlying the command document may be released after the started event, so set to null to ensure it's not used
+        // when sending the failed or succeeded event
+        commandDocument = null;
+    }
+
+    private String getTruncatedJsonCommand() {
+        StringWriter writer = new StringWriter();
+
+        BsonReader bsonReader = commandDocument.asBsonReader();
+        try {
+            JsonWriter jsonWriter = new JsonWriter(writer,
+                    JsonWriterSettings.builder().outputMode(JsonMode.RELAXED).maxLength(MAX_COMMAND_DOCUMENT_LENGTH_TO_LOG).build());
+
+            jsonWriter.pipe(bsonReader);
+
+            return writer.toString();
+        } finally {
+            bsonReader.close();
+        }
+    }
+
+    @Override
+    public void sendFailedEvent(final Throwable t) {
+        Throwable commandEventException = t;
+        if (t instanceof MongoCommandException && (securitySensitiveCommands.contains(commandName))) {
+            commandEventException = new MongoCommandException(new BsonDocument(), description.getServerAddress());
+        }
+        long elapsedTimeNanos = System.nanoTime() - startTimeNanos;
+
+        if (loggingRequired()) {
+            logger.debug(
+                    format("Execution of command with request id %d failed to complete successfully in %.2f ms on connection [%s] "
+                                    + "to server %s",
+                            message.getId(), nanosToMillis(elapsedTimeNanos), description.getConnectionId(),
+                            description.getServerAddress()),
+                    commandEventException);
+        }
+
+        if (eventRequired()) {
+            sendCommandFailedEvent(message, commandName, description, elapsedTimeNanos, commandEventException, commandListener);
+        }
+    }
+
+    @Override
+    public void sendSucceededEvent(final ResponseBuffers responseBuffers) {
+        long elapsedTimeNanos = System.nanoTime() - startTimeNanos;
+
+        if (loggingRequired()) {
+            logger.debug(
+                    format("Execution of command with request id %d completed successfully in %.2f ms on connection [%s] to server %s",
+                            message.getId(), nanosToMillis(elapsedTimeNanos), description.getConnectionId(),
+                            description.getServerAddress()));
+        }
+
+        if (eventRequired()) {
+            BsonDocument responseDocumentForEvent = (securitySensitiveCommands.contains(commandName))
+                    ? new BsonDocument()
+                    : responseBuffers.getResponseDocument(message.getId(), new RawBsonDocumentCodec());
+            sendCommandSucceededEvent(message, commandName, responseDocumentForEvent, description,
+                    elapsedTimeNanos, commandListener);
+        }
+    }
+
+    @Override
+    public void sendSucceededEventForOneWayCommand() {
+        long elapsedTimeNanos = System.nanoTime() - startTimeNanos;
+
+        if (loggingRequired()) {
+            logger.debug(
+                    format("Execution of one-way command with request id %d completed successfully in %.2f ms on connection [%s] "
+                                    + "to server %s",
+                            message.getId(), nanosToMillis(elapsedTimeNanos), description.getConnectionId(),
+                            description.getServerAddress()));
+        }
+
+        if (eventRequired()) {
+            BsonDocument responseDocumentForEvent = new BsonDocument("ok", new BsonInt32(1));
+            sendCommandSucceededEvent(message, commandName, responseDocumentForEvent, description,
+                    elapsedTimeNanos, commandListener);
+        }
+    }
+
+    private boolean loggingRequired() {
+        return logger.isDebugEnabled();
+    }
+
+    private boolean eventRequired() {
+        return commandListener != null;
+    }
+
+    private double nanosToMillis(final long elapsedTimeNanos) {
+        return elapsedTimeNanos / 1000000.0;
+    }
+}

--- a/driver-core/src/main/com/mongodb/connection/NoOpCommandEventSender.java
+++ b/driver-core/src/main/com/mongodb/connection/NoOpCommandEventSender.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.connection;
+
+class NoOpCommandEventSender implements CommandEventSender {
+    @Override
+    public void sendStartedEvent() {
+    }
+
+    @Override
+    public void sendFailedEvent(final Throwable t) {
+    }
+
+    @Override
+    public void sendSucceededEvent(final ResponseBuffers responseBuffers) {
+    }
+
+    @Override
+    public void sendSucceededEventForOneWayCommand() {
+    }
+}

--- a/driver-core/src/main/com/mongodb/connection/ProtocolHelper.java
+++ b/driver-core/src/main/com/mongodb/connection/ProtocolHelper.java
@@ -260,12 +260,11 @@ final class ProtocolHelper {
     }
 
     static void sendCommandSucceededEvent(final RequestMessage message, final String commandName, final BsonDocument response,
-                                          final ConnectionDescription connectionDescription, final long startTimeNanos,
+                                          final ConnectionDescription connectionDescription, final long elapsedTimeNanos,
                                           final CommandListener commandListener) {
         try {
-            commandListener.commandSucceeded(new CommandSucceededEvent(message.getId(), connectionDescription,
-                                                                       commandName,
-                                                                       response, System.nanoTime() - startTimeNanos));
+            commandListener.commandSucceeded(new CommandSucceededEvent(message.getId(), connectionDescription, commandName, response,
+                    elapsedTimeNanos));
         } catch (Exception e) {
             if (PROTOCOL_EVENT_LOGGER.isWarnEnabled()) {
                 PROTOCOL_EVENT_LOGGER.warn(format("Exception thrown raising command succeeded event to listener %s", commandListener), e);
@@ -274,11 +273,11 @@ final class ProtocolHelper {
     }
 
     static void sendCommandFailedEvent(final RequestMessage message, final String commandName,
-                                       final ConnectionDescription connectionDescription, final long startTimeNanos,
+                                       final ConnectionDescription connectionDescription, final long elapsedTimeNanos,
                                        final Throwable throwable, final CommandListener commandListener) {
         try {
-            commandListener.commandFailed(new CommandFailedEvent(message.getId(), connectionDescription, commandName,
-                                                                 System.nanoTime() - startTimeNanos, throwable));
+            commandListener.commandFailed(new CommandFailedEvent(message.getId(), connectionDescription, commandName, elapsedTimeNanos,
+                    throwable));
         } catch (Exception e) {
             if (PROTOCOL_EVENT_LOGGER.isWarnEnabled()) {
                 PROTOCOL_EVENT_LOGGER.warn(format("Exception thrown raising command failed event to listener %s", commandListener), e);

--- a/driver-core/src/main/com/mongodb/connection/QueryProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/QueryProtocol.java
@@ -299,7 +299,8 @@ class QueryProtocol<T> implements LegacyProtocol<QueryResult<T>> {
 
         } catch (RuntimeException e) {
             if (commandListener != null) {
-                sendCommandFailedEvent(message, FIND_COMMAND_NAME, connection.getDescription(), startTimeNanos, e, commandListener);
+                sendCommandFailedEvent(message, FIND_COMMAND_NAME, connection.getDescription(), System.nanoTime() - startTimeNanos, e,
+                        commandListener);
             }
             throw e;
         }
@@ -327,8 +328,9 @@ class QueryProtocol<T> implements LegacyProtocol<QueryResult<T>> {
                                                 getCommandName(isExplainEvent), startTimeNanos, commandListener, callback,
                                                 receiveCallback));
         } catch (Throwable t) {
-            if (commandListener != null && sentStartedEvent) {
-                sendCommandFailedEvent(message, FIND_COMMAND_NAME, connection.getDescription(), startTimeNanos, t, commandListener);
+            if (commandListener != null) {
+                sendCommandFailedEvent(message, FIND_COMMAND_NAME, connection.getDescription(), System.nanoTime() - startTimeNanos, t,
+                        commandListener);
             }
             callback.onResult(null, t);
         }
@@ -359,7 +361,7 @@ class QueryProtocol<T> implements LegacyProtocol<QueryResult<T>> {
         if (commandListener != null) {
             BsonDocument response = asFindCommandResponseDocument(responseBuffers, queryResult, isExplainEvent);
             sendCommandSucceededEvent(message, getCommandName(isExplainEvent), response, connectionDescription,
-                                      startTimeNanos, commandListener);
+                    System.nanoTime() - startTimeNanos, commandListener);
         }
     }
 
@@ -534,7 +536,7 @@ class QueryProtocol<T> implements LegacyProtocol<QueryResult<T>> {
                 }
             } catch (Throwable t) {
                 if (commandListener != null) {
-                    sendCommandFailedEvent(message, FIND_COMMAND_NAME, connectionDescription, startTimeNanos, t,
+                    sendCommandFailedEvent(message, FIND_COMMAND_NAME, connectionDescription, System.nanoTime() - startTimeNanos, t,
                             commandListener);
                 }
                 callback.onResult(null, t);

--- a/driver-core/src/main/com/mongodb/connection/RequestMessage.java
+++ b/driver-core/src/main/com/mongodb/connection/RequestMessage.java
@@ -117,15 +117,6 @@ abstract class RequestMessage {
     }
 
     /**
-     * Gets the collection namespace to send the message to.
-     *
-     * @return the namespace, which may be null for some message types
-     */
-    public String getNamespace() {
-        return getCollectionName();
-    }
-
-    /**
      * Gets the message settings.
      *
      * @return the message settings

--- a/driver-core/src/main/com/mongodb/connection/ResponseBuffers.java
+++ b/driver-core/src/main/com/mongodb/connection/ResponseBuffers.java
@@ -16,7 +16,9 @@
 
 package com.mongodb.connection;
 
+import org.bson.BsonDocument;
 import org.bson.ByteBuf;
+import org.bson.codecs.Decoder;
 
 import java.io.Closeable;
 
@@ -39,6 +41,12 @@ class ResponseBuffers implements Closeable {
      */
     public ReplyHeader getReplyHeader() {
         return replyHeader;
+    }
+
+    <T extends BsonDocument> T getResponseDocument(final int messageId, final Decoder<T> decoder) {
+        ReplyMessage<T> replyMessage = new ReplyMessage<T>(this, decoder, messageId);
+        reset();
+        return replyMessage.getDocuments().get(0);
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/connection/SendMessageCallback.java
+++ b/driver-core/src/main/com/mongodb/connection/SendMessageCallback.java
@@ -58,7 +58,8 @@ class SendMessageCallback<T> implements SingleResultCallback<Void> {
         buffer.close();
         if (t != null) {
             if (commandListener != null){
-                sendCommandFailedEvent(message, commandName, connection.getDescription(), startTimeNanos, t, commandListener);
+                sendCommandFailedEvent(message, commandName, connection.getDescription(), System.nanoTime() - startTimeNanos, t,
+                        commandListener);
             }
             callback.onResult(null, t);
         } else {

--- a/driver-core/src/main/com/mongodb/connection/WriteProtocol.java
+++ b/driver-core/src/main/com/mongodb/connection/WriteProtocol.java
@@ -148,15 +148,16 @@ abstract class WriteProtocol implements LegacyProtocol<WriteConcernResult> {
     private void sendSucceededEvent(final InternalConnection connection, final RequestMessage message,
                                     final BsonDocument responseDocument, final long startTimeNanos) {
         if (commandListener != null) {
-            sendCommandSucceededEvent(message, getCommandName(message), responseDocument, connection.getDescription(), startTimeNanos,
-                    commandListener);
+            sendCommandSucceededEvent(message, getCommandName(message), responseDocument, connection.getDescription(),
+                    System.nanoTime() - startTimeNanos, commandListener);
         }
     }
 
     private void sendFailedEvent(final InternalConnection connection, final RequestMessage message,
                                  final boolean sentCommandStartedEvent, final Throwable t, final long startTimeNanos) {
         if (commandListener != null && sentCommandStartedEvent) {
-            sendCommandFailedEvent(message, getCommandName(message), connection.getDescription(), startTimeNanos, t, commandListener);
+            sendCommandFailedEvent(message, getCommandName(message), connection.getDescription(), System.nanoTime() - startTimeNanos, t,
+                    commandListener);
         }
     }
 

--- a/driver-core/src/test/unit/com/mongodb/connection/ByteBufBsonDocumentSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/ByteBufBsonDocumentSpecification.groovy
@@ -26,6 +26,7 @@ import org.bson.BsonValue
 import org.bson.ByteBuf
 import org.bson.ByteBufNIO
 import org.bson.codecs.BsonDocumentCodec
+import org.bson.codecs.DecoderContext
 import org.bson.codecs.EncoderContext
 import org.bson.io.BasicOutputBuffer
 import org.bson.json.JsonMode
@@ -206,7 +207,18 @@ class ByteBufBsonDocumentSpecification extends Specification {
         emptyDocumentByteBuf.referenceCount == 1
     }
 
-    def 'hashCode should equal hash code of identical BsonDocument'() {
+    def 'should create BsonReader'() {
+        when:
+        def reader = document.asBsonReader()
+
+        then:
+        new BsonDocumentCodec().decode(reader, DecoderContext.builder().build()) == document
+
+        cleanup:
+        reader.close()
+    }
+
+   def 'hashCode should equal hash code of identical BsonDocument'() {
         expect:
         byteBufDocument.hashCode() == document.hashCode()
         documentByteBuf.referenceCount == 1

--- a/driver-core/src/test/unit/com/mongodb/connection/LoggingCommandEventSenderSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/LoggingCommandEventSenderSpecification.groovy
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.connection
+
+import com.mongodb.MongoInternalException
+import com.mongodb.MongoNamespace
+import com.mongodb.ReadPreference
+import com.mongodb.ServerAddress
+import com.mongodb.diagnostics.logging.Logger
+import com.mongodb.event.CommandFailedEvent
+import com.mongodb.event.CommandListener
+import com.mongodb.event.CommandStartedEvent
+import com.mongodb.event.CommandSucceededEvent
+import com.mongodb.internal.connection.NoOpSessionContext
+import com.mongodb.internal.validator.NoOpFieldNameValidator
+import org.bson.BsonDocument
+import org.bson.BsonInt32
+import org.bson.BsonString
+import spock.lang.Specification
+
+class LoggingCommandEventSenderSpecification extends Specification {
+
+    def 'should send events'() {
+        given:
+        def connectionDescription = new ConnectionDescription(new ServerId(new ClusterId(), new ServerAddress()))
+        def namespace = new MongoNamespace('test.driver')
+        def messageSettings = MessageSettings.builder().serverVersion(new ServerVersion(3, 6)).build()
+        def commandListener = new TestCommandListener()
+        def commandDocument = new BsonDocument('ping', new BsonInt32(1))
+        def replyDocument = new BsonDocument('ok', new BsonInt32(1))
+        def failureException = new MongoInternalException('failure!')
+        def message = new CommandMessage(namespace, commandDocument,
+                new NoOpFieldNameValidator(), ReadPreference.primary(), messageSettings)
+        def bsonOutput = new ByteBufferBsonOutput(new SimpleBufferProvider())
+        message.encode(bsonOutput, NoOpSessionContext.INSTANCE)
+        def logger = Stub(Logger) {
+            isDebugEnabled() >> debugLoggingEnabled
+        }
+        def sender = new LoggingCommandEventSender([] as Set, connectionDescription, commandListener, message, bsonOutput, logger)
+
+        when:
+        sender.sendStartedEvent()
+        sender.sendSucceededEventForOneWayCommand()
+        sender.sendSucceededEvent(MessageHelper.buildSuccessfulReply(message.getId(), replyDocument.toJson()))
+        sender.sendFailedEvent(failureException)
+
+        then:
+        commandListener.eventsWereDelivered(
+                [
+                        new CommandStartedEvent(message.getId(), connectionDescription, namespace.databaseName,
+                                commandDocument.getFirstKey(), commandDocument.append('$db', new BsonString(namespace.databaseName))),
+                        new CommandSucceededEvent(message.getId(), connectionDescription, commandDocument.getFirstKey(),
+                                new BsonDocument(), 1),
+                        new CommandSucceededEvent(message.getId(), connectionDescription, commandDocument.getFirstKey(),
+                                replyDocument, 1),
+                        new CommandFailedEvent(message.getId(), connectionDescription, commandDocument.getFirstKey(), 1, failureException)
+                ])
+
+        where:
+        debugLoggingEnabled << [true, false]
+    }
+
+    def 'should log events'() {
+        given:
+        def connectionDescription = new ConnectionDescription(new ServerId(new ClusterId(), new ServerAddress()))
+        def namespace = new MongoNamespace('test.driver')
+        def messageSettings = MessageSettings.builder().serverVersion(new ServerVersion(3, 6)).build()
+        def commandDocument = new BsonDocument('ping', new BsonInt32(1))
+        def replyDocument = new BsonDocument('ok', new BsonInt32(1))
+        def failureException = new MongoInternalException('failure!')
+        def message = new CommandMessage(namespace, commandDocument, new NoOpFieldNameValidator(), ReadPreference.primary(),
+                messageSettings)
+        def bsonOutput = new ByteBufferBsonOutput(new SimpleBufferProvider())
+        message.encode(bsonOutput, NoOpSessionContext.INSTANCE)
+        def logger = Mock(Logger) {
+            isDebugEnabled() >> true
+        }
+        def sender = new LoggingCommandEventSender([] as Set, connectionDescription, commandListener, message, bsonOutput, logger)
+        when:
+        sender.sendStartedEvent()
+        sender.sendSucceededEventForOneWayCommand()
+        sender.sendSucceededEvent(MessageHelper.buildSuccessfulReply(message.getId(), replyDocument.toJson()))
+        sender.sendFailedEvent(failureException)
+
+        then:
+        1 * logger.debug {
+            it == "Sending command \'{ \"ping\" : 1, \"\$db\" : \"test\" } ...\' with request id ${message.getId()} to database test " +
+                    "on connection [connectionId{localValue:${connectionDescription.connectionId.localValue}}] " +
+                    'to server 127.0.0.1:27017'
+        }
+        1 * logger.debug {
+            it.matches("Execution of one-way command with request id ${message.getId()} completed successfully in \\d+\\.\\d+ ms " +
+                    "on connection \\[connectionId\\{localValue:${connectionDescription.connectionId.localValue}\\}] " +
+                    'to server 127\\.0\\.0\\.1:27017')
+        }
+        1 * logger.debug {
+            it.matches("Execution of command with request id ${message.getId()} completed successfully in \\d+\\.\\d+ ms " +
+                    "on connection \\[connectionId\\{localValue:${connectionDescription.connectionId.localValue}\\}] " +
+                    'to server 127\\.0\\.0\\.1:27017')
+        }
+        1 * logger.debug({
+            it.matches("Execution of command with request id ${message.getId()} failed to complete successfully in \\d+\\.\\d+ ms " +
+                    "on connection \\[connectionId\\{localValue:${connectionDescription.connectionId.localValue}\\}] " +
+                    'to server 127\\.0\\.0\\.1:27017')
+        }, failureException)
+
+        where:
+        commandListener << [null, Stub(CommandListener)]
+    }
+}


### PR DESCRIPTION
JAVA-2721: Add ability to cap the size of JSON generated by JsonWriter
JAVA-2697, JAVA-2698: Log successful and failed command events, including elapsed time, request id, and truncated (at 1000 characters) JSON representation of the command.

Patch build: https://evergreen.mongodb.com/version/5a46a0d9e3c33137e10073d6