### PR TITLE
Refactor CRUD implementations to reduce API surface exposure and share code

### DIFF
--- a/config/checkstyle-exclude.xml
+++ b/config/checkstyle-exclude.xml
@@ -60,6 +60,7 @@
     <suppress checks="ParameterNumber" files="DefaultServer"/>
     <suppress checks="ParameterNumber" files="DefaultClusterFactory"/>
     <suppress checks="ParameterNumber" files="DefaultClusterableServerFactory"/>
+    <suppress checks="ParameterNumber" files="Operations"/>
 
     <!--Legacy code that has not yet been cleaned-->
     <suppress checks="FinalClass" files="AggregationOptions"/>

--- a/driver-async/src/main/com/mongodb/async/client/ListDatabasesIterableImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/ListDatabasesIterableImpl.java
@@ -19,10 +19,11 @@ package com.mongodb.async.client;
 import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
 import com.mongodb.async.AsyncBatchCursor;
+import com.mongodb.internal.operation.AsyncOperations;
 import com.mongodb.operation.AsyncOperationExecutor;
 import com.mongodb.operation.AsyncReadOperation;
-import com.mongodb.operation.ListDatabasesOperation;
 import com.mongodb.session.ClientSession;
+import org.bson.BsonDocument;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 
@@ -32,8 +33,8 @@ import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 final class ListDatabasesIterableImpl<TResult> extends MongoIterableImpl<TResult> implements ListDatabasesIterable<TResult> {
+    private AsyncOperations<BsonDocument> operations;
     private final Class<TResult> resultClass;
-    private final CodecRegistry codecRegistry;
 
     private long maxTimeMS;
     private Bson filter;
@@ -42,8 +43,8 @@ final class ListDatabasesIterableImpl<TResult> extends MongoIterableImpl<TResult
     ListDatabasesIterableImpl(final ClientSession clientSession, final Class<TResult> resultClass, final CodecRegistry codecRegistry,
                               final ReadPreference readPreference, final AsyncOperationExecutor executor) {
         super(clientSession, executor, ReadConcern.DEFAULT, readPreference); // TODO: read concern?
+        this.operations = new AsyncOperations<BsonDocument>(BsonDocument.class, readPreference, codecRegistry, ReadConcern.DEFAULT);
         this.resultClass = notNull("clazz", resultClass);
-        this.codecRegistry = notNull("codecRegistry", codecRegistry);
     }
 
     @Override
@@ -74,7 +75,6 @@ final class ListDatabasesIterableImpl<TResult> extends MongoIterableImpl<TResult
 
     @Override
     AsyncReadOperation<AsyncBatchCursor<TResult>> asAsyncReadOperation() {
-        return new ListDatabasesOperation<TResult>(codecRegistry.get(resultClass)).maxTime(maxTimeMS, MILLISECONDS)
-                .filter(toBsonDocumentOrNull(filter, codecRegistry)).nameOnly(nameOnly);
+        return operations.listDatabases(resultClass, filter, nameOnly, maxTimeMS);
     }
 }

--- a/driver-async/src/main/com/mongodb/async/client/MongoCollectionImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoCollectionImpl.java
@@ -28,16 +28,10 @@ import com.mongodb.WriteConcernResult;
 import com.mongodb.WriteError;
 import com.mongodb.async.SingleResultCallback;
 import com.mongodb.bulk.BulkWriteResult;
-import com.mongodb.bulk.DeleteRequest;
-import com.mongodb.bulk.IndexRequest;
-import com.mongodb.bulk.InsertRequest;
-import com.mongodb.bulk.UpdateRequest;
 import com.mongodb.bulk.WriteRequest;
 import com.mongodb.client.model.BulkWriteOptions;
 import com.mongodb.client.model.CountOptions;
 import com.mongodb.client.model.CreateIndexOptions;
-import com.mongodb.client.model.DeleteManyModel;
-import com.mongodb.client.model.DeleteOneModel;
 import com.mongodb.client.model.DeleteOptions;
 import com.mongodb.client.model.DropIndexOptions;
 import com.mongodb.client.model.FindOneAndDeleteOptions;
@@ -47,53 +41,35 @@ import com.mongodb.client.model.FindOptions;
 import com.mongodb.client.model.IndexModel;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.InsertManyOptions;
-import com.mongodb.client.model.InsertOneModel;
 import com.mongodb.client.model.InsertOneOptions;
 import com.mongodb.client.model.RenameCollectionOptions;
-import com.mongodb.client.model.ReplaceOneModel;
-import com.mongodb.client.model.ReturnDocument;
-import com.mongodb.client.model.UpdateManyModel;
-import com.mongodb.client.model.UpdateOneModel;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.WriteModel;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
-import com.mongodb.diagnostics.logging.Logger;
-import com.mongodb.diagnostics.logging.Loggers;
+import com.mongodb.internal.operation.AsyncOperations;
+import com.mongodb.internal.operation.IndexHelper;
 import com.mongodb.operation.AsyncOperationExecutor;
-import com.mongodb.operation.CountOperation;
-import com.mongodb.operation.CreateIndexesOperation;
-import com.mongodb.operation.DropCollectionOperation;
-import com.mongodb.operation.DropIndexOperation;
-import com.mongodb.operation.FindAndDeleteOperation;
-import com.mongodb.operation.FindAndReplaceOperation;
-import com.mongodb.operation.FindAndUpdateOperation;
-import com.mongodb.operation.MixedBulkWriteOperation;
-import com.mongodb.operation.RenameCollectionOperation;
+import com.mongodb.operation.AsyncWriteOperation;
 import com.mongodb.session.ClientSession;
 import org.bson.BsonDocument;
-import org.bson.BsonDocumentWrapper;
-import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.bson.Document;
-import org.bson.codecs.Codec;
-import org.bson.codecs.CollectibleCodec;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.assertions.Assertions.notNull;
-import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
-import static java.lang.String.format;
+import static com.mongodb.bulk.WriteRequest.Type.DELETE;
+import static com.mongodb.bulk.WriteRequest.Type.INSERT;
+import static com.mongodb.bulk.WriteRequest.Type.REPLACE;
+import static com.mongodb.bulk.WriteRequest.Type.UPDATE;
 import static java.util.Collections.singletonList;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
-    private static final Logger LOGGER = Loggers.getLogger("client");
     private final MongoNamespace namespace;
     private final Class<TDocument> documentClass;
     private final ReadPreference readPreference;
@@ -102,6 +78,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     private final boolean retryWrites;
     private final ReadConcern readConcern;
     private final AsyncOperationExecutor executor;
+    private final AsyncOperations<TDocument> operations;
 
     MongoCollectionImpl(final MongoNamespace namespace, final Class<TDocument> documentClass, final CodecRegistry codecRegistry,
                         final ReadPreference readPreference, final WriteConcern writeConcern, final boolean retryWrites,
@@ -114,6 +91,9 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
         this.retryWrites = retryWrites;
         this.readConcern = notNull("readConcern", readConcern);
         this.executor = notNull("executor", executor);
+        this.operations = new AsyncOperations<TDocument>(namespace, documentClass, readPreference, codecRegistry, writeConcern, retryWrites,
+                readConcern);
+
     }
 
     @Override
@@ -210,19 +190,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private void executeCount(final ClientSession clientSession, final Bson filter, final CountOptions options,
                               final SingleResultCallback<Long> callback) {
-        CountOperation operation = new CountOperation(namespace)
-                .filter(toBsonDocument(filter))
-                .skip(options.getSkip())
-                .limit(options.getLimit())
-                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
-                .collation(options.getCollation())
-                .readConcern(readConcern);
-        if (options.getHint() != null) {
-            operation.hint(toBsonDocument(options.getHint()));
-        } else if (options.getHintString() != null) {
-            operation.hint(new BsonString(options.getHintString()));
-        }
-        executor.execute(operation, readPreference, clientSession, callback);
+        executor.execute(operations.count(filter, options), readPreference, clientSession, callback);
     }
 
     @Override
@@ -438,57 +406,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     private void executeBulkWrite(final ClientSession clientSession, final List<? extends WriteModel<? extends TDocument>> requests,
                                   final BulkWriteOptions options, final SingleResultCallback<BulkWriteResult> callback) {
         notNull("requests", requests);
-        List<WriteRequest> writeRequests = new ArrayList<WriteRequest>(requests.size());
-        for (WriteModel<? extends TDocument> writeModel : requests) {
-            WriteRequest writeRequest;
-            if (writeModel == null) {
-                throw new IllegalArgumentException("requests can not contain a null value");
-            } else if (writeModel instanceof InsertOneModel) {
-                TDocument document = ((InsertOneModel<TDocument>) writeModel).getDocument();
-                if (getCodec() instanceof CollectibleCodec) {
-                    document = ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(document);
-                }
-                writeRequest = new InsertRequest(documentToBsonDocument(document));
-            } else if (writeModel instanceof ReplaceOneModel) {
-                ReplaceOneModel<TDocument> replaceOneModel = (ReplaceOneModel<TDocument>) writeModel;
-                writeRequest = new UpdateRequest(toBsonDocument(replaceOneModel.getFilter()),
-                        documentToBsonDocument(replaceOneModel.getReplacement()),
-                        WriteRequest.Type.REPLACE)
-                        .upsert(replaceOneModel.getOptions().isUpsert())
-                        .collation(replaceOneModel.getOptions().getCollation());
-            } else if (writeModel instanceof UpdateOneModel) {
-                UpdateOneModel<TDocument> updateOneModel = (UpdateOneModel<TDocument>) writeModel;
-                writeRequest = new UpdateRequest(toBsonDocument(updateOneModel.getFilter()), toBsonDocument(updateOneModel.getUpdate()),
-                        WriteRequest.Type.UPDATE)
-                        .multi(false)
-                        .upsert(updateOneModel.getOptions().isUpsert())
-                        .collation(updateOneModel.getOptions().getCollation())
-                        .arrayFilters(toBsonDocumentList(updateOneModel.getOptions().getArrayFilters()));
-            } else if (writeModel instanceof UpdateManyModel) {
-                UpdateManyModel<TDocument> updateManyModel = (UpdateManyModel<TDocument>) writeModel;
-                writeRequest = new UpdateRequest(toBsonDocument(updateManyModel.getFilter()), toBsonDocument(updateManyModel.getUpdate()),
-                        WriteRequest.Type.UPDATE)
-                        .multi(true)
-                        .upsert(updateManyModel.getOptions().isUpsert())
-                        .collation(updateManyModel.getOptions().getCollation())
-                        .arrayFilters(toBsonDocumentList(updateManyModel.getOptions().getArrayFilters()));
-            } else if (writeModel instanceof DeleteOneModel) {
-                DeleteOneModel<TDocument> deleteOneModel = (DeleteOneModel<TDocument>) writeModel;
-                writeRequest = new DeleteRequest(toBsonDocument(deleteOneModel.getFilter())).multi(false)
-                        .collation(deleteOneModel.getOptions().getCollation());
-            } else if (writeModel instanceof DeleteManyModel) {
-                DeleteManyModel<TDocument> deleteManyModel = (DeleteManyModel<TDocument>) writeModel;
-                writeRequest = new DeleteRequest(toBsonDocument(deleteManyModel.getFilter())).multi(true)
-                        .collation(deleteManyModel.getOptions().getCollation());
-            } else {
-                throw new UnsupportedOperationException(format("WriteModel of type %s is not supported", writeModel.getClass()));
-            }
-
-            writeRequests.add(writeRequest);
-        }
-
-        executor.execute(new MixedBulkWriteOperation(namespace, writeRequests, options.isOrdered(), writeConcern, retryWrites)
-                .bypassDocumentValidation(options.getBypassDocumentValidation()), clientSession, callback);
+        executor.execute(operations.bulkWrite(requests, options), clientSession, callback);
     }
 
     @Override
