### PR TITLE
JAVA-2717, JAVA-2656: Reference documentation additions

### DIFF
--- a/docs/reference/content/driver-async/tutorials/authentication.md
+++ b/docs/reference/content/driver-async/tutorials/authentication.md
@@ -23,18 +23,8 @@ An authentication credential is represented as an instance of the
 [`MongoCredential`]({{< apiref "com/mongodb/MongoCredential" >}}) class. The [`MongoCredential`]({{<apiref "com/mongodb/MongoCredential.html">}}) class includes static
 factory methods for each of the supported authentication mechanisms.  
 
-To specify a list of these instances, use the [`MongoClientSettings`]({{< apiref "com/mongodb/async/client/MongoClientSettings" >}}) and pass as a parameter to the
-[`MongoClients.create()`]({{<apiref "com/mongodb/async/client/MongoClients.html#create-com.mongodb.async.client.MongoClientSettings-">}}) method.
-
-To specify a single `MongoCredential` instance, you can also use the [`ConnectionString`]({{< apiref "com/mongodb/ConnectionString" >}}) and pass to a
+You can also use the [`ConnectionString`]({{< apiref "com/mongodb/ConnectionString" >}}) and pass it to a
 [`MongoClients.create()`]({{< apiref "com/mongodb/async/client/MongoClients.html#create-com.mongodb.ConnectionString-" >}}) method.
-
-{{% note %}}
-
-- You can also specify the credential with a string that specifies the connection URI and pass the string to the [`MongoClients.create()`]({{< apiref "com/mongodb/async/client/MongoClients.html#create-java.lang.String-" >}}) method that takes the connection string as a parameter.  For brevity, the tutorial omits the examples using the string.
-
-- Given the flexibility of role-based access control in MongoDB, it is usually sufficient to authenticate with a single user, but, for completeness, the driver accepts a list of credentials.
-{{% /note %}}
 
 ## Default Authentication Mechanism
 
@@ -60,7 +50,7 @@ ClusterSettings clusterSettings = ClusterSettings.builder()
                                   .hosts(asList(new ServerAddress("localhost"))).build();
 MongoClientSettings settings = MongoClientSettings.builder()
                                   .clusterSettings(clusterSettings)
-                                  .credentialList(Arrays.asList(credential))
+                                  .credential(credential)
                                   .build();
 MongoClient mongoClient = MongoClients.create(settings);
 ```
@@ -74,7 +64,7 @@ MongoClient mongoClient = MongoClients.create(
 ```
 
 For challenge and response mechanisms, using the default authentication
-mechanism is the recommended approach as the approach will make
+mechanism is the recommended approach as it will make
 upgrading from MongoDB 2.6 to MongoDB 3.0 seamless, even after
 [upgrading the authentication schema]({{<docsref "release-notes/3.0-scram/">}}).
 
@@ -92,7 +82,7 @@ ClusterSettings clusterSettings = ClusterSettings.builder()
                                   .hosts(asList(new ServerAddress("localhost"))).build();
 MongoClientSettings settings = MongoClientSettings.builder()
                                   .clusterSettings(clusterSettings)
-                                  .credentialList(Arrays.asList(credential))
+                                  .credential(credential)
                                   .build();
 MongoClient mongoClient = MongoClients.create(settings);
 
@@ -121,7 +111,7 @@ ClusterSettings clusterSettings = ClusterSettings.builder()
                                   .hosts(asList(new ServerAddress("localhost"))).build();
 MongoClientSettings settings = MongoClientSettings.builder()
                                   .clusterSettings(clusterSettings)
