### PR TITLE
JAVA-2521: Remove Automatic-Module-Name from mongo-java-driver jar

### DIFF
--- a/mongo-java-driver/build.gradle
+++ b/mongo-java-driver/build.gradle
@@ -42,7 +42,6 @@ sourceSets {
 // copied from driver-core
 jar {
     manifest {
-        instruction 'Automatic-Module-Name', 'org.mongodb.driver.legacy.client'
         instruction 'Build-Version', getGitVersion()
         instruction 'Import-Package',
                     'javax.xml.bind.*',


### PR DESCRIPTION
As discussed off-line