@@ -515,12 +433,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private void executeInsertOne(final ClientSession clientSession, final TDocument document, final InsertOneOptions options,
                                   final SingleResultCallback<Void> callback) {
-        TDocument insertDocument = document;
-        if (getCodec() instanceof CollectibleCodec) {
-            insertDocument = ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(insertDocument);
-        }
-        executeSingleWriteRequest(clientSession,
-                new InsertRequest(documentToBsonDocument(insertDocument)), options.getBypassDocumentValidation(),
+        executeSingleWriteRequest(clientSession, operations.insertOne(document, options), INSERT,
                 new SingleResultCallback<BulkWriteResult>() {
                     @Override
                     public void onResult(final BulkWriteResult result, final Throwable t) {
@@ -555,25 +468,13 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private void executeInsertMany(final ClientSession clientSession, final List<? extends TDocument> documents,
                                    final InsertManyOptions options, final SingleResultCallback<Void> callback) {
-        notNull("documents", documents);
-        List<InsertRequest> requests = new ArrayList<InsertRequest>(documents.size());
-        for (TDocument document : documents) {
-            if (document == null) {
-                throw new IllegalArgumentException("documents can not contain a null value");
-            }
-            if (getCodec() instanceof CollectibleCodec) {
-                document = ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(document);
-            }
-            requests.add(new InsertRequest(documentToBsonDocument(document)));
-        }
-        executor.execute(new MixedBulkWriteOperation(namespace, requests, options.isOrdered(), writeConcern, retryWrites)
-                .bypassDocumentValidation(options.getBypassDocumentValidation()), clientSession, errorHandlingCallback(
+        executor.execute(operations.insertMany(documents, options), clientSession,
                 new SingleResultCallback<BulkWriteResult>() {
                     @Override
                     public void onResult(final BulkWriteResult result, final Throwable t) {
                         callback.onResult(null, t);
                     }
-                }, LOGGER));
+                });
     }
 
     @Override
@@ -623,7 +524,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     private void executeDelete(final ClientSession clientSession, final Bson filter, final DeleteOptions options, final boolean multi,
                                final SingleResultCallback<DeleteResult> callback) {
         executeSingleWriteRequest(clientSession,
-                new DeleteRequest(toBsonDocument(filter)).multi(multi).collation(options.getCollation()), null,
+                multi ? operations.deleteMany(filter, options) : operations.deleteOne(filter, options), DELETE,
                 new SingleResultCallback<BulkWriteResult>() {
                     @Override
                     public void onResult(final BulkWriteResult result, final Throwable t) {
@@ -667,9 +568,8 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private void executeReplaceOne(final ClientSession clientSession, final Bson filter, final TDocument replacement,
                                    final UpdateOptions options, final SingleResultCallback<UpdateResult> callback) {
-        executeSingleWriteRequest(clientSession, new UpdateRequest(toBsonDocument(filter), documentToBsonDocument(replacement),
-                        WriteRequest.Type.REPLACE).upsert(options.isUpsert()).collation(options.getCollation()),
-                options.getBypassDocumentValidation(), new SingleResultCallback<BulkWriteResult>() {
+        executeSingleWriteRequest(clientSession, operations.replaceOne(filter, replacement, options), REPLACE,
+                new SingleResultCallback<BulkWriteResult>() {
                     @Override
                     public void onResult(final BulkWriteResult result, final Throwable t) {
                         if (t != null) {
@@ -731,9 +631,8 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private void executeUpdate(final ClientSession clientSession, final Bson filter, final Bson update, final UpdateOptions options,
                                final boolean multi, final SingleResultCallback<UpdateResult> callback) {
-        executeSingleWriteRequest(clientSession, new UpdateRequest(toBsonDocument(filter), toBsonDocument(update), WriteRequest.Type.UPDATE)
-                        .upsert(options.isUpsert()).multi(multi).collation(options.getCollation())
-                        .arrayFilters(toBsonDocumentList(options.getArrayFilters())), options.getBypassDocumentValidation(),
+        executeSingleWriteRequest(clientSession,
+                multi ? operations.updateMany(filter, update, options) : operations.updateOne(filter, update, options), UPDATE,
                 new SingleResultCallback<BulkWriteResult>() {
                     @Override
                     public void onResult(final BulkWriteResult result, final Throwable t) {
@@ -770,12 +669,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private void executeFindOneAndDelete(final ClientSession clientSession, final Bson filter, final FindOneAndDeleteOptions options,
                                          final SingleResultCallback<TDocument> callback) {
-        executor.execute(new FindAndDeleteOperation<TDocument>(namespace, writeConcern, retryWrites, getCodec())
-                .filter(toBsonDocument(filter))
-                .projection(toBsonDocument(options.getProjection()))
-                .sort(toBsonDocument(options.getSort()))
-                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
-                .collation(options.getCollation()), clientSession, callback);
+        executor.execute(operations.findOneAndDelete(filter, options), clientSession, callback);
     }
 
     @Override
@@ -804,16 +698,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private void executeFindOneAndReplace(final ClientSession clientSession, final Bson filter, final TDocument replacement,
                                           final FindOneAndReplaceOptions options, final SingleResultCallback<TDocument> callback) {
-        executor.execute(new FindAndReplaceOperation<TDocument>(namespace, writeConcern, retryWrites, getCodec(),
-                documentToBsonDocument(replacement))
-                .filter(toBsonDocument(filter))
-                .projection(toBsonDocument(options.getProjection()))
-                .sort(toBsonDocument(options.getSort()))
-                .returnOriginal(options.getReturnDocument() == ReturnDocument.BEFORE)
-                .upsert(options.isUpsert())
-                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
-                .bypassDocumentValidation(options.getBypassDocumentValidation())
-                .collation(options.getCollation()), clientSession, callback);
+        executor.execute(operations.findOneAndReplace(filter, replacement, options), clientSession, callback);
     }
 
     @Override
@@ -842,16 +727,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private void executeFindOneAndUpdate(final ClientSession clientSession, final Bson filter, final Bson update,
                                          final FindOneAndUpdateOptions options, final SingleResultCallback<TDocument> callback) {
-        executor.execute(new FindAndUpdateOperation<TDocument>(namespace, writeConcern, retryWrites, getCodec(), toBsonDocument(update))
-                .filter(toBsonDocument(filter))
-                .projection(toBsonDocument(options.getProjection()))
-                .sort(toBsonDocument(options.getSort()))
-                .returnOriginal(options.getReturnDocument() == ReturnDocument.BEFORE)
-                .upsert(options.isUpsert())
-                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
-                .bypassDocumentValidation(options.getBypassDocumentValidation())
-                .collation(options.getCollation())
-                .arrayFilters(toBsonDocumentList(options.getArrayFilters())), clientSession, callback);
+        executor.execute(operations.findOneAndUpdate(filter, update, options), clientSession, callback);
     }
 
     @Override
@@ -866,7 +742,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     private void executeDrop(final ClientSession clientSession, final SingleResultCallback<Void> callback) {
-        executor.execute(new DropCollectionOperation(namespace, writeConcern), clientSession, callback);
+        executor.execute(operations.dropCollection(), clientSession, callback);
     }
 
     @Override
@@ -934,46 +810,28 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private void executeCreateIndexes(final ClientSession clientSession, final List<IndexModel> indexes,
                                       final CreateIndexOptions createIndexOptions, final SingleResultCallback<List<String>> callback) {
-        notNull("indexes", indexes);
-        notNull("createIndexOptions", createIndexOptions);
-
-        List<IndexRequest> indexRequests = new ArrayList<IndexRequest>(indexes.size());
-        for (IndexModel model : indexes) {
-            if (model == null) {
-                throw new IllegalArgumentException("indexes can not contain a null value");
-            }
-            indexRequests.add(new IndexRequest(toBsonDocument(model.getKeys()))
-                    .name(model.getOptions().getName())
-                    .background(model.getOptions().isBackground())
-                    .unique(model.getOptions().isUnique())
-                    .sparse(model.getOptions().isSparse())
-                    .expireAfter(model.getOptions().getExpireAfter(TimeUnit.SECONDS), TimeUnit.SECONDS)
-                    .version(model.getOptions().getVersion())
-                    .weights(toBsonDocument(model.getOptions().getWeights()))
-                    .defaultLanguage(model.getOptions().getDefaultLanguage())
-                    .languageOverride(model.getOptions().getLanguageOverride())
-                    .textVersion(model.getOptions().getTextVersion())
-                    .sphereVersion(model.getOptions().getSphereVersion())
-                    .bits(model.getOptions().getBits())
-                    .min(model.getOptions().getMin())
-                    .max(model.getOptions().getMax())
-                    .bucketSize(model.getOptions().getBucketSize())
-                    .storageEngine(toBsonDocument(model.getOptions().getStorageEngine()))
-                    .partialFilterExpression(toBsonDocument(model.getOptions().getPartialFilterExpression()))
-                    .collation(model.getOptions().getCollation()));
-        }
-        final CreateIndexesOperation createIndexesOperation = new CreateIndexesOperation(getNamespace(), indexRequests, writeConcern)
-                .maxTime(createIndexOptions.getMaxTime(MILLISECONDS), MILLISECONDS);
-        executor.execute(createIndexesOperation, clientSession, new SingleResultCallback<Void>() {
+        executor.execute(operations.createIndexes(indexes, createIndexOptions), clientSession, new SingleResultCallback<Void>() {
             @Override
             public void onResult(final Void result, final Throwable t) {
                 if (t != null) {
                     callback.onResult(null, t);
                 } else {
-                    callback.onResult(createIndexesOperation.getIndexNames(), null);
+                    callback.onResult(getIndexNames(indexes), null);
                 }
             }
         });
+    }
+
+    private List<String> getIndexNames(final List<IndexModel> indexes) {
+        List<String> indexNames = new ArrayList<String>(indexes.size());
+        for (IndexModel index : indexes) {
+            if (index.getOptions().getName() != null) {
+                indexNames.add(index.getOptions().getName());
+            } else {
+                indexNames.add(IndexHelper.generateIndexName(toBsonDocument(index.getKeys())));
+            }
+        }
+        return indexNames;
     }
 
     @Override
@@ -1069,14 +927,12 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private void executeDropIndex(final ClientSession clientSession, final Bson keys,
                                   final DropIndexOptions dropIndexOptions, final SingleResultCallback<Void> callback) {
-        executor.execute(new DropIndexOperation(namespace, keys.toBsonDocument(BsonDocument.class, codecRegistry), writeConcern)
-                        .maxTime(dropIndexOptions.getMaxTime(MILLISECONDS), MILLISECONDS), clientSession, callback);
+        executor.execute(operations.dropIndex(keys, dropIndexOptions), clientSession, callback);
     }
 
     private void executeDropIndex(final ClientSession clientSession, final String indexName,
                                   final DropIndexOptions dropIndexOptions, final SingleResultCallback<Void> callback) {
-        executor.execute(new DropIndexOperation(namespace, indexName, writeConcern)
-                .maxTime(dropIndexOptions.getMaxTime(MILLISECONDS), MILLISECONDS), clientSession, callback);
+        executor.execute(operations.dropIndex(indexName, dropIndexOptions), clientSession, callback);
     }
 
     @Override
@@ -1105,15 +961,12 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private void executeRenameCollection(final ClientSession clientSession, final MongoNamespace newCollectionNamespace,
                                          final RenameCollectionOptions options, final SingleResultCallback<Void> callback) {
-        executor.execute(new RenameCollectionOperation(getNamespace(), newCollectionNamespace, writeConcern)
-                .dropTarget(options.isDropTarget()), clientSession, callback);
+        executor.execute(operations.renameCollection(newCollectionNamespace, options), clientSession, callback);
     }
 
-    private void executeSingleWriteRequest(final ClientSession clientSession, final WriteRequest request,
-                                           final Boolean bypassDocumentValidation, final SingleResultCallback<BulkWriteResult> callback) {
-        executor.execute(new MixedBulkWriteOperation(namespace, singletonList(request), true, writeConcern, retryWrites)
-                         .bypassDocumentValidation(bypassDocumentValidation), clientSession,
-                         new SingleResultCallback<BulkWriteResult>() {
+    private void executeSingleWriteRequest(final ClientSession clientSession, final AsyncWriteOperation<BulkWriteResult> writeOperation,
+                                           final WriteRequest.Type type, final SingleResultCallback<BulkWriteResult> callback) {
+        executor.execute(writeOperation, clientSession, new SingleResultCallback<BulkWriteResult>() {
                              @Override
                              public void onResult(final BulkWriteResult result, final Throwable t) {
                                  if (t instanceof MongoBulkWriteException) {
@@ -1121,7 +974,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
                                      if (e.getWriteErrors().isEmpty()) {
                                          callback.onResult(null,
                                                            new MongoWriteConcernException(e.getWriteConcernError(),
-                                                                                          translateBulkWriteResult(request,
+                                                                                          translateBulkWriteResult(type,
                                                                                                                    e.getWriteResult()),
                                                                                           e.getServerAddress()));
                                      } else {
@@ -1135,8 +988,8 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
                          });
     }
 
-    private WriteConcernResult translateBulkWriteResult(final WriteRequest request, final BulkWriteResult writeResult) {
-        switch (request.getType()) {
+    private WriteConcernResult translateBulkWriteResult(final WriteRequest.Type type, final BulkWriteResult writeResult) {
+        switch (type) {
             case INSERT:
                 return WriteConcernResult.acknowledged(writeResult.getInsertedCount(), false, null);
             case DELETE:
@@ -1148,7 +1001,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
                                                        writeResult.getUpserts().isEmpty()
                                                        ? null : writeResult.getUpserts().get(0).getId());
             default:
-                throw new MongoInternalException("Unhandled write request type: " + request.getType());
+                throw new MongoInternalException("Unhandled write request type: " + type);
         }
     }
 
@@ -1162,30 +1015,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
         }
     }
 
-    private Codec<TDocument> getCodec() {
-        return getCodec(documentClass);
-    }
-
-    private <TResult> Codec<TResult> getCodec(final Class<TResult> resultClass) {
-        return codecRegistry.get(resultClass);
-    }
-
-    private BsonDocument documentToBsonDocument(final TDocument document) {
-        return BsonDocumentWrapper.asBsonDocument(document, codecRegistry);
-    }
-
     private BsonDocument toBsonDocument(final Bson document) {
         return document == null ? null : document.toBsonDocument(documentClass, codecRegistry);
-    }
-
-    private List<BsonDocument> toBsonDocumentList(final List<? extends Bson> bsonList) {
-        if (bsonList == null) {
-            return null;
-        }
-        List<BsonDocument> bsonDocumentList = new ArrayList<BsonDocument>(bsonList.size());
-        for (Bson cur : bsonList) {
-            bsonDocumentList.add(toBsonDocument(cur));
-        }
-        return bsonDocumentList;
     }
 }

--- a/driver-async/src/main/com/mongodb/async/client/MongoIterableImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoIterableImpl.java
@@ -25,10 +25,7 @@ import com.mongodb.async.SingleResultCallback;
 import com.mongodb.operation.AsyncOperationExecutor;
 import com.mongodb.operation.AsyncReadOperation;
 import com.mongodb.session.ClientSession;
-import org.bson.BsonDocument;
 import org.bson.assertions.Assertions;
-import org.bson.codecs.configuration.CodecRegistry;
-import org.bson.conversions.Bson;
 
 import java.util.Collection;
 import java.util.List;
@@ -39,8 +36,8 @@ import static com.mongodb.assertions.Assertions.notNull;
 abstract class MongoIterableImpl<TResult> implements MongoIterable<TResult> {
     private final ClientSession clientSession;
     private final ReadConcern readConcern;
-    private AsyncOperationExecutor executor;
-    private ReadPreference readPreference;
+    private final AsyncOperationExecutor executor;
+    private final ReadPreference readPreference;
     private Integer batchSize;
 
     MongoIterableImpl(final ClientSession clientSession, final AsyncOperationExecutor executor, final ReadConcern readConcern,
@@ -162,14 +159,6 @@ abstract class MongoIterableImpl<TResult> implements MongoIterable<TResult> {
     public void batchCursor(final SingleResultCallback<AsyncBatchCursor<TResult>> callback) {
         notNull("callback", callback);
         executor.execute(asAsyncReadOperation(), readPreference, clientSession, callback);
-    }
-
-    BsonDocument toBsonDocumentOrNull(final Bson document, final CodecRegistry codecRegistry) {
-        return toBsonDocumentOrNull(document, BsonDocument.class, codecRegistry);
-    }
-
-    <T> BsonDocument toBsonDocumentOrNull(final Bson document, final Class<T> documentClass, final CodecRegistry codecRegistry) {
-        return document == null ? null : document.toBsonDocument(documentClass, codecRegistry);
     }
 
     private void loopCursor(final AsyncBatchCursor<TResult> batchCursor, final Block<? super TResult> block,

--- a/driver-async/src/main/com/mongodb/async/client/WriteOperationThenCursorReadOperation.java
+++ b/driver-async/src/main/com/mongodb/async/client/WriteOperationThenCursorReadOperation.java
@@ -22,24 +22,23 @@ import com.mongodb.binding.AsyncReadBinding;
 import com.mongodb.binding.AsyncWriteBinding;
 import com.mongodb.operation.AsyncReadOperation;
 import com.mongodb.operation.AsyncWriteOperation;
-import com.mongodb.operation.FindOperation;
 
-class AggregateToCollectionThenFindOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>> {
+class WriteOperationThenCursorReadOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>> {
     private final AsyncWriteOperation<Void> aggregateToCollectionOperation;
-    private final FindOperation<T> findOperation;
+    private final AsyncReadOperation<AsyncBatchCursor<T>> readOperation;
 
-    AggregateToCollectionThenFindOperation(final AsyncWriteOperation<Void> aggregateToCollectionOperation,
-                                           final FindOperation<T> findOperation) {
+    WriteOperationThenCursorReadOperation(final AsyncWriteOperation<Void> aggregateToCollectionOperation,
+                                          final AsyncReadOperation<AsyncBatchCursor<T>> readOperation) {
         this.aggregateToCollectionOperation = aggregateToCollectionOperation;
-        this.findOperation = findOperation;
+        this.readOperation = readOperation;
     }
 
     public AsyncWriteOperation<Void> getAggregateToCollectionOperation() {
         return aggregateToCollectionOperation;
     }
 
-    public FindOperation<T> getFindOperation() {
-        return findOperation;
+    public AsyncReadOperation<AsyncBatchCursor<T>> getReadOperation() {
+        return readOperation;
     }
 
     @Override
@@ -51,7 +50,7 @@ class AggregateToCollectionThenFindOperation<T> implements AsyncReadOperation<As
                 if (t != null) {
                     callback.onResult(null, t);
                 } else {
-                    findOperation.executeAsync(binding, callback);
+                    readOperation.executeAsync(binding, callback);
                 }
             }
         });

--- a/driver-async/src/test/unit/com/mongodb/async/client/MapReduceIterableSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/MapReduceIterableSpecification.groovy
@@ -28,6 +28,7 @@ import com.mongodb.async.SingleResultCallback
 import com.mongodb.client.model.Collation
 import com.mongodb.client.model.MapReduceAction
 import com.mongodb.operation.AsyncOperationExecutor
+import com.mongodb.operation.FindOperation
 import com.mongodb.operation.MapReduceStatistics
 import com.mongodb.operation.MapReduceToCollectionOperation
 import com.mongodb.operation.MapReduceWithInlineResultsOperation
@@ -137,7 +138,7 @@ class MapReduceIterableSpecification extends Specification {
                 .collation(collation)
         mapReduceIterable.into([]) { result, t -> }
 
-        def operation = executor.getReadOperation() as AggregateToCollectionThenFindOperation
+        def operation = executor.getReadOperation() as WriteOperationThenCursorReadOperation
         def expectedOperation = new MapReduceToCollectionOperation(namespace, new BsonJavaScript('map'),
                 new BsonJavaScript('reduce'), 'collName', writeConcern)
                 .databaseName(collectionNamespace.getDatabaseName())
@@ -162,7 +163,7 @@ class MapReduceIterableSpecification extends Specification {
         expect writeOperation, isTheSameAs(expectedOperation)
 
         when: 'the subsequent read should have the batchSize set'
-        def readOperation = operation.getFindOperation()
+        def readOperation = operation.getReadOperation() as FindOperation
 
         then: 'should use the correct settings'
         readOperation.getNamespace() == collectionNamespace

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncOperations.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.operation;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.ReadConcern;
+import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
+import com.mongodb.async.AsyncBatchCursor;
+import com.mongodb.bulk.BulkWriteResult;
+import com.mongodb.client.model.BulkWriteOptions;
+import com.mongodb.client.model.Collation;
+import com.mongodb.client.model.CountOptions;
+import com.mongodb.client.model.CreateIndexOptions;
+import com.mongodb.client.model.DeleteOptions;
+import com.mongodb.client.model.DropIndexOptions;
+import com.mongodb.client.model.FindOneAndDeleteOptions;
+import com.mongodb.client.model.FindOneAndReplaceOptions;
+import com.mongodb.client.model.FindOneAndUpdateOptions;
+import com.mongodb.client.model.FindOptions;
+import com.mongodb.client.model.IndexModel;
+import com.mongodb.client.model.InsertManyOptions;
+import com.mongodb.client.model.InsertOneOptions;
+import com.mongodb.client.model.MapReduceAction;
+import com.mongodb.client.model.RenameCollectionOptions;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.WriteModel;
+import com.mongodb.operation.AsyncReadOperation;
+import com.mongodb.operation.AsyncWriteOperation;
+import com.mongodb.operation.MapReduceAsyncBatchCursor;
+import com.mongodb.operation.MapReduceStatistics;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
+
+import java.util.List;
+
+/**
+ * This class is NOT part of the public API. It may change at any time without notification.
+ */
+public final class AsyncOperations<TDocument> {
+    private final Operations<TDocument> operations;
+
+    public AsyncOperations(final Class<TDocument> documentClass, final ReadPreference readPreference,
+                           final CodecRegistry codecRegistry, final ReadConcern readConcern) {
+        this(null, documentClass, readPreference, codecRegistry, WriteConcern.ACKNOWLEDGED, false, readConcern);
+    }
+
+    public AsyncOperations(final MongoNamespace namespace, final Class<TDocument> documentClass, final ReadPreference readPreference,
+                           final CodecRegistry codecRegistry, final ReadConcern readConcern) {
+        this(namespace, documentClass, readPreference, codecRegistry, WriteConcern.ACKNOWLEDGED, false, readConcern);
+    }
+
+    public AsyncOperations(final MongoNamespace namespace, final Class<TDocument> documentClass, final ReadPreference readPreference,
+                           final CodecRegistry codecRegistry, final WriteConcern writeConcern, final boolean retryWrites,
+                           final ReadConcern readConcern) {
+        this.operations = new Operations<TDocument>(namespace, documentClass, readPreference, codecRegistry, writeConcern, retryWrites,
+                readConcern);
+    }
+
+    public AsyncReadOperation<Long> count(final Bson filter, final CountOptions options) {
+        return operations.count(filter, options);
+    }
+
+    public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> findFirst(final Bson filter, final Class<TResult> resultClass,
+                                                                             final FindOptions options) {
+        return operations.findFirst(filter, resultClass, options);
+    }
+
+    public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> find(final Bson filter, final Class<TResult> resultClass,
+                                                                        final FindOptions options) {
+        return operations.find(filter, resultClass, options);
+    }
+
+    public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> find(final MongoNamespace findNamespace, final Bson filter,
+                                                                        final Class<TResult> resultClass, final FindOptions options) {
+        return operations.find(findNamespace, filter, resultClass, options);
+    }
+
+    public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> distinct(final String fieldName, final Bson filter,
+                                                                            final Class<TResult> resultClass, final long maxTimeMS,
+                                                                            final Collation collation) {
+        return operations.distinct(fieldName, filter, resultClass, maxTimeMS, collation);
+    }
+
+    public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> aggregate(final List<? extends Bson> pipeline,
+                                                                             final Class<TResult> resultClass,
+                                                                             final long maxTimeMS, final long maxAwaitTimeMS,
+                                                                             final Integer batchSize, final Collation collation,
+                                                                             final Bson hint, final String comment,
+                                                                             final Boolean allowDiskUse, final Boolean useCursor) {
+        return operations.aggregate(pipeline, resultClass, maxTimeMS, maxAwaitTimeMS, batchSize, collation, hint, comment, allowDiskUse,
+                useCursor);
+    }
+
+    public AsyncWriteOperation<Void> aggregateToCollection(final List<? extends Bson> pipeline, final long maxTimeMS,
+                                                           final Boolean allowDiskUse, final Boolean bypassDocumentValidation,
+                                                           final Collation collation, final Bson hint, final String comment) {
+        return operations.aggregateToCollection(pipeline, maxTimeMS, allowDiskUse, bypassDocumentValidation, collation, hint, comment);
+    }
+
+    public AsyncWriteOperation<MapReduceStatistics> mapReduceToCollection(final String databaseName, final String collectionName,
+                                                                          final String mapFunction, final String reduceFunction,
+                                                                          final String finalizeFunction, final Bson filter, final int limit,
+                                                                          final long maxTimeMS, final boolean jsMode, final Bson scope,
+                                                                          final Bson sort, final boolean verbose,
+                                                                          final MapReduceAction action, final boolean nonAtomic,
+                                                                          final boolean sharded, final Boolean bypassDocumentValidation,
+                                                                          final Collation collation) {
+        return operations.mapReduceToCollection(databaseName, collectionName, mapFunction, reduceFunction, finalizeFunction, filter, limit,
+                maxTimeMS, jsMode, scope, sort, verbose, action, nonAtomic, sharded, bypassDocumentValidation, collation);
+    }
+
+    public <TResult> AsyncReadOperation<MapReduceAsyncBatchCursor<TResult>> mapReduce(final String mapFunction, final String reduceFunction,
+                                                                                      final String finalizeFunction,
+                                                                                      final Class<TResult> resultClass,
+                                                                                      final Bson filter, final int limit,
+                                                                                      final long maxTimeMS, final boolean jsMode,
+                                                                                      final Bson scope, final Bson sort,
+                                                                                      final boolean verbose, final Collation collation) {
+        return operations.mapReduce(mapFunction, reduceFunction, finalizeFunction, resultClass, filter, limit, maxTimeMS, jsMode, scope,
+                sort, verbose, collation);
+    }
+
+    public AsyncWriteOperation<TDocument> findOneAndDelete(final Bson filter, final FindOneAndDeleteOptions options) {
+        return operations.findOneAndDelete(filter, options);
+    }
+
+    public AsyncWriteOperation<TDocument> findOneAndReplace(final Bson filter, final TDocument replacement,
+                                                            final FindOneAndReplaceOptions options) {
+        return operations.findOneAndReplace(filter, replacement, options);
+    }
+
+    public AsyncWriteOperation<TDocument> findOneAndUpdate(final Bson filter, final Bson update, final FindOneAndUpdateOptions options) {
+        return operations.findOneAndUpdate(filter, update, options);
+    }
+
+    public AsyncWriteOperation<BulkWriteResult> insertOne(final TDocument document, final InsertOneOptions options) {
+        return operations.insertOne(document, options);
+    }
+
+
+    public AsyncWriteOperation<BulkWriteResult> replaceOne(final Bson filter, final TDocument replacement, final UpdateOptions options) {
+        return operations.replaceOne(filter, replacement, options);
+    }
+
+    public AsyncWriteOperation<BulkWriteResult> deleteOne(final Bson filter, final DeleteOptions options) {
+        return operations.deleteOne(filter, options);
+    }
+
+    public AsyncWriteOperation<BulkWriteResult> deleteMany(final Bson filter, final DeleteOptions options) {
+        return operations.deleteMany(filter, options);
+    }
+
+    public AsyncWriteOperation<BulkWriteResult> updateOne(final Bson filter, final Bson update, final UpdateOptions updateOptions) {
+        return operations.updateOne(filter, update, updateOptions);
+    }
+
+    public AsyncWriteOperation<BulkWriteResult> updateMany(final Bson filter, final Bson update, final UpdateOptions updateOptions) {
+        return operations.updateMany(filter, update, updateOptions);
+    }
+
+    public AsyncWriteOperation<BulkWriteResult> insertMany(final List<? extends TDocument> documents,
+                                                           final InsertManyOptions options) {
+        return operations.insertMany(documents, options);
+    }
+
+    @SuppressWarnings("unchecked")
+    public AsyncWriteOperation<BulkWriteResult> bulkWrite(final List<? extends WriteModel<? extends TDocument>> requests,
+                                                          final BulkWriteOptions options) {
+        return operations.bulkWrite(requests, options);
+    }
+
+
+    public AsyncWriteOperation<Void> dropCollection() {
+        return operations.dropCollection();
+    }
+
+    public AsyncWriteOperation<Void> renameCollection(final MongoNamespace newCollectionNamespace,
+                                                      final RenameCollectionOptions options) {
+        return operations.renameCollection(newCollectionNamespace, options);
+    }
+
+    public AsyncWriteOperation<Void> createIndexes(final List<IndexModel> indexes, final CreateIndexOptions options) {
+        return operations.createIndexes(indexes, options);
+    }
+
+    public AsyncWriteOperation<Void> dropIndex(final String indexName, final DropIndexOptions options) {
+        return operations.dropIndex(indexName, options);
+    }
+
+    public AsyncWriteOperation<Void> dropIndex(final Bson keys, final DropIndexOptions options) {
+        return operations.dropIndex(keys, options);
+    }
+
+    public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> listCollections(final String databaseName,
+                                                                                   final Class<TResult> resultClass, final Bson filter,
+                                                                                   final Integer batchSize, final long maxTimeMS) {
+        return operations.listCollections(databaseName, resultClass, filter, batchSize, maxTimeMS);
+    }
+
+    public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> listDatabases(final Class<TResult> resultClass, final Bson filter,
+                                                                                 final Boolean nameOnly, final long maxTimeMS) {
+        return operations.listDatabases(resultClass, filter, nameOnly, maxTimeMS);
+    }
+
+    public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> listIndexes(final Class<TResult> resultClass, final Integer batchSize,
+                                                                               final long maxTimeMS) {
+        return operations.listIndexes(resultClass, batchSize, maxTimeMS);
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/operation/IndexHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/IndexHelper.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 MongoDB, Inc.
+ * Copyright 2017 MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,21 +14,24 @@
  * limitations under the License.
  */
 
-package com.mongodb.operation;
+package com.mongodb.internal.operation;
 
 import org.bson.BsonDocument;
 import org.bson.BsonNumber;
 import org.bson.BsonString;
 import org.bson.BsonValue;
 
-final class IndexHelper {
+/**
+ * This class is NOT part of the public API. It may change at any time without notification.
+ */
+public final class IndexHelper {
 
     /**
      * Convenience method to generate an index name from the set of fields it is over.
      *
      * @return a string representation of this index's fields
      */
-    static String generateIndexName(final BsonDocument index) {
+    public static String generateIndexName(final BsonDocument index) {
         StringBuilder indexName = new StringBuilder();
         for (final String keyNames : index.keySet()) {
             if (indexName.length() != 0) {

--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -1,0 +1,511 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.operation;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.ReadConcern;
+import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
+import com.mongodb.bulk.DeleteRequest;
+import com.mongodb.bulk.IndexRequest;
+import com.mongodb.bulk.InsertRequest;
+import com.mongodb.bulk.UpdateRequest;
+import com.mongodb.bulk.WriteRequest;
+import com.mongodb.client.model.BulkWriteOptions;
+import com.mongodb.client.model.Collation;
+import com.mongodb.client.model.CountOptions;
+import com.mongodb.client.model.CreateIndexOptions;
+import com.mongodb.client.model.DeleteManyModel;
+import com.mongodb.client.model.DeleteOneModel;
+import com.mongodb.client.model.DeleteOptions;
+import com.mongodb.client.model.DropIndexOptions;
+import com.mongodb.client.model.FindOneAndDeleteOptions;
+import com.mongodb.client.model.FindOneAndReplaceOptions;
+import com.mongodb.client.model.FindOneAndUpdateOptions;
+import com.mongodb.client.model.FindOptions;
+import com.mongodb.client.model.IndexModel;
+import com.mongodb.client.model.InsertManyOptions;
+import com.mongodb.client.model.InsertOneModel;
+import com.mongodb.client.model.InsertOneOptions;
+import com.mongodb.client.model.MapReduceAction;
+import com.mongodb.client.model.RenameCollectionOptions;
+import com.mongodb.client.model.ReplaceOneModel;
+import com.mongodb.client.model.ReturnDocument;
+import com.mongodb.client.model.UpdateManyModel;
+import com.mongodb.client.model.UpdateOneModel;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.WriteModel;
+import com.mongodb.operation.AggregateOperation;
+import com.mongodb.operation.AggregateToCollectionOperation;
+import com.mongodb.operation.CountOperation;
+import com.mongodb.operation.CreateIndexesOperation;
+import com.mongodb.operation.DistinctOperation;
+import com.mongodb.operation.DropCollectionOperation;
+import com.mongodb.operation.DropIndexOperation;
+import com.mongodb.operation.FindAndDeleteOperation;
+import com.mongodb.operation.FindAndReplaceOperation;
+import com.mongodb.operation.FindAndUpdateOperation;
+import com.mongodb.operation.FindOperation;
+import com.mongodb.operation.ListCollectionsOperation;
+import com.mongodb.operation.ListDatabasesOperation;
+import com.mongodb.operation.ListIndexesOperation;
+import com.mongodb.operation.MapReduceToCollectionOperation;
+import com.mongodb.operation.MapReduceWithInlineResultsOperation;
+import com.mongodb.operation.MixedBulkWriteOperation;
+import com.mongodb.operation.RenameCollectionOperation;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentWrapper;
+import org.bson.BsonJavaScript;
+import org.bson.BsonString;
+import org.bson.codecs.Codec;
+import org.bson.codecs.CollectibleCodec;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static com.mongodb.assertions.Assertions.notNull;
+import static java.lang.String.format;
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+final class Operations<TDocument> {
+    private final MongoNamespace namespace;
+    private final Class<TDocument> documentClass;
+    private final ReadPreference readPreference;
+    private final CodecRegistry codecRegistry;
+    private final WriteConcern writeConcern;
+    private final boolean retryWrites;
+    private final ReadConcern readConcern;
+
+    Operations(final MongoNamespace namespace, final Class<TDocument> documentClass, final ReadPreference readPreference,
+                      final CodecRegistry codecRegistry, final WriteConcern writeConcern, final boolean retryWrites,
+                      final ReadConcern readConcern) {
+        this.namespace = namespace;
+        this.documentClass = documentClass;
+        this.readPreference = readPreference;
+        this.codecRegistry = codecRegistry;
+        this.writeConcern = writeConcern;
+        this.retryWrites = retryWrites;
+        this.readConcern = readConcern;
+    }
+
+    CountOperation count(final Bson filter, final CountOptions options) {
+        CountOperation operation = new CountOperation(namespace)
+                .filter(toBsonDocument(filter))
+                .skip(options.getSkip())
+                .limit(options.getLimit())
+                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
+                .collation(options.getCollation())
+                .readConcern(readConcern);
+        if (options.getHint() != null) {
+            operation.hint(toBsonDocument(options.getHint()));
+        } else if (options.getHintString() != null) {
+            operation.hint(new BsonString(options.getHintString()));
+        }
+        return operation;
+    }
+
+    <TResult> FindOperation<TResult> findFirst(final Bson filter, final Class<TResult> resultClass,
+                                                      final FindOptions options) {
+        return createFindOperation(namespace, filter, resultClass, options).batchSize(0).limit(-1);
+    }
+
+    <TResult> FindOperation<TResult> find(final Bson filter, final Class<TResult> resultClass,
+                                                 final FindOptions options) {
+        return createFindOperation(namespace, filter, resultClass, options);
+    }
+
+    <TResult> FindOperation<TResult> find(final MongoNamespace findNamespace, final Bson filter,
+                                                 final Class<TResult> resultClass, final FindOptions options) {
+        return createFindOperation(findNamespace, filter, resultClass, options);
+    }
+
+    @SuppressWarnings("deprecation")
+    private <TResult> FindOperation<TResult> createFindOperation(final MongoNamespace findNamespace, final Bson filter,
+                                                                 final Class<TResult> resultClass, final FindOptions options) {
+        return new FindOperation<TResult>(findNamespace, codecRegistry.get(resultClass))
+                .filter(filter.toBsonDocument(documentClass, codecRegistry))
+                .batchSize(options.getBatchSize())
+                .skip(options.getSkip())
+                .limit(options.getLimit())
+                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
+                .maxAwaitTime(options.getMaxAwaitTime(MILLISECONDS), MILLISECONDS)
+                .modifiers(toBsonDocumentOrNull(options.getModifiers()))
+                .projection(toBsonDocumentOrNull(options.getProjection()))
+                .sort(toBsonDocumentOrNull(options.getSort()))
+                .cursorType(options.getCursorType())
+                .noCursorTimeout(options.isNoCursorTimeout())
+                .oplogReplay(options.isOplogReplay())
+                .partial(options.isPartial())
+                .slaveOk(readPreference.isSlaveOk())
+                .readConcern(readConcern)
+                .collation(options.getCollation())
+                .comment(options.getComment())
+                .hint(toBsonDocumentOrNull(options.getHint()))
+                .min(toBsonDocumentOrNull(options.getMin()))
+                .max(toBsonDocumentOrNull(options.getMax()))
+                .maxScan(options.getMaxScan())
+                .returnKey(options.isReturnKey())
+                .showRecordId(options.isShowRecordId())
+                .snapshot(options.isSnapshot());
+    }
+
+    <TResult> DistinctOperation<TResult> distinct(final String fieldName, final Bson filter,
+                                                         final Class<TResult> resultClass, final long maxTimeMS,
+                                                         final Collation collation) {
+        return new DistinctOperation<TResult>(namespace, fieldName, codecRegistry.get(resultClass))
+                .filter(filter == null ? null : filter.toBsonDocument(documentClass, codecRegistry))
+                .maxTime(maxTimeMS, MILLISECONDS)
+                .readConcern(readConcern)
+                .collation(collation);
+
+    }
+
+    @SuppressWarnings("deprecation")
+    <TResult> AggregateOperation<TResult> aggregate(final List<? extends Bson> pipeline, final Class<TResult> resultClass,
+                                                           final long maxTimeMS, final long maxAwaitTimeMS, final Integer batchSize,
+                                                           final Collation collation,
+                                                           final Bson hint, final String comment, final Boolean allowDiskUse,
+                                                           final Boolean useCursor) {
+        return new AggregateOperation<TResult>(namespace, toBsonDocumentList(pipeline), codecRegistry.get(resultClass))
+                .maxTime(maxTimeMS, MILLISECONDS)
+                .maxAwaitTime(maxAwaitTimeMS, MILLISECONDS)
+                .allowDiskUse(allowDiskUse)
+                .batchSize(batchSize)
+                .useCursor(useCursor)
+                .readConcern(readConcern)
+                .collation(collation)
+                .hint(hint == null ? null : hint.toBsonDocument(documentClass, codecRegistry))
+                .comment(comment);
+
+    }
+
+    AggregateToCollectionOperation aggregateToCollection(final List<? extends Bson> pipeline, final long maxTimeMS,
+                                                                final Boolean allowDiskUse, final Boolean bypassDocumentValidation,
+                                                                final Collation collation, final Bson hint, final String comment) {
+        return new AggregateToCollectionOperation(namespace, toBsonDocumentList(pipeline), writeConcern)
+                .maxTime(maxTimeMS, MILLISECONDS)
+                .allowDiskUse(allowDiskUse)
+                .bypassDocumentValidation(bypassDocumentValidation)
+                .collation(collation)
+                .hint(hint == null ? null : hint.toBsonDocument(documentClass, codecRegistry))
+                .comment(comment);
+    }
+
+    MapReduceToCollectionOperation mapReduceToCollection(final String databaseName, final String collectionName,
+                                                                final String mapFunction, final String reduceFunction,
+                                                                final String finalizeFunction, final Bson filter, final int limit,
+                                                                final long maxTimeMS, final boolean jsMode, final Bson scope,
+                                                                final Bson sort, final boolean verbose, final MapReduceAction action,
+                                                                final boolean nonAtomic, final boolean sharded,
+                                                                final Boolean bypassDocumentValidation, final Collation collation) {
+        MapReduceToCollectionOperation operation = new MapReduceToCollectionOperation(namespace, new BsonJavaScript(mapFunction),
+                new BsonJavaScript(reduceFunction), collectionName, writeConcern)
+                .filter(toBsonDocumentOrNull(filter))
+                .limit(limit)
+                .maxTime(maxTimeMS, MILLISECONDS)
+                .jsMode(jsMode)
+                .scope(toBsonDocumentOrNull(scope))
+                .sort(toBsonDocumentOrNull(sort))
+                .verbose(verbose)
+                .action(action.getValue())
+                .nonAtomic(nonAtomic)
+                .sharded(sharded)
+                .databaseName(databaseName)
+                .bypassDocumentValidation(bypassDocumentValidation)
+                .collation(collation);
+
+        if (finalizeFunction != null) {
+            operation.finalizeFunction(new BsonJavaScript(finalizeFunction));
+        }
+        return operation;
+    }
+
+    <TResult> MapReduceWithInlineResultsOperation<TResult> mapReduce(final String mapFunction, final String reduceFunction,
+                                                                            final String finalizeFunction, final Class<TResult> resultClass,
+                                                                            final Bson filter, final int limit,
+                                                                            final long maxTimeMS, final boolean jsMode, final Bson scope,
+                                                                            final Bson sort, final boolean verbose,
+                                                                            final Collation collation) {
+        MapReduceWithInlineResultsOperation<TResult> operation =
+                new MapReduceWithInlineResultsOperation<TResult>(namespace,
+                        new BsonJavaScript(mapFunction),
+                        new BsonJavaScript(reduceFunction),
+                        codecRegistry.get(resultClass))
+                        .filter(toBsonDocumentOrNull(filter))
+                        .limit(limit)
+                        .maxTime(maxTimeMS, MILLISECONDS)
+                        .jsMode(jsMode)
+                        .scope(toBsonDocumentOrNull(scope))
+                        .sort(toBsonDocumentOrNull(sort))
+                        .verbose(verbose)
+                        .readConcern(readConcern)
+                        .collation(collation);
+        if (finalizeFunction != null) {
+            operation.finalizeFunction(new BsonJavaScript(finalizeFunction));
+        }
+        return operation;
+    }
+
+    FindAndDeleteOperation<TDocument> findOneAndDelete(final Bson filter, final FindOneAndDeleteOptions options) {
+        return new FindAndDeleteOperation<TDocument>(namespace, writeConcern, retryWrites, getCodec())
+                .filter(toBsonDocument(filter))
+                .projection(toBsonDocument(options.getProjection()))
+                .sort(toBsonDocument(options.getSort()))
+                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
+                .collation(options.getCollation());
+    }
+
+    FindAndReplaceOperation<TDocument> findOneAndReplace(final Bson filter, final TDocument replacement,
+                                                                final FindOneAndReplaceOptions options) {
+        return new FindAndReplaceOperation<TDocument>(namespace, writeConcern, retryWrites, getCodec(),
+                documentToBsonDocument(replacement))
+                .filter(toBsonDocument(filter))
+                .projection(toBsonDocument(options.getProjection()))
+                .sort(toBsonDocument(options.getSort()))
+                .returnOriginal(options.getReturnDocument() == ReturnDocument.BEFORE)
+                .upsert(options.isUpsert())
+                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
+                .bypassDocumentValidation(options.getBypassDocumentValidation())
+                .collation(options.getCollation());
+    }
+
+    FindAndUpdateOperation<TDocument> findOneAndUpdate(final Bson filter, final Bson update, final FindOneAndUpdateOptions options) {
+        return new FindAndUpdateOperation<TDocument>(namespace, writeConcern, retryWrites, getCodec(),
+                toBsonDocument(update))
+                .filter(toBsonDocument(filter))
+                .projection(toBsonDocument(options.getProjection()))
+                .sort(toBsonDocument(options.getSort()))
+                .returnOriginal(options.getReturnDocument() == ReturnDocument.BEFORE)
+                .upsert(options.isUpsert())
+                .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
+                .bypassDocumentValidation(options.getBypassDocumentValidation())
+                .collation(options.getCollation())
+                .arrayFilters(toBsonDocumentList(options.getArrayFilters()));
+    }
+
+
+    MixedBulkWriteOperation insertOne(final TDocument document, final InsertOneOptions options) {
+        return bulkWrite(singletonList(new InsertOneModel<TDocument>(document)),
+                new BulkWriteOptions().bypassDocumentValidation(options.getBypassDocumentValidation()));
+    }
+
+
+    MixedBulkWriteOperation replaceOne(final Bson filter, final TDocument replacement, final UpdateOptions options) {
+        return bulkWrite(singletonList(new ReplaceOneModel<TDocument>(filter, replacement, options)),
+                new BulkWriteOptions().bypassDocumentValidation(options.getBypassDocumentValidation()));
+    }
+
+    MixedBulkWriteOperation deleteOne(final Bson filter, final DeleteOptions options) {
+        return bulkWrite(singletonList(new DeleteOneModel<TDocument>(filter, options)), new BulkWriteOptions());
+    }
+
+    MixedBulkWriteOperation deleteMany(final Bson filter, final DeleteOptions options) {
+        return bulkWrite(singletonList(new DeleteManyModel<TDocument>(filter, options)), new BulkWriteOptions());
+    }
+
+    MixedBulkWriteOperation updateOne(final Bson filter, final Bson update, final UpdateOptions updateOptions) {
+        return bulkWrite(singletonList(new UpdateOneModel<TDocument>(filter, update, updateOptions)),
+                new BulkWriteOptions().bypassDocumentValidation(updateOptions.getBypassDocumentValidation()));
+    }
+
+    MixedBulkWriteOperation updateMany(final Bson filter, final Bson update, final UpdateOptions updateOptions) {
+        return bulkWrite(singletonList(new UpdateManyModel<TDocument>(filter, update, updateOptions)),
+                new BulkWriteOptions().bypassDocumentValidation(updateOptions.getBypassDocumentValidation()));
+    }
+
+    MixedBulkWriteOperation insertMany(final List<? extends TDocument> documents,
+                                              final InsertManyOptions options) {
+        notNull("documents", documents);
+        List<InsertRequest> requests = new ArrayList<InsertRequest>(documents.size());
+        for (TDocument document : documents) {
+            if (document == null) {
+                throw new IllegalArgumentException("documents can not contain a null value");
+            }
+            if (getCodec() instanceof CollectibleCodec) {
+                document = ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(document);
+            }
+            requests.add(new InsertRequest(documentToBsonDocument(document)));
+        }
+
+        return new MixedBulkWriteOperation(namespace, requests, options.isOrdered(), writeConcern, retryWrites)
+                .bypassDocumentValidation(options.getBypassDocumentValidation());
+    }
+
+    @SuppressWarnings("unchecked")
+    MixedBulkWriteOperation bulkWrite(final List<? extends WriteModel<? extends TDocument>> requests,
+                                             final BulkWriteOptions options) {
+        notNull("requests", requests);
+        List<WriteRequest> writeRequests = new ArrayList<WriteRequest>(requests.size());
+        for (WriteModel<? extends TDocument> writeModel : requests) {
+            WriteRequest writeRequest;
+            if (writeModel == null) {
+                throw new IllegalArgumentException("requests can not contain a null value");
+            } else if (writeModel instanceof InsertOneModel) {
+                TDocument document = ((InsertOneModel<TDocument>) writeModel).getDocument();
+                if (getCodec() instanceof CollectibleCodec) {
+                    document = ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(document);
+                }
+                writeRequest = new InsertRequest(documentToBsonDocument(document));
+            } else if (writeModel instanceof ReplaceOneModel) {
+                ReplaceOneModel<TDocument> replaceOneModel = (ReplaceOneModel<TDocument>) writeModel;
+                writeRequest = new UpdateRequest(toBsonDocument(replaceOneModel.getFilter()), documentToBsonDocument(replaceOneModel
+                        .getReplacement()),
+                        WriteRequest.Type.REPLACE)
+                        .upsert(replaceOneModel.getOptions().isUpsert())
+                        .collation(replaceOneModel.getOptions().getCollation());
+            } else if (writeModel instanceof UpdateOneModel) {
+                UpdateOneModel<TDocument> updateOneModel = (UpdateOneModel<TDocument>) writeModel;
+                writeRequest = new UpdateRequest(toBsonDocument(updateOneModel.getFilter()), toBsonDocument(updateOneModel.getUpdate()),
+                        WriteRequest.Type.UPDATE)
+                        .multi(false)
+                        .upsert(updateOneModel.getOptions().isUpsert())
+                        .collation(updateOneModel.getOptions().getCollation())
+                        .arrayFilters(toBsonDocumentList(updateOneModel.getOptions().getArrayFilters()));
+            } else if (writeModel instanceof UpdateManyModel) {
+                UpdateManyModel<TDocument> updateManyModel = (UpdateManyModel<TDocument>) writeModel;
+                writeRequest = new UpdateRequest(toBsonDocument(updateManyModel.getFilter()), toBsonDocument(updateManyModel.getUpdate()),
+                        WriteRequest.Type.UPDATE)
+                        .multi(true)
+                        .upsert(updateManyModel.getOptions().isUpsert())
+                        .collation(updateManyModel.getOptions().getCollation())
+                        .arrayFilters(toBsonDocumentList(updateManyModel.getOptions().getArrayFilters()));
+            } else if (writeModel instanceof DeleteOneModel) {
+                DeleteOneModel<TDocument> deleteOneModel = (DeleteOneModel<TDocument>) writeModel;
+                writeRequest = new DeleteRequest(toBsonDocument(deleteOneModel.getFilter())).multi(false)
+                        .collation(deleteOneModel.getOptions().getCollation());
+            } else if (writeModel instanceof DeleteManyModel) {
+                DeleteManyModel<TDocument> deleteManyModel = (DeleteManyModel<TDocument>) writeModel;
+                writeRequest = new DeleteRequest(toBsonDocument(deleteManyModel.getFilter())).multi(true)
+                        .collation(deleteManyModel.getOptions().getCollation());
+            } else {
+                throw new UnsupportedOperationException(format("WriteModel of type %s is not supported", writeModel.getClass()));
+            }
+            writeRequests.add(writeRequest);
+        }
+
+        return new MixedBulkWriteOperation(namespace, writeRequests, options.isOrdered(), writeConcern, retryWrites)
+                .bypassDocumentValidation(options.getBypassDocumentValidation());
+    }
+
+
+    DropCollectionOperation dropCollection() {
+        return new DropCollectionOperation(namespace, writeConcern);
+    }
+
+
+    RenameCollectionOperation renameCollection(final MongoNamespace newCollectionNamespace,
+                                                      final RenameCollectionOptions renameCollectionOptions) {
+        return new RenameCollectionOperation(namespace, newCollectionNamespace, writeConcern)
+                .dropTarget(renameCollectionOptions.isDropTarget());
+    }
+
+    CreateIndexesOperation createIndexes(final List<IndexModel> indexes, final CreateIndexOptions createIndexOptions) {
+        notNull("indexes", indexes);
+        notNull("createIndexOptions", createIndexOptions);
+        List<IndexRequest> indexRequests = new ArrayList<IndexRequest>(indexes.size());
+        for (IndexModel model : indexes) {
+            if (model == null) {
+                throw new IllegalArgumentException("indexes can not contain a null value");
+            }
+            indexRequests.add(new IndexRequest(toBsonDocument(model.getKeys()))
+                    .name(model.getOptions().getName())
+                    .background(model.getOptions().isBackground())
+                    .unique(model.getOptions().isUnique())
+                    .sparse(model.getOptions().isSparse())
+                    .expireAfter(model.getOptions().getExpireAfter(TimeUnit.SECONDS), TimeUnit.SECONDS)
+                    .version(model.getOptions().getVersion())
+                    .weights(toBsonDocument(model.getOptions().getWeights()))
+                    .defaultLanguage(model.getOptions().getDefaultLanguage())
+                    .languageOverride(model.getOptions().getLanguageOverride())
+                    .textVersion(model.getOptions().getTextVersion())
+                    .sphereVersion(model.getOptions().getSphereVersion())
+                    .bits(model.getOptions().getBits())
+                    .min(model.getOptions().getMin())
+                    .max(model.getOptions().getMax())
+                    .bucketSize(model.getOptions().getBucketSize())
+                    .storageEngine(toBsonDocument(model.getOptions().getStorageEngine()))
+                    .partialFilterExpression(toBsonDocument(model.getOptions().getPartialFilterExpression()))
+                    .collation(model.getOptions().getCollation())
+            );
+        }
+        return new CreateIndexesOperation(namespace, indexRequests, writeConcern)
+                .maxTime(createIndexOptions.getMaxTime(MILLISECONDS), MILLISECONDS);
+    }
+
+    DropIndexOperation dropIndex(final String indexName, final DropIndexOptions dropIndexOptions) {
+        return new DropIndexOperation(namespace, indexName, writeConcern)
+                .maxTime(dropIndexOptions.getMaxTime(MILLISECONDS), MILLISECONDS);
+    }
+
+    DropIndexOperation dropIndex(final Bson keys, final DropIndexOptions dropIndexOptions) {
+        return new DropIndexOperation(namespace, keys.toBsonDocument(BsonDocument.class, codecRegistry), writeConcern)
+                .maxTime(dropIndexOptions.getMaxTime(MILLISECONDS), MILLISECONDS);
+    }
+
+    <TResult> ListCollectionsOperation<TResult> listCollections(final String databaseName, final Class<TResult> resultClass,
+                                                                       final Bson filter, final Integer batchSize, final long maxTimeMS) {
+        return new ListCollectionsOperation<TResult>(databaseName, codecRegistry.get(resultClass))
+                .filter(toBsonDocumentOrNull(filter))
+                .batchSize(batchSize == null ? 0 : batchSize)
+                .maxTime(maxTimeMS, MILLISECONDS);
+    }
+
+    <TResult> ListDatabasesOperation<TResult> listDatabases(final Class<TResult> resultClass, final Bson filter,
+                                                                   final Boolean nameOnly, final long maxTimeMS) {
+        return new ListDatabasesOperation<TResult>(codecRegistry.get(resultClass)).maxTime(maxTimeMS, MILLISECONDS)
+                .filter(toBsonDocumentOrNull(filter))
+                .nameOnly(nameOnly);
+    }
+
+    <TResult> ListIndexesOperation<TResult> listIndexes(final Class<TResult> resultClass, final Integer batchSize,
+                                                               final long maxTimeMS) {
+        return new ListIndexesOperation<TResult>(namespace, codecRegistry.get(resultClass))
+                .batchSize(batchSize == null ? 0 : batchSize)
+                .maxTime(maxTimeMS, MILLISECONDS);
+    }
+
+    private Codec<TDocument> getCodec() {
+        return codecRegistry.get(documentClass);
+    }
+
+    private BsonDocument documentToBsonDocument(final TDocument document) {
+        return BsonDocumentWrapper.asBsonDocument(document, codecRegistry);
+    }
+
+    private BsonDocument toBsonDocument(final Bson bson) {
+        return bson == null ? null : bson.toBsonDocument(documentClass, codecRegistry);
+    }
+
+    private List<BsonDocument> toBsonDocumentList(final List<? extends Bson> bsonList) {
+        if (bsonList == null) {
+            return null;
+        }
+        List<BsonDocument> bsonDocumentList = new ArrayList<BsonDocument>(bsonList.size());
+        for (Bson cur : bsonList) {
+            bsonDocumentList.add(toBsonDocument(cur));
+        }
+        return bsonDocumentList;
+    }
+
+    BsonDocument toBsonDocumentOrNull(final Bson document) {
+        return document == null ? null : document.toBsonDocument(documentClass, codecRegistry);
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2017 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.operation;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.ReadConcern;
+import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
+import com.mongodb.bulk.BulkWriteResult;
+import com.mongodb.client.model.BulkWriteOptions;
+import com.mongodb.client.model.Collation;
+import com.mongodb.client.model.CountOptions;
+import com.mongodb.client.model.CreateIndexOptions;
+import com.mongodb.client.model.DeleteOptions;
+import com.mongodb.client.model.DropIndexOptions;
+import com.mongodb.client.model.FindOneAndDeleteOptions;
+import com.mongodb.client.model.FindOneAndReplaceOptions;
+import com.mongodb.client.model.FindOneAndUpdateOptions;
+import com.mongodb.client.model.FindOptions;
+import com.mongodb.client.model.IndexModel;
+import com.mongodb.client.model.InsertManyOptions;
+import com.mongodb.client.model.InsertOneOptions;
+import com.mongodb.client.model.MapReduceAction;
+import com.mongodb.client.model.RenameCollectionOptions;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.WriteModel;
+import com.mongodb.operation.BatchCursor;
+import com.mongodb.operation.MapReduceBatchCursor;
+import com.mongodb.operation.MapReduceStatistics;
+import com.mongodb.operation.ReadOperation;
+import com.mongodb.operation.WriteOperation;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
+
+import java.util.List;
+
+/**
+ * This class is NOT part of the public API. It may change at any time without notification.
+ */
+public final class SyncOperations<TDocument> {
+    private final Operations<TDocument> operations;
+
+    public SyncOperations(final Class<TDocument> documentClass, final ReadPreference readPreference,
+                          final CodecRegistry codecRegistry, final ReadConcern readConcern) {
+        this(null, documentClass, readPreference, codecRegistry, WriteConcern.ACKNOWLEDGED, false, readConcern);
+    }
+
+    public SyncOperations(final MongoNamespace namespace, final Class<TDocument> documentClass, final ReadPreference readPreference,
+                          final CodecRegistry codecRegistry, final ReadConcern readConcern) {
+        this(namespace, documentClass, readPreference, codecRegistry, WriteConcern.ACKNOWLEDGED, false, readConcern);
+    }
+
+    public SyncOperations(final MongoNamespace namespace, final Class<TDocument> documentClass, final ReadPreference readPreference,
+                          final CodecRegistry codecRegistry, final WriteConcern writeConcern, final boolean retryWrites,
+                          final ReadConcern readConcern) {
+        this.operations = new Operations<TDocument>(namespace, documentClass, readPreference, codecRegistry, writeConcern, retryWrites,
+                readConcern);
+    }
+
+    public ReadOperation<Long> count(final Bson filter, final CountOptions options) {
+        return operations.count(filter, options);
+    }
+
+    public <TResult> ReadOperation<BatchCursor<TResult>> findFirst(final Bson filter, final Class<TResult> resultClass,
+                                                                   final FindOptions options) {
+        return operations.findFirst(filter, resultClass, options);
+    }
+
+    public <TResult> ReadOperation<BatchCursor<TResult>> find(final Bson filter, final Class<TResult> resultClass,
+                                                              final FindOptions options) {
+        return operations.find(filter, resultClass, options);
+    }
+
+    public <TResult> ReadOperation<BatchCursor<TResult>> find(final MongoNamespace findNamespace, final Bson filter,
+                                                              final Class<TResult> resultClass, final FindOptions options) {
+        return operations.find(findNamespace, filter, resultClass, options);
+    }
+
+    public <TResult> ReadOperation<BatchCursor<TResult>> distinct(final String fieldName, final Bson filter,
+                                                                  final Class<TResult> resultClass, final long maxTimeMS,
+                                                                  final Collation collation) {
+        return operations.distinct(fieldName, filter, resultClass, maxTimeMS, collation);
+    }
+
+    public <TResult> ReadOperation<BatchCursor<TResult>> aggregate(final List<? extends Bson> pipeline, final Class<TResult> resultClass,
+                                                                   final long maxTimeMS, final long maxAwaitTimeMS, final Integer batchSize,
+                                                                   final Collation collation, final Bson hint, final String comment,
+                                                                   final Boolean allowDiskUse, final Boolean useCursor) {
+        return operations.aggregate(pipeline, resultClass, maxTimeMS, maxAwaitTimeMS, batchSize, collation, hint, comment, allowDiskUse,
+                useCursor);
+    }
+
+    public WriteOperation<Void> aggregateToCollection(final List<? extends Bson> pipeline, final long maxTimeMS,
+                                                      final Boolean allowDiskUse, final Boolean bypassDocumentValidation,
+                                                      final Collation collation, final Bson hint, final String comment) {
+        return operations.aggregateToCollection(pipeline, maxTimeMS, allowDiskUse, bypassDocumentValidation, collation, hint, comment);
+    }
+
+    public WriteOperation<MapReduceStatistics> mapReduceToCollection(final String databaseName, final String collectionName,
+                                                                     final String mapFunction, final String reduceFunction,
+                                                                     final String finalizeFunction, final Bson filter, final int limit,
+                                                                     final long maxTimeMS, final boolean jsMode, final Bson scope,
+                                                                     final Bson sort, final boolean verbose, final MapReduceAction action,
+                                                                     final boolean nonAtomic, final boolean sharded,
+                                                                     final Boolean bypassDocumentValidation, final Collation collation) {
+        return operations.mapReduceToCollection(databaseName, collectionName, mapFunction, reduceFunction, finalizeFunction, filter, limit,
+                maxTimeMS, jsMode, scope, sort, verbose, action, nonAtomic, sharded, bypassDocumentValidation, collation);
+    }
+
+    public <TResult> ReadOperation<MapReduceBatchCursor<TResult>> mapReduce(final String mapFunction, final String reduceFunction,
+                                                                            final String finalizeFunction, final Class<TResult> resultClass,
+                                                                            final Bson filter, final int limit,
+                                                                            final long maxTimeMS, final boolean jsMode, final Bson scope,
+                                                                            final Bson sort, final boolean verbose,
+                                                                            final Collation collation) {
+        return operations.mapReduce(mapFunction, reduceFunction, finalizeFunction, resultClass, filter, limit, maxTimeMS, jsMode, scope,
+                sort, verbose, collation);
+    }
+
+    public WriteOperation<TDocument> findOneAndDelete(final Bson filter, final FindOneAndDeleteOptions options) {
+        return operations.findOneAndDelete(filter, options);
+    }
+
+    public WriteOperation<TDocument> findOneAndReplace(final Bson filter, final TDocument replacement,
+                                                       final FindOneAndReplaceOptions options) {
+        return operations.findOneAndReplace(filter, replacement, options);
+    }
+
+    public WriteOperation<TDocument> findOneAndUpdate(final Bson filter, final Bson update, final FindOneAndUpdateOptions options) {
+        return operations.findOneAndUpdate(filter, update, options);
+    }
+
+    public WriteOperation<BulkWriteResult> insertOne(final TDocument document, final InsertOneOptions options) {
+        return operations.insertOne(document, options);
+    }
+
+
+    public WriteOperation<BulkWriteResult> replaceOne(final Bson filter, final TDocument replacement, final UpdateOptions options) {
+        return operations.replaceOne(filter, replacement, options);
+    }
+
+    public WriteOperation<BulkWriteResult> deleteOne(final Bson filter, final DeleteOptions options) {
+        return operations.deleteOne(filter, options);
+    }
+
+    public WriteOperation<BulkWriteResult> deleteMany(final Bson filter, final DeleteOptions options) {
+        return operations.deleteMany(filter, options);
+    }
+
+    public WriteOperation<BulkWriteResult> updateOne(final Bson filter, final Bson update, final UpdateOptions updateOptions) {
+        return operations.updateOne(filter, update, updateOptions);
+    }
+
+    public WriteOperation<BulkWriteResult> updateMany(final Bson filter, final Bson update, final UpdateOptions updateOptions) {
+        return operations.updateMany(filter, update, updateOptions);
+    }
+
+    public WriteOperation<BulkWriteResult> insertMany(final List<? extends TDocument> documents,
+                                                      final InsertManyOptions options) {
+        return operations.insertMany(documents, options);
+    }
+
+    @SuppressWarnings("unchecked")
+    public WriteOperation<BulkWriteResult> bulkWrite(final List<? extends WriteModel<? extends TDocument>> requests,
+                                                     final BulkWriteOptions options) {
+        return operations.bulkWrite(requests, options);
+    }
+
+
+    public WriteOperation<Void> dropCollection() {
+        return operations.dropCollection();
+    }
+
+    public WriteOperation<Void> renameCollection(final MongoNamespace newCollectionNamespace,
+                                                 final RenameCollectionOptions options) {
+        return operations.renameCollection(newCollectionNamespace, options);
+    }
+
+    public WriteOperation<Void> createIndexes(final List<IndexModel> indexes, final CreateIndexOptions options) {
+        return operations.createIndexes(indexes, options);
+    }
+
+    public WriteOperation<Void> dropIndex(final String indexName, final DropIndexOptions options) {
+        return operations.dropIndex(indexName, options);
+    }
+
+    public WriteOperation<Void> dropIndex(final Bson keys, final DropIndexOptions options) {
+        return operations.dropIndex(keys, options);
+    }
+
+    public <TResult> ReadOperation<BatchCursor<TResult>> listCollections(final String databaseName, final Class<TResult> resultClass,
+                                                                         final Bson filter, final Integer batchSize, final long maxTimeMS) {
+        return operations.listCollections(databaseName, resultClass, filter, batchSize, maxTimeMS);
+    }
+
+    public <TResult> ReadOperation<BatchCursor<TResult>> listDatabases(final Class<TResult> resultClass, final Bson filter,
+                                                                       final Boolean nameOnly, final long maxTimeMS) {
+        return operations.listDatabases(resultClass, filter, nameOnly, maxTimeMS);
+    }
+
+    public <TResult> ReadOperation<BatchCursor<TResult>> listIndexes(final Class<TResult> resultClass, final Integer batchSize,
+                                                                     final long maxTimeMS) {
+        return operations.listIndexes(resultClass, batchSize, maxTimeMS);
+    }
+}

--- a/driver-core/src/main/com/mongodb/operation/CreateIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateIndexesOperation.java
@@ -30,6 +30,7 @@ import com.mongodb.bulk.IndexRequest;
 import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.Connection;
 import com.mongodb.connection.ConnectionDescription;
+import com.mongodb.internal.operation.IndexHelper;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
@@ -48,7 +49,7 @@ import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandli
 import static com.mongodb.operation.CommandOperationHelper.executeWrappedCommandProtocol;
 import static com.mongodb.operation.CommandOperationHelper.executeWrappedCommandProtocolAsync;
 import static com.mongodb.operation.DocumentHelper.putIfNotZero;
-import static com.mongodb.operation.IndexHelper.generateIndexName;
+import static com.mongodb.internal.operation.IndexHelper.generateIndexName;
 import static com.mongodb.operation.OperationHelper.AsyncCallableWithConnection;
 import static com.mongodb.operation.OperationHelper.CallableWithConnection;
 import static com.mongodb.operation.OperationHelper.LOGGER;

--- a/driver-core/src/main/com/mongodb/operation/DropIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DropIndexOperation.java
@@ -39,7 +39,7 @@ import static com.mongodb.operation.CommandOperationHelper.executeWrappedCommand
 import static com.mongodb.operation.CommandOperationHelper.executeWrappedCommandProtocolAsync;
 import static com.mongodb.operation.CommandOperationHelper.isNamespaceError;
 import static com.mongodb.operation.DocumentHelper.putIfNotZero;
-import static com.mongodb.operation.IndexHelper.generateIndexName;
+import static com.mongodb.internal.operation.IndexHelper.generateIndexName;
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.withConnection;

--- a/driver/src/main/com/mongodb/AggregateIterableImpl.java
+++ b/driver/src/main/com/mongodb/AggregateIterableImpl.java
@@ -18,10 +18,9 @@ package com.mongodb;
 
 import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.model.Collation;
-import com.mongodb.operation.AggregateOperation;
-import com.mongodb.operation.AggregateToCollectionOperation;
+import com.mongodb.client.model.FindOptions;
+import com.mongodb.internal.operation.SyncOperations;
 import com.mongodb.operation.BatchCursor;
-import com.mongodb.operation.FindOperation;
 import com.mongodb.operation.ReadOperation;
 import com.mongodb.session.ClientSession;
 import org.bson.BsonDocument;
@@ -29,18 +28,16 @@ import org.bson.BsonValue;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.assertions.Assertions.notNull;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult> implements AggregateIterable<TResult> {
+    private final SyncOperations<TDocument> operations;
     private final MongoNamespace namespace;
     private final Class<TDocument> documentClass;
     private final Class<TResult> resultClass;
-    private final WriteConcern writeConcern;
     private final CodecRegistry codecRegistry;
     private final List<? extends Bson> pipeline;
 
@@ -58,23 +55,24 @@ class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
                           final ReadConcern readConcern, final WriteConcern writeConcern, final OperationExecutor executor,
                           final List<? extends Bson> pipeline) {
         super(clientSession, executor, readConcern, readPreference);
+        this.operations = new SyncOperations<TDocument>(namespace, documentClass, readPreference, codecRegistry, writeConcern, false,
+                readConcern);
         this.namespace = notNull("namespace", namespace);
         this.documentClass = notNull("documentClass", documentClass);
         this.resultClass = notNull("resultClass", resultClass);
         this.codecRegistry = notNull("codecRegistry", codecRegistry);
-        this.writeConcern = notNull("writeConcern", writeConcern);
         this.pipeline = notNull("pipeline", pipeline);
     }
 
     @Override
     public void toCollection() {
-        List<BsonDocument> aggregateList = createBsonDocumentList(pipeline);
 
-        if (getOutCollection(aggregateList) == null) {
+        if (getOutCollection() == null) {
             throw new IllegalStateException("The last stage of the aggregation pipeline must be $out");
         }
 
-        getExecutor().execute(createAggregateToCollectionOperation(aggregateList), getClientSession());
+        getExecutor().execute(operations.aggregateToCollection(pipeline, maxTimeMS, allowDiskUse, bypassDocumentValidation, collation, hint,
+                comment), getClientSession());
     }
 
     @Override
@@ -137,57 +135,30 @@ class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
     @Override
     @SuppressWarnings("deprecation")
     ReadOperation<BatchCursor<TResult>> asReadOperation() {
-        List<BsonDocument> aggregateList = createBsonDocumentList(pipeline);
-
-        BsonValue outCollection = getOutCollection(aggregateList);
+        BsonValue outCollection = getOutCollection();
 
         if (outCollection != null) {
-            getExecutor().execute(createAggregateToCollectionOperation(aggregateList), getClientSession());
-            FindOperation<TResult> findOperation =
-                    new FindOperation<TResult>(new MongoNamespace(namespace.getDatabaseName(), outCollection.asString().getValue()),
-                                                      codecRegistry.get(resultClass))
-                            .readConcern(getReadConcern())
-                            .collation(collation);
+            getExecutor().execute(operations.aggregateToCollection(pipeline, maxTimeMS, allowDiskUse, bypassDocumentValidation, collation,
+                    hint, comment), getClientSession());
+
+            FindOptions findOptions = new FindOptions().collation(collation);
             if (getBatchSize() != null) {
-                findOperation.batchSize(getBatchSize());
+                findOptions.batchSize(getBatchSize());
             }
-            return findOperation;
+            return operations.find(new MongoNamespace(namespace.getDatabaseName(), outCollection.asString().getValue()), new BsonDocument(),
+                    resultClass, findOptions);
         } else {
-            return new AggregateOperation<TResult>(namespace, aggregateList, codecRegistry.get(resultClass))
-                    .maxTime(maxTimeMS, MILLISECONDS)
-                    .maxAwaitTime(maxAwaitTimeMS, MILLISECONDS)
-                    .allowDiskUse(allowDiskUse)
-                    .batchSize(getBatchSize())
-                    .useCursor(useCursor)
-                    .readConcern(getReadConcern())
-                    .collation(collation)
-                    .hint(hint == null ? null : hint.toBsonDocument(documentClass, codecRegistry))
-                    .comment(comment);
+            return operations.aggregate(pipeline, resultClass, maxTimeMS, maxAwaitTimeMS, getBatchSize(), collation,
+                    hint, comment, allowDiskUse, useCursor);
         }
     }
 
-    private BsonValue getOutCollection(final List<BsonDocument> aggregateList) {
-        return aggregateList.size() == 0 ? null : aggregateList.get(aggregateList.size() - 1).get("$out");
-    }
-
-    private AggregateToCollectionOperation createAggregateToCollectionOperation(final List<BsonDocument> aggregateList) {
-        return new AggregateToCollectionOperation(namespace, aggregateList, writeConcern)
-                        .maxTime(maxTimeMS, MILLISECONDS)
-                        .allowDiskUse(allowDiskUse)
-                        .bypassDocumentValidation(bypassDocumentValidation)
-                        .collation(collation)
-                        .hint(hint == null ? null : hint.toBsonDocument(documentClass, codecRegistry))
-                        .comment(comment);
-    }
-
-    private List<BsonDocument> createBsonDocumentList(final List<? extends Bson> pipeline) {
-        List<BsonDocument> aggregateList = new ArrayList<BsonDocument>(pipeline.size());
-        for (Bson obj : pipeline) {
-            if (obj == null) {
-                throw new IllegalArgumentException("pipeline can not contain a null value");
-            }
-            aggregateList.add(obj.toBsonDocument(documentClass, codecRegistry));
+    private BsonValue getOutCollection() {
+        if (pipeline.size() == 0) {
+            return null;
         }
-        return aggregateList;
+
+        Bson lastStage = notNull("last stage", pipeline.get(pipeline.size() - 1));
+        return lastStage.toBsonDocument(documentClass, codecRegistry).get("$out");
     }
 }

--- a/driver/src/main/com/mongodb/DistinctIterableImpl.java
+++ b/driver/src/main/com/mongodb/DistinctIterableImpl.java
@@ -18,8 +18,8 @@ package com.mongodb;
 
 import com.mongodb.client.DistinctIterable;
 import com.mongodb.client.model.Collation;
+import com.mongodb.internal.operation.SyncOperations;
 import com.mongodb.operation.BatchCursor;
-import com.mongodb.operation.DistinctOperation;
 import com.mongodb.operation.ReadOperation;
 import com.mongodb.session.ClientSession;
 import org.bson.codecs.configuration.CodecRegistry;
@@ -28,13 +28,11 @@ import org.bson.conversions.Bson;
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.assertions.Assertions.notNull;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 class DistinctIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult> implements DistinctIterable<TResult> {
-    private final MongoNamespace namespace;
-    private final Class<TDocument> documentClass;
+    private final SyncOperations<TDocument> operations;
+
     private final Class<TResult> resultClass;
-    private final CodecRegistry codecRegistry;
     private final String fieldName;
 
     private Bson filter;
@@ -46,10 +44,8 @@ class DistinctIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult
                          final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
                          final ReadConcern readConcern, final OperationExecutor executor, final String fieldName, final Bson filter) {
         super(clientSession, executor, readConcern, readPreference);
-        this.namespace = notNull("namespace", namespace);
-        this.documentClass = notNull("documentClass", documentClass);
+        this.operations = new SyncOperations<TDocument>(namespace, documentClass, readPreference, codecRegistry, readConcern);
         this.resultClass = notNull("resultClass", resultClass);
-        this.codecRegistry = notNull("codecRegistry", codecRegistry);
         this.fieldName = notNull("mapFunction", fieldName);
         this.filter = filter;
     }
@@ -81,10 +77,6 @@ class DistinctIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult
 
     @Override
     ReadOperation<BatchCursor<TResult>> asReadOperation() {
-        return new DistinctOperation<TResult>(namespace, fieldName, codecRegistry.get(resultClass))
-                       .filter(filter == null ? null : filter.toBsonDocument(documentClass, codecRegistry))
-                       .maxTime(maxTimeMS, MILLISECONDS)
-                       .readConcern(getReadConcern())
-                       .collation(collation);
+        return operations.distinct(fieldName, filter, resultClass, maxTimeMS, collation);
     }
 }

--- a/driver/src/main/com/mongodb/FindIterableImpl.java
+++ b/driver/src/main/com/mongodb/FindIterableImpl.java
@@ -19,8 +19,8 @@ package com.mongodb;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.FindOptions;
+import com.mongodb.internal.operation.SyncOperations;
 import com.mongodb.operation.BatchCursor;
-import com.mongodb.operation.FindOperation;
 import com.mongodb.operation.ReadOperation;
 import com.mongodb.session.ClientSession;
 import org.bson.codecs.configuration.CodecRegistry;
@@ -29,14 +29,13 @@ import org.bson.conversions.Bson;
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.assertions.Assertions.notNull;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @SuppressWarnings("deprecation")
 final class FindIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult> implements FindIterable<TResult> {
-    private final MongoNamespace namespace;
-    private final Class<TDocument> documentClass;
+
+    private final SyncOperations<TDocument> operations;
+
     private final Class<TResult> resultClass;
-    private final CodecRegistry codecRegistry;
     private final FindOptions findOptions;
 
     private Bson filter;
@@ -45,10 +44,8 @@ final class FindIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResu
                      final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
                      final ReadConcern readConcern, final OperationExecutor executor, final Bson filter, final FindOptions findOptions) {
         super(clientSession, executor, readConcern, readPreference);
-        this.namespace = notNull("namespace", namespace);
-        this.documentClass = notNull("documentClass", documentClass);
+        this.operations = new SyncOperations<TDocument>(namespace, documentClass, readPreference, codecRegistry, readConcern);
         this.resultClass = notNull("resultClass", resultClass);
-        this.codecRegistry = notNull("codecRegistry", codecRegistry);
         this.filter = notNull("filter", filter);
         this.findOptions = notNull("findOptions", findOptions);
     }
@@ -189,41 +186,12 @@ final class FindIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResu
 
     @Override
     public TResult first() {
-        FindOperation<TResult> findFirstOperation = createQueryOperation().batchSize(0).limit(-1);
-        BatchCursor<TResult> batchCursor = getExecutor().execute(findFirstOperation, getReadPreference(), getClientSession());
+        BatchCursor<TResult> batchCursor = getExecutor().execute(operations.findFirst(filter, resultClass, findOptions),
+                getReadPreference(), getClientSession());
         return batchCursor.hasNext() ? batchCursor.next().iterator().next() : null;
     }
 
     protected ReadOperation<BatchCursor<TResult>> asReadOperation() {
-        return createQueryOperation();
+        return operations.find(filter, resultClass, findOptions);
     }
-
-    private FindOperation<TResult> createQueryOperation() {
-        return new FindOperation<TResult>(namespace, codecRegistry.get(resultClass))
-                   .filter(filter.toBsonDocument(documentClass, codecRegistry))
-                   .batchSize(findOptions.getBatchSize())
-                   .skip(findOptions.getSkip())
-                   .limit(findOptions.getLimit())
-                   .maxTime(findOptions.getMaxTime(MILLISECONDS), MILLISECONDS)
-                   .maxAwaitTime(findOptions.getMaxAwaitTime(MILLISECONDS), MILLISECONDS)
-                   .modifiers(toBsonDocumentOrNull(findOptions.getModifiers(), documentClass, codecRegistry))
-                   .projection(toBsonDocumentOrNull(findOptions.getProjection(), documentClass, codecRegistry))
-                   .sort(toBsonDocumentOrNull(findOptions.getSort(), documentClass, codecRegistry))
-                   .cursorType(findOptions.getCursorType())
-                   .noCursorTimeout(findOptions.isNoCursorTimeout())
-                   .oplogReplay(findOptions.isOplogReplay())
-                   .partial(findOptions.isPartial())
-                   .slaveOk(getReadPreference().isSlaveOk())
-                   .readConcern(getReadConcern())
-                   .collation(findOptions.getCollation())
-                   .comment(findOptions.getComment())
-                   .hint(toBsonDocumentOrNull(findOptions.getHint(), documentClass, codecRegistry))
-                   .min(toBsonDocumentOrNull(findOptions.getMin(), documentClass, codecRegistry))
-                   .max(toBsonDocumentOrNull(findOptions.getMax(), documentClass, codecRegistry))
-                   .maxScan(findOptions.getMaxScan())
-                   .returnKey(findOptions.isReturnKey())
-                   .showRecordId(findOptions.isShowRecordId())
-                   .snapshot(findOptions.isSnapshot());
-    }
-
 }

--- a/driver/src/main/com/mongodb/MapReduceIterableImpl.java
+++ b/driver/src/main/com/mongodb/MapReduceIterableImpl.java
@@ -19,15 +19,16 @@ package com.mongodb;
 import com.mongodb.binding.ReadBinding;
 import com.mongodb.client.MapReduceIterable;
 import com.mongodb.client.model.Collation;
+import com.mongodb.client.model.FindOptions;
 import com.mongodb.client.model.MapReduceAction;
+import com.mongodb.internal.operation.SyncOperations;
 import com.mongodb.operation.BatchCursor;
-import com.mongodb.operation.FindOperation;
 import com.mongodb.operation.MapReduceBatchCursor;
-import com.mongodb.operation.MapReduceToCollectionOperation;
-import com.mongodb.operation.MapReduceWithInlineResultsOperation;
+import com.mongodb.operation.MapReduceStatistics;
 import com.mongodb.operation.ReadOperation;
+import com.mongodb.operation.WriteOperation;
 import com.mongodb.session.ClientSession;
-import org.bson.BsonJavaScript;
+import org.bson.BsonDocument;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 
@@ -35,14 +36,11 @@ import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.ReadPreference.primary;
 import static com.mongodb.assertions.Assertions.notNull;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 class MapReduceIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult> implements MapReduceIterable<TResult> {
+    private final SyncOperations<TDocument> operations;
     private final MongoNamespace namespace;
-    private final Class<TDocument> documentClass;
     private final Class<TResult> resultClass;
-    private final CodecRegistry codecRegistry;
-    private final WriteConcern writeConcern;
     private final String mapFunction;
     private final String reduceFunction;
 
@@ -68,11 +66,10 @@ class MapReduceIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
                           final ReadConcern readConcern, final WriteConcern writeConcern, final OperationExecutor executor,
                           final String mapFunction, final String reduceFunction) {
         super(clientSession, executor, readConcern, readPreference);
+        this.operations = new SyncOperations<TDocument>(namespace, documentClass, readPreference, codecRegistry, writeConcern, false,
+                readConcern);
         this.namespace = notNull("namespace", namespace);
-        this.documentClass = notNull("documentClass", documentClass);
         this.resultClass = notNull("resultClass", resultClass);
-        this.codecRegistry = notNull("codecRegistry", codecRegistry);
-        this.writeConcern = notNull("writeConcern", writeConcern);
         this.mapFunction = notNull("mapFunction", mapFunction);
         this.reduceFunction = notNull("reduceFunction", reduceFunction);
     }
@@ -196,56 +193,27 @@ class MapReduceIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
     @Override
     ReadOperation<BatchCursor<TResult>> asReadOperation() {
         if (inline) {
-            final MapReduceWithInlineResultsOperation<TResult> operation =
-                    new MapReduceWithInlineResultsOperation<TResult>(namespace,
-                                                                            new BsonJavaScript(mapFunction),
-                                                                            new BsonJavaScript(reduceFunction),
-                                                                            codecRegistry.get(resultClass))
-                            .filter(toBsonDocumentOrNull(filter, documentClass, codecRegistry))
-                            .limit(limit)
-                            .maxTime(maxTimeMS, MILLISECONDS)
-                            .jsMode(jsMode)
-                            .scope(toBsonDocumentOrNull(scope, documentClass, codecRegistry))
-                            .sort(toBsonDocumentOrNull(sort, documentClass, codecRegistry))
-                            .verbose(verbose)
-                            .readConcern(getReadConcern())
-                            .collation(collation);
-            if (finalizeFunction != null) {
-                operation.finalizeFunction(new BsonJavaScript(finalizeFunction));
-            }
+            ReadOperation<MapReduceBatchCursor<TResult>> operation = operations.mapReduce(mapFunction, reduceFunction, finalizeFunction,
+                    resultClass, filter, limit, maxTimeMS, jsMode, scope, sort, verbose, collation);
             return new WrappedMapReduceReadOperation<TResult>(operation);
         } else {
             getExecutor().execute(createMapReduceToCollectionOperation(), getClientSession());
 
             String dbName = databaseName != null ? databaseName : namespace.getDatabaseName();
-            return new FindOperation<TResult>(new MongoNamespace(dbName, collectionName), codecRegistry.get(resultClass))
-                    .collation(collation)
-                    .batchSize(getBatchSize() == null ? 0 : getBatchSize());
+
+            FindOptions findOptions = new FindOptions().collation(collation);
+            if (getBatchSize() != null) {
+                findOptions.batchSize(getBatchSize());
+            }
+            return operations.find(new MongoNamespace(dbName, collectionName), new BsonDocument(), resultClass, findOptions);
         }
 
     }
 
-    private MapReduceToCollectionOperation createMapReduceToCollectionOperation() {
-        MapReduceToCollectionOperation operation = new MapReduceToCollectionOperation(namespace, new BsonJavaScript(mapFunction),
-                new BsonJavaScript(reduceFunction), collectionName, writeConcern)
-                .filter(toBsonDocumentOrNull(filter, documentClass, codecRegistry))
-                .limit(limit)
-                .maxTime(maxTimeMS, MILLISECONDS)
-                .jsMode(jsMode)
-                .scope(toBsonDocumentOrNull(scope, documentClass, codecRegistry))
-                .sort(toBsonDocumentOrNull(sort, documentClass, codecRegistry))
-                .verbose(verbose)
-                .action(action.getValue())
-                .nonAtomic(nonAtomic)
-                .sharded(sharded)
-                .databaseName(databaseName)
-                .bypassDocumentValidation(bypassDocumentValidation)
-                .collation(collation);
-
-        if (finalizeFunction != null) {
-            operation.finalizeFunction(new BsonJavaScript(finalizeFunction));
-        }
-        return operation;
+    private WriteOperation<MapReduceStatistics> createMapReduceToCollectionOperation() {
+        return operations.mapReduceToCollection(databaseName, collectionName, mapFunction, reduceFunction, finalizeFunction, filter,
+                limit, maxTimeMS, jsMode, scope, sort, verbose, action, nonAtomic, sharded, bypassDocumentValidation, collation
+        );
     }
 
     // this could be inlined, but giving it a name so that it's unit-testable
@@ -256,7 +224,7 @@ class MapReduceIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
             return operation;
         }
 
-        WrappedMapReduceReadOperation(final MapReduceWithInlineResultsOperation<TResult> operation) {
+        WrappedMapReduceReadOperation(final ReadOperation<MapReduceBatchCursor<TResult>> operation) {
             this.operation = operation;
         }
 

--- a/driver/src/main/com/mongodb/MongoCollectionImpl.java
+++ b/driver/src/main/com/mongodb/MongoCollectionImpl.java
@@ -17,10 +17,6 @@
 package com.mongodb;
 
 import com.mongodb.bulk.BulkWriteResult;
-import com.mongodb.bulk.DeleteRequest;
-import com.mongodb.bulk.IndexRequest;
-import com.mongodb.bulk.InsertRequest;
-import com.mongodb.bulk.UpdateRequest;
 import com.mongodb.bulk.WriteRequest;
 import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.ChangeStreamIterable;
@@ -32,8 +28,6 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.BulkWriteOptions;
 import com.mongodb.client.model.CountOptions;
 import com.mongodb.client.model.CreateIndexOptions;
-import com.mongodb.client.model.DeleteManyModel;
-import com.mongodb.client.model.DeleteOneModel;
 import com.mongodb.client.model.DeleteOptions;
 import com.mongodb.client.model.DropIndexOptions;
 import com.mongodb.client.model.FindOneAndDeleteOptions;
@@ -43,47 +37,33 @@ import com.mongodb.client.model.FindOptions;
 import com.mongodb.client.model.IndexModel;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.InsertManyOptions;
-import com.mongodb.client.model.InsertOneModel;
 import com.mongodb.client.model.InsertOneOptions;
+import com.mongodb.internal.operation.SyncOperations;
 import com.mongodb.client.model.RenameCollectionOptions;
-import com.mongodb.client.model.ReplaceOneModel;
-import com.mongodb.client.model.ReturnDocument;
-import com.mongodb.client.model.UpdateManyModel;
-import com.mongodb.client.model.UpdateOneModel;
 import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.WriteModel;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
-import com.mongodb.operation.CountOperation;
-import com.mongodb.operation.CreateIndexesOperation;
-import com.mongodb.operation.DropCollectionOperation;
-import com.mongodb.operation.DropIndexOperation;
-import com.mongodb.operation.FindAndDeleteOperation;
-import com.mongodb.operation.FindAndReplaceOperation;
-import com.mongodb.operation.FindAndUpdateOperation;
-import com.mongodb.operation.MixedBulkWriteOperation;
+import com.mongodb.internal.operation.IndexHelper;
 import com.mongodb.operation.RenameCollectionOperation;
+import com.mongodb.operation.WriteOperation;
 import com.mongodb.session.ClientSession;
 import org.bson.BsonDocument;
-import org.bson.BsonDocumentWrapper;
-import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.bson.Document;
-import org.bson.codecs.Codec;
-import org.bson.codecs.CollectibleCodec;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.assertions.Assertions.notNull;
-import static java.lang.String.format;
-import static java.util.Arrays.asList;
+import static com.mongodb.bulk.WriteRequest.Type.DELETE;
+import static com.mongodb.bulk.WriteRequest.Type.INSERT;
+import static com.mongodb.bulk.WriteRequest.Type.REPLACE;
+import static com.mongodb.bulk.WriteRequest.Type.UPDATE;
 import static java.util.Collections.singletonList;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     private final MongoNamespace namespace;
@@ -93,6 +73,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     private final WriteConcern writeConcern;
     private final boolean retryWrites;
     private final ReadConcern readConcern;
+    private final SyncOperations<TDocument> operations;
     private final OperationExecutor executor;
 
     MongoCollectionImpl(final MongoNamespace namespace, final Class<TDocument> documentClass, final CodecRegistry codecRegistry,
@@ -106,6 +87,8 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
         this.retryWrites = retryWrites;
         this.readConcern = notNull("readConcern", readConcern);
         this.executor = notNull("executor", executor);
+        this.operations = new SyncOperations<TDocument>(namespace, documentClass, readPreference, codecRegistry, writeConcern, retryWrites,
+                readConcern);
     }
 
     @Override
@@ -200,19 +183,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     private long executeCount(final ClientSession clientSession, final Bson filter, final CountOptions options) {
-        CountOperation operation = new CountOperation(namespace)
-                                           .filter(toBsonDocument(filter))
-                                           .skip(options.getSkip())
-                                           .limit(options.getLimit())
-                                           .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
-                                           .collation(options.getCollation())
-                                           .readConcern(readConcern);
-        if (options.getHint() != null) {
-            operation.hint(toBsonDocument(options.getHint()));
-        } else if (options.getHintString() != null) {
-            operation.hint(new BsonString(options.getHintString()));
-        }
-        return executor.execute(operation, readPreference, clientSession);
+        return executor.execute(operations.count(filter, options), readPreference, clientSession);
     }
 
     @Override
@@ -430,56 +401,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
                                              final List<? extends WriteModel<? extends TDocument>> requests,
                                              final BulkWriteOptions options) {
         notNull("requests", requests);
-        List<WriteRequest> writeRequests = new ArrayList<WriteRequest>(requests.size());
-        for (WriteModel<? extends TDocument> writeModel : requests) {
-            WriteRequest writeRequest;
-            if (writeModel == null) {
-                throw new IllegalArgumentException("requests can not contain a null value");
-            } else if (writeModel instanceof InsertOneModel) {
-                TDocument document = ((InsertOneModel<TDocument>) writeModel).getDocument();
-                if (getCodec() instanceof CollectibleCodec) {
-                    document = ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(document);
-                }
-                writeRequest = new InsertRequest(documentToBsonDocument(document));
-            } else if (writeModel instanceof ReplaceOneModel) {
-                ReplaceOneModel<TDocument> replaceOneModel = (ReplaceOneModel<TDocument>) writeModel;
-                writeRequest = new UpdateRequest(toBsonDocument(replaceOneModel.getFilter()), documentToBsonDocument(replaceOneModel
-                                                                                                                     .getReplacement()),
-                                                        WriteRequest.Type.REPLACE)
-                                       .upsert(replaceOneModel.getOptions().isUpsert())
-                                       .collation(replaceOneModel.getOptions().getCollation());
-            } else if (writeModel instanceof UpdateOneModel) {
-                UpdateOneModel<TDocument> updateOneModel = (UpdateOneModel<TDocument>) writeModel;
-                writeRequest = new UpdateRequest(toBsonDocument(updateOneModel.getFilter()), toBsonDocument(updateOneModel.getUpdate()),
-                                                        WriteRequest.Type.UPDATE)
-                                       .multi(false)
-                                       .upsert(updateOneModel.getOptions().isUpsert())
-                                       .collation(updateOneModel.getOptions().getCollation())
-                                       .arrayFilters(toBsonDocumentList(updateOneModel.getOptions().getArrayFilters()));
-            } else if (writeModel instanceof UpdateManyModel) {
-                UpdateManyModel<TDocument> updateManyModel = (UpdateManyModel<TDocument>) writeModel;
-                writeRequest = new UpdateRequest(toBsonDocument(updateManyModel.getFilter()), toBsonDocument(updateManyModel.getUpdate()),
-                                                        WriteRequest.Type.UPDATE)
-                                       .multi(true)
-                                       .upsert(updateManyModel.getOptions().isUpsert())
-                                       .collation(updateManyModel.getOptions().getCollation())
-                                       .arrayFilters(toBsonDocumentList(updateManyModel.getOptions().getArrayFilters()));
-            } else if (writeModel instanceof DeleteOneModel) {
-                DeleteOneModel<TDocument> deleteOneModel = (DeleteOneModel<TDocument>) writeModel;
-                writeRequest = new DeleteRequest(toBsonDocument(deleteOneModel.getFilter())).multi(false)
-                                       .collation(deleteOneModel.getOptions().getCollation());
-            } else if (writeModel instanceof DeleteManyModel) {
-                DeleteManyModel<TDocument> deleteManyModel = (DeleteManyModel<TDocument>) writeModel;
-                writeRequest = new DeleteRequest(toBsonDocument(deleteManyModel.getFilter())).multi(true)
-                                       .collation(deleteManyModel.getOptions().getCollation());
-            } else {
-                throw new UnsupportedOperationException(format("WriteModel of type %s is not supported", writeModel.getClass()));
-            }
-            writeRequests.add(writeRequest);
-        }
-
-        return executor.execute(new MixedBulkWriteOperation(namespace, writeRequests, options.isOrdered(), writeConcern, retryWrites)
-                                        .bypassDocumentValidation(options.getBypassDocumentValidation()), clientSession);
+        return executor.execute(operations.bulkWrite(requests, options), clientSession);
     }
 
     @Override
@@ -506,12 +428,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     private void executeInsertOne(final ClientSession clientSession, final TDocument document, final InsertOneOptions options) {
-        TDocument insertDocument = document;
-        if (getCodec() instanceof CollectibleCodec) {
-            insertDocument = ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(document);
-        }
-        executeSingleWriteRequest(clientSession, new InsertRequest(documentToBsonDocument(insertDocument)),
-                options.getBypassDocumentValidation());
+        executeSingleWriteRequest(clientSession, operations.insertOne(document, options), INSERT);
     }
 
     @Override
@@ -537,20 +454,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private void executeInsertMany(final ClientSession clientSession, final List<? extends TDocument> documents,
                                    final InsertManyOptions options) {
-        notNull("documents", documents);
-        List<InsertRequest> requests = new ArrayList<InsertRequest>(documents.size());
-        for (TDocument document : documents) {
-            if (document == null) {
-                throw new IllegalArgumentException("documents can not contain a null value");
-            }
-            if (getCodec() instanceof CollectibleCodec) {
-                document = ((CollectibleCodec<TDocument>) getCodec()).generateIdIfAbsentFromDocument(document);
-            }
-            requests.add(new InsertRequest(documentToBsonDocument(document)));
-        }
-
-        executor.execute(new MixedBulkWriteOperation(namespace, requests, options.isOrdered(), writeConcern, retryWrites)
-                                 .bypassDocumentValidation(options.getBypassDocumentValidation()), clientSession);
+        executor.execute(operations.insertMany(documents, options), clientSession);
     }
 
     @Override
@@ -619,10 +523,8 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private UpdateResult executeReplaceOne(final ClientSession clientSession, final Bson filter, final TDocument replacement,
                                            final UpdateOptions updateOptions) {
-        return toUpdateResult(executeSingleWriteRequest(clientSession,
-                new UpdateRequest(toBsonDocument(filter), documentToBsonDocument(replacement), WriteRequest.Type.REPLACE)
-                        .upsert(updateOptions.isUpsert()).collation(updateOptions.getCollation()),
-                updateOptions.getBypassDocumentValidation()));
+        return toUpdateResult(executeSingleWriteRequest(clientSession, operations.replaceOne(filter, replacement, updateOptions),
+                REPLACE));
     }
 
     @Override
@@ -692,13 +594,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     private TDocument executeFindOneAndDelete(final ClientSession clientSession, final Bson filter, final FindOneAndDeleteOptions options) {
-        return executor.execute(new FindAndDeleteOperation<TDocument>(namespace, writeConcern, retryWrites, getCodec())
-                                        .filter(toBsonDocument(filter))
-                                        .projection(toBsonDocument(options.getProjection()))
-                                        .sort(toBsonDocument(options.getSort()))
-                                        .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
-                                        .collation(options.getCollation()),
-                clientSession);
+        return executor.execute(operations.findOneAndDelete(filter, options), clientSession);
     }
 
     @Override
@@ -725,17 +621,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private TDocument executeFindOneAndReplace(final ClientSession clientSession, final Bson filter, final TDocument replacement,
                                                final FindOneAndReplaceOptions options) {
-        return executor.execute(new FindAndReplaceOperation<TDocument>(namespace, writeConcern, retryWrites, getCodec(),
-                                                                              documentToBsonDocument(replacement))
-                                        .filter(toBsonDocument(filter))
-                                        .projection(toBsonDocument(options.getProjection()))
-                                        .sort(toBsonDocument(options.getSort()))
-                                        .returnOriginal(options.getReturnDocument() == ReturnDocument.BEFORE)
-                                        .upsert(options.isUpsert())
-                                        .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
-                                        .bypassDocumentValidation(options.getBypassDocumentValidation())
-                                        .collation(options.getCollation()),
-                clientSession);
+        return executor.execute(operations.findOneAndReplace(filter, replacement, options), clientSession);
     }
 
     @Override
@@ -762,18 +648,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private TDocument executeFindOneAndUpdate(final ClientSession clientSession, final Bson filter, final Bson update,
                                               final FindOneAndUpdateOptions options) {
-        return executor.execute(new FindAndUpdateOperation<TDocument>(namespace, writeConcern, retryWrites, getCodec(),
-                        toBsonDocument(update))
-                                        .filter(toBsonDocument(filter))
-                                        .projection(toBsonDocument(options.getProjection()))
-                                        .sort(toBsonDocument(options.getSort()))
-                                        .returnOriginal(options.getReturnDocument() == ReturnDocument.BEFORE)
-                                        .upsert(options.isUpsert())
-                                        .maxTime(options.getMaxTime(MILLISECONDS), MILLISECONDS)
-                                        .bypassDocumentValidation(options.getBypassDocumentValidation())
-                                        .collation(options.getCollation())
-                                        .arrayFilters(toBsonDocumentList(options.getArrayFilters())),
-                clientSession);
+        return executor.execute(operations.findOneAndUpdate(filter, update, options), clientSession);
     }
     @Override
     public void drop() {
@@ -787,7 +662,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     private void executeDrop(final ClientSession clientSession) {
-        executor.execute(new DropCollectionOperation(namespace, writeConcern), clientSession);
+        executor.execute(operations.dropCollection(), clientSession);
     }
 
     @Override
@@ -834,38 +709,20 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private List<String> executeCreateIndexes(final ClientSession clientSession, final List<IndexModel> indexes,
                                               final CreateIndexOptions createIndexOptions) {
-        notNull("indexes", indexes);
-        notNull("createIndexOptions", createIndexOptions);
-        List<IndexRequest> indexRequests = new ArrayList<IndexRequest>(indexes.size());
-        for (IndexModel model : indexes) {
-            if (model == null) {
-                throw new IllegalArgumentException("indexes can not contain a null value");
+        executor.execute(operations.createIndexes(indexes, createIndexOptions), clientSession);
+        return getIndexNames(indexes);
+    }
+
+    private List<String> getIndexNames(final List<IndexModel> indexes) {
+        List<String> indexNames = new ArrayList<String>(indexes.size());
+        for (IndexModel index : indexes) {
+            if (index.getOptions().getName() != null) {
+                indexNames.add(index.getOptions().getName());
+            } else {
+                indexNames.add(IndexHelper.generateIndexName(toBsonDocument(index.getKeys())));
             }
-            indexRequests.add(new IndexRequest(toBsonDocument(model.getKeys()))
-                                      .name(model.getOptions().getName())
-                                      .background(model.getOptions().isBackground())
-                                      .unique(model.getOptions().isUnique())
-                                      .sparse(model.getOptions().isSparse())
-                                      .expireAfter(model.getOptions().getExpireAfter(TimeUnit.SECONDS), TimeUnit.SECONDS)
-                                      .version(model.getOptions().getVersion())
-                                      .weights(toBsonDocument(model.getOptions().getWeights()))
-                                      .defaultLanguage(model.getOptions().getDefaultLanguage())
-                                      .languageOverride(model.getOptions().getLanguageOverride())
-                                      .textVersion(model.getOptions().getTextVersion())
-                                      .sphereVersion(model.getOptions().getSphereVersion())
-                                      .bits(model.getOptions().getBits())
-                                      .min(model.getOptions().getMin())
-                                      .max(model.getOptions().getMax())
-                                      .bucketSize(model.getOptions().getBucketSize())
-                                      .storageEngine(toBsonDocument(model.getOptions().getStorageEngine()))
-                                      .partialFilterExpression(toBsonDocument(model.getOptions().getPartialFilterExpression()))
-                                      .collation(model.getOptions().getCollation())
-            );
         }
-        CreateIndexesOperation createIndexesOperation = new CreateIndexesOperation(getNamespace(), indexRequests, writeConcern)
-                .maxTime(createIndexOptions.getMaxTime(MILLISECONDS), MILLISECONDS);
-        executor.execute(createIndexesOperation, clientSession);
-        return createIndexesOperation.getIndexNames();
+        return indexNames;
     }
 
     @Override
@@ -960,13 +817,11 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private void executeDropIndex(final ClientSession clientSession, final String indexName, final DropIndexOptions dropIndexOptions) {
         notNull("dropIndexOptions", dropIndexOptions);
-        executor.execute(new DropIndexOperation(namespace, indexName, writeConcern)
-                .maxTime(dropIndexOptions.getMaxTime(MILLISECONDS), MILLISECONDS), clientSession);
+        executor.execute(operations.dropIndex(indexName, dropIndexOptions), clientSession);
     }
 
     private void executeDropIndex(final ClientSession clientSession, final Bson keys, final DropIndexOptions dropIndexOptions) {
-        executor.execute(new DropIndexOperation(namespace, keys.toBsonDocument(BsonDocument.class, codecRegistry), writeConcern)
-                        .maxTime(dropIndexOptions.getMaxTime(MILLISECONDS), MILLISECONDS), clientSession);
+        executor.execute(operations.dropIndex(keys, dropIndexOptions), clientSession);
     }
 
     @Override
@@ -1001,8 +856,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     private DeleteResult executeDelete(final ClientSession clientSession, final Bson filter, final DeleteOptions deleteOptions,
                                        final boolean multi) {
         com.mongodb.bulk.BulkWriteResult result = executeSingleWriteRequest(clientSession,
-                new DeleteRequest(toBsonDocument(filter)).multi(multi)
-                        .collation(deleteOptions.getCollation()), null);
+                multi ? operations.deleteMany(filter, deleteOptions) : operations.deleteOne(filter, deleteOptions), DELETE);
         if (result.wasAcknowledged()) {
             return DeleteResult.acknowledged(result.getDeletedCount());
         } else {
@@ -1012,22 +866,20 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private UpdateResult executeUpdate(final ClientSession clientSession, final Bson filter, final Bson update,
                                        final UpdateOptions updateOptions, final boolean multi) {
-        return toUpdateResult(executeSingleWriteRequest(clientSession, new UpdateRequest(toBsonDocument(filter), toBsonDocument(update),
-                WriteRequest.Type.UPDATE).upsert(updateOptions.isUpsert()).multi(multi).collation(updateOptions.getCollation())
-                                         .arrayFilters(toBsonDocumentList(updateOptions.getArrayFilters())),
-                updateOptions.getBypassDocumentValidation()));
+        return toUpdateResult(executeSingleWriteRequest(clientSession,
+                multi ? operations.updateMany(filter, update, updateOptions) : operations.updateOne(filter, update, updateOptions),
+                UPDATE));
     }
 
-
-    private BulkWriteResult executeSingleWriteRequest(final ClientSession clientSession, final WriteRequest request,
-                                                      final Boolean bypassDocumentValidation) {
+    private BulkWriteResult executeSingleWriteRequest(final ClientSession clientSession,
+                                                      final WriteOperation<BulkWriteResult> writeOperation,
+                                                      final WriteRequest.Type type) {
         try {
-            return executor.execute(new MixedBulkWriteOperation(namespace, asList(request), true, writeConcern, retryWrites)
-                    .bypassDocumentValidation(bypassDocumentValidation), clientSession);
+            return executor.execute(writeOperation, clientSession);
         } catch (MongoBulkWriteException e) {
             if (e.getWriteErrors().isEmpty()) {
                 throw new MongoWriteConcernException(e.getWriteConcernError(),
-                                                     translateBulkWriteResult(request, e.getWriteResult()),
+                                                     translateBulkWriteResult(type, e.getWriteResult()),
                                                      e.getServerAddress());
             } else {
                 throw new MongoWriteException(new WriteError(e.getWriteErrors().get(0)), e.getServerAddress());
@@ -1035,8 +887,8 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
         }
     }
 
-    private WriteConcernResult translateBulkWriteResult(final WriteRequest request, final BulkWriteResult writeResult) {
-        switch (request.getType()) {
+    private WriteConcernResult translateBulkWriteResult(final WriteRequest.Type type, final BulkWriteResult writeResult) {
+        switch (type) {
             case INSERT:
                 return WriteConcernResult.acknowledged(writeResult.getInsertedCount(), false, null);
             case DELETE:
@@ -1048,7 +900,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
                                                        writeResult.getUpserts().isEmpty()
                                                        ? null : writeResult.getUpserts().get(0).getId());
             default:
-                throw new MongoInternalException("Unhandled write request type: " + request.getType());
+                throw new MongoInternalException("Unhandled write request type: " + type);
         }
     }
 
@@ -1062,26 +914,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
         }
     }
 
-    private Codec<TDocument> getCodec() {
-        return codecRegistry.get(documentClass);
-    }
-
-    private BsonDocument documentToBsonDocument(final TDocument document) {
-        return BsonDocumentWrapper.asBsonDocument(document, codecRegistry);
-    }
-
     private BsonDocument toBsonDocument(final Bson bson) {
         return bson == null ? null : bson.toBsonDocument(documentClass, codecRegistry);
-    }
-
-    private List<BsonDocument> toBsonDocumentList(final List<? extends Bson> bsonList) {
-        if (bsonList == null) {
-            return null;
-        }
-        List<BsonDocument> bsonDocumentList = new ArrayList<BsonDocument>(bsonList.size());
-        for (Bson cur : bsonList) {
-            bsonDocumentList.add(toBsonDocument(cur));
-        }
-        return bsonDocumentList;
     }
 }

--- a/driver/src/main/com/mongodb/MongoIterableImpl.java
+++ b/driver/src/main/com/mongodb/MongoIterableImpl.java
@@ -21,9 +21,6 @@ import com.mongodb.client.MongoIterable;
 import com.mongodb.operation.BatchCursor;
 import com.mongodb.operation.ReadOperation;
 import com.mongodb.session.ClientSession;
-import org.bson.BsonDocument;
-import org.bson.codecs.configuration.CodecRegistry;
-import org.bson.conversions.Bson;
 
 import java.util.Collection;
 
@@ -32,8 +29,8 @@ import static com.mongodb.assertions.Assertions.notNull;
 abstract class MongoIterableImpl<TResult> implements MongoIterable<TResult> {
     private final ClientSession clientSession;
     private final ReadConcern readConcern;
-    private OperationExecutor executor;
-    private ReadPreference readPreference;
+    private final OperationExecutor executor;
+    private final ReadPreference readPreference;
     private Integer batchSize;
 
     MongoIterableImpl(final ClientSession clientSession, final OperationExecutor executor, final ReadConcern readConcern,
@@ -116,14 +113,6 @@ abstract class MongoIterableImpl<TResult> implements MongoIterable<TResult> {
             }
         });
         return target;
-    }
-
-    BsonDocument toBsonDocumentOrNull(final Bson document, final CodecRegistry codecRegistry) {
-        return toBsonDocumentOrNull(document, BsonDocument.class, codecRegistry);
-    }
-
-    <T> BsonDocument toBsonDocumentOrNull(final Bson document, final Class<T> documentClass, final CodecRegistry codecRegistry) {
-        return document == null ? null : document.toBsonDocument(documentClass, codecRegistry);
     }
 
     private BatchCursor<TResult> execute() {

--- a/driver/src/test/unit/com/mongodb/AggregateIterableSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/AggregateIterableSpecification.groovy
@@ -128,6 +128,8 @@ class AggregateIterableSpecification extends Specification {
         operation.getNamespace() == collectionNamespace
         operation.getBatchSize() == 99
         operation.getCollation() == collation
+        operation.getMaxAwaitTime(MILLISECONDS) == 0
+        operation.getMaxTime(MILLISECONDS) == 0
 
         when: 'toCollection should work as expected'
         new AggregateIterableImpl(null, namespace, Document, Document, codecRegistry, readPreference, readConcern, writeConcern, executor,


### PR DESCRIPTION
We already have two CRUD API implementations, and may soon add a third, that proxy to instances of ReadOperation/WriteOperation or AsyncReadOperation/AsyncWriteOperation.  Two problem that causes:

* there is duplicated code in the two implementations (for example, in converting from WriteModel to WriteRequest)
* there is unnecessary exposure to the concrete implementations of the operation interfaces (e.g. FindOperation, MixedBulkWriteOperation)

This patch attempts to address these shortcomings, by:

* Creating in core a SyncOperations and an AsyncOperations class, whose methods take the same parameters as the CRUD API but return instances, respectively of ReadOperation/WriteOperation and AsyncReadOperation/AsyncWriteOperation.  These are both implemented in terms of a package-private Operations class that has the same methods, but which return instances of the concrete operation types.  SyncOperations and AsyncOperations are in com.mongodb.internal currently, so are not considered part of the public API.
* Re-implementing the sync and async CRUD API (MongoCollection and MongoIterable subclasses) in terms of SyncOperations (for the sync API) and AsyncOperations (for the async API).

Note that the tests have not been refactored.  The driver and driver-async unit tests still assert equality with the concrete operation instances.  We can leave that for a separate PR or do it as a follow-on commit to this.  As part of that we could make SyncOperations and AsyncOperations interfaces so that they can be mocked.