-                                  .credentialList(Arrays.asList(credential))
+                                  .credential(credential)
                                   .build();
 MongoClient mongoClient = MongoClients.create(settings);
 ```
@@ -161,7 +151,7 @@ EventLoopGroup eventLoopGroup = new NioEventLoopGroup();  // make sure applicati
 
 MongoClientSettings settings = MongoClientSettings.builder()
                 .clusterSettings(clusterSettings)
-                .credentialList(Arrays.asList(credential))
+                .credential(credential)
                 .streamFactoryFactory(NettyStreamFactoryFactory.builder().eventLoopGroup(eventLoopGroup).build())
                 .sslSettings(SslSettings.builder().enabled(true).build())
                 .build();
@@ -196,7 +186,7 @@ ClusterSettings clusterSettings = ClusterSettings.builder()
                                   .hosts(asList(new ServerAddress("localhost"))).build();
 MongoClientSettings settings = MongoClientSettings.builder()
                                   .clusterSettings(clusterSettings)
-                                  .credentialList(Arrays.asList(credential))
+                                  .credential(credential)
                                   .build();
 MongoClient mongoClient = MongoClients.create(settings);
 
@@ -270,7 +260,7 @@ ClusterSettings clusterSettings = ClusterSettings.builder()
                                   .hosts(asList(new ServerAddress("localhost"))).build();
 MongoClientSettings settings = MongoClientSettings.builder()
                                   .clusterSettings(clusterSettings)
-                                  .credentialList(Arrays.asList(credential))
+                                  .credential(credential)
                                   .build();
 MongoClient mongoClient = MongoClients.create(settings);
 ```

--- a/docs/reference/content/driver-async/tutorials/authentication.md
+++ b/docs/reference/content/driver-async/tutorials/authentication.md
@@ -240,7 +240,9 @@ mongodb://username%40MYREALM.com@myserver/?authMechanism=GSSAPI&authMechanismPro
 ```
 
 {{% note %}}
-There are limitations when authenticating from a Windows client. For details, see
+On Windows, Oracle's JRE uses [LSA](https://msdn.microsoft.com/en-us/library/windows/desktop/aa378326.aspx) rather than 
+[SSPI](https://msdn.microsoft.com/en-us/library/windows/desktop/aa380493.aspx) in its implementation of GSSAPI, which limits
+interoperability with Windows Active Directory and in particular the ability to implement single sign-on. 
 
 - [JDK-8054026](https://bugs.openjdk.java.net/browse/JDK-8054026) 
 - [JDK-6722928](https://bugs.openjdk.java.net/browse/JDK-6722928) 

--- a/docs/reference/content/driver-async/tutorials/authentication.md
+++ b/docs/reference/content/driver-async/tutorials/authentication.md
@@ -203,12 +203,6 @@ MongoClient mongoClient = MongoClients.create(new ConnectionString(
 {{% note %}}
 The method refers to the `GSSAPI` authentication mechanism instead of `Kerberos` because technically the driver is authenticating via the
 [GSSAPI](https://tools.ietf.org/html/rfc4752) SASL mechanism.
-
-The `GSSAPI` authentication mechanism is supported only in the following environments:
-
-* Linux: Java 6 and above
-* Windows: Java 7 and above with [SSPI](https://msdn.microsoft.com/en-us/library/windows/desktop/aa380493)
-* OS X: Java 7 and above
 {{% /note %}}
 
 To successfully authenticate via Kerberos, the application typically
@@ -244,6 +238,14 @@ Or via the `ConnectionString`:
 ```
 mongodb://username%40MYREALM.com@myserver/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:othername
 ```
+
+{{% note %}}
+There are limitations when authenticating from a Windows client. For details, see
+
+- [JDK-8054026](https://bugs.openjdk.java.net/browse/JDK-8054026) 
+- [JDK-6722928](https://bugs.openjdk.java.net/browse/JDK-6722928) 
+- [SO 23427343](https://stackoverflow.com/questions/23427343/cannot-retrieve-tgt-despite-allowtgtsessionkey-registry-entry)    
+{{% /note %}}
 
 
 ## LDAP (PLAIN)

--- a/docs/reference/content/driver/tutorials/authentication.md
+++ b/docs/reference/content/driver/tutorials/authentication.md
@@ -23,17 +23,8 @@ An authentication credential is represented as an instance of the
 [`MongoCredential`]({{<apiref "com/mongodb/MongoCredential.html">}}) class. The [`MongoCredential`]({{<apiref "com/mongodb/MongoCredential.html">}}) class includes static
 factory methods for each of the supported authentication mechanisms.
 
-To specify a list of these instances, use one of
-several [`MongoClient()`]({{< apiref "com/mongodb/MongoClient.html">}}) constructors that take a parameter of type
-`List <MongoCredential>`.
-
-To specify a single `MongoCredential`, you can also use a [`MongoClientURI`]({{< apiref "/com/mongodb/MongoClientURI.html">}}) and pass it to a [`MongoClient()`]({{< apiref "com/mongodb/MongoClient.html">}}) constructor that takes a `MongoClientURI` parameter.
-
-{{% note %}}
-Given the flexibility of role-based access control in MongoDB, it is
-usually sufficient to authenticate with a single user, but, for
-completeness, the driver accepts a list of credentials.
-{{% /note %}}
+You can also use a [`MongoClientURI`]({{< apiref "/com/mongodb/MongoClientURI.html">}}) and pass it to a 
+[`MongoClient()`]({{< apiref "com/mongodb/MongoClient.html">}}) constructor that takes a `MongoClientURI` parameter.
 
 ## Default Authentication Mechanism
 
@@ -52,8 +43,7 @@ String database; // the name of the database in which the user is defined
 char[] password; // the password as a character array
 // ...
 MongoCredential credential = MongoCredential.createCredential(user, database, password);
-MongoClient mongoClient = new MongoClient(new ServerAddress("host1", 27017),
-                                         Arrays.asList(credential));
+MongoClient mongoClient = new MongoClient(new ServerAddress("host1", 27017), credential);
 ```
 Or use a connection string without explicitly specifying the
 authentication mechanism:
@@ -64,7 +54,7 @@ MongoClient mongoClient = new MongoClient(uri);
 ```
 
 For challenge and response mechanisms, using the default authentication
-mechanism is the recommended approach as the approach will make
+mechanism is the recommended approach as it will make
 upgrading from MongoDB 2.6 to MongoDB 3.0 seamless, even after
 [upgrading the authentication schema]({{<docsref "release-notes/3.0-scram/">}}).
 
@@ -81,8 +71,7 @@ char[] password; // the password as a character array
 MongoCredential credential = MongoCredential.createScramSha1Credential(user,
                                                                       database,
                                                                       password);
-MongoClient mongoClient = new MongoClient(new ServerAddress("host1", 27017),
-                                             Arrays.asList(credential));
+MongoClient mongoClient = new MongoClient(new ServerAddress("host1", 27017), credential);
 ```
 
 Or use a connection string  that explicitly specifies the
@@ -105,8 +94,7 @@ char[] password; // the password as a character array
 MongoCredential credential = MongoCredential.createMongoCRCredential(user,
                                                                     database,
                                                                     password);
-MongoClient mongoClient = new MongoClient(new ServerAddress("host1", 27017),
-                                         Arrays.asList(credential));
+MongoClient mongoClient = new MongoClient(new ServerAddress("host1", 27017), credential);
 ```
 Or use a connection string that explicitly specifies the
 `authMechanism=MONGODB-CR`:
@@ -140,8 +128,7 @@ MongoCredential credential = MongoCredential.createMongoX509Credential(user);
 MongoClientOptions options = MongoClientOptions.builder().sslEnabled(true).build();
 
 
-MongoClient mongoClient = new MongoClient(new ServerAddress("host1", 27017),
-                                         Arrays.asList(credential), options);
+MongoClient mongoClient = new MongoClient(new ServerAddress("host1", 27017), credential, options);
 ```
 
 Or use a connection string that explicitly specifies the
@@ -168,6 +155,7 @@ static factory method:
 String user;   // The Kerberos user name, including the realm, e.g. "user1@MYREALM.ME"
 // ...
 MongoCredential credential = MongoCredential.createGSSAPICredential(user);
+MongoClient mongoClient = new MongoClient(new ServerAddress("host1", 27017), credential);
 ```
 Or use a connection string that explicitly specifies the
 `authMechanism=GSSAPI`:
@@ -202,6 +190,7 @@ String user;          // The LDAP user name
 char[] password;      // The LDAP password
 // ...
 MongoCredential credential = MongoCredential.createPlainCredential(user, "$external", password);
+MongoClient mongoClient = new MongoClient(new ServerAddress("host1", 27017), credential);
 ```
 Or use a connection string that explicitly specifies the
 `authMechanism=PLAIN`:

--- a/docs/reference/content/driver/tutorials/authentication.md
+++ b/docs/reference/content/driver/tutorials/authentication.md
@@ -206,7 +206,9 @@ mongodb://username%40MYREALM.com@myserver/?authMechanism=GSSAPI&authMechanismPro
 ```
 
 {{% note %}}
-There are limitations when authenticating from a Windows client. For details, see
+On Windows, Oracle's JRE uses [LSA](https://msdn.microsoft.com/en-us/library/windows/desktop/aa378326.aspx) rather than 
+[SSPI](https://msdn.microsoft.com/en-us/library/windows/desktop/aa380493.aspx) in its implementation of GSSAPI, which limits
+interoperability with Windows Active Directory and in particular the ability to implement single sign-on. 
 
 - [JDK-8054026](https://bugs.openjdk.java.net/browse/JDK-8054026) 
 - [JDK-6722928](https://bugs.openjdk.java.net/browse/JDK-6722928) 

--- a/docs/reference/content/driver/tutorials/authentication.md
+++ b/docs/reference/content/driver/tutorials/authentication.md
@@ -180,6 +180,40 @@ java.security.krb5.realm=MYREALM.ME
 java.security.krb5.kdc=mykdc.myrealm.me
 ```
 
+Depending on the Kerberos setup, additional property specifications may be required, either via the application code or, in some cases, the [withMechanismProperty()]({{<apiref "com/mongodb/MongoCredential.html#withMechanismProperty-java.lang.String-T-">}}) method of the `MongoCredential` instance:
+
+- **[`SERVICE_NAME`]({{< apiref "com/mongodb/MongoCredential.html#SERVICE_NAME_KEY" >}})**
+
+
+- **[`CANONICALIZE_HOST_NAME`]({{< apiref "com/mongodb/MongoCredential.html#CANONICALIZE_HOST_NAME_KEY" >}})**
+
+
+- **[`JAVA_SUBJECT`]({{< apiref "com/mongodb/MongoCredential.html#JAVA_SUBJECT_KEY" >}})**
+
+- **[`JAVA_SASL_CLIENT_PROPERTIES`]({{< apiref "com/mongodb/MongoCredential.html#JAVA_SASL_CLIENT_PROPERTIES_KEY" >}})**
+
+For example, to specify the `SERVICE_NAME` property via the `MongoCredential` object:
+
+
+```java
+credential = credential.withMechanismProperty(MongoCredential.SERVICE_NAME_KEY, "othername");
+```
+
+Or via the `ConnectionString`:
+
+```
+mongodb://username%40MYREALM.com@myserver/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:othername
+```
+
+{{% note %}}
+There are limitations when authenticating from a Windows client. For details, see
+
+- [JDK-8054026](https://bugs.openjdk.java.net/browse/JDK-8054026) 
+- [JDK-6722928](https://bugs.openjdk.java.net/browse/JDK-6722928) 
+- [SO 23427343](https://stackoverflow.com/questions/23427343/cannot-retrieve-tgt-despite-allowtgtsessionkey-registry-entry)    
+{{% /note %}}
+
+
 ## LDAP (PLAIN)
 
 [MongoDB Enterprise](http://www.mongodb.com/products/mongodb-enterprise) supports proxy authentication through a Lightweight Directory Access Protocol (LDAP) service. To create a credential of type [LDAP]({{<apiref "core/authentication/#ldap-proxy-authority-authentication">}}) use the


### PR DESCRIPTION
Two commits: One for GSSAPI limitations on Windows, and one to replace references to methods that take multiple credentials to ones that take a single credential.

[JAVA-2717](https://jira.mongodb.org/browse/JAVA-2717)
[JAVA-2656](https://jira.mongodb.org/browse/JAVA-2656)

[Sync Reference docs](http://jyemin.github.io/mongo-java-driver/3.6/driver/tutorials/authentication/)
[Async Reference docs](http://jyemin.github.io/mongo-java-driver/3.6/driver-async/tutorials/authentication/)