### PR TITLE
JAVA-2754: Fix bug in BsonBinaryReader.getMark

### DIFF
--- a/bson/src/main/org/bson/BsonBinaryReader.java
+++ b/bson/src/main/org/bson/BsonBinaryReader.java
@@ -17,6 +17,7 @@
 package org.bson;
 
 import org.bson.io.BsonInput;
+import org.bson.io.BsonInputMark;
 import org.bson.io.ByteBufferBsonInput;
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
@@ -415,17 +416,18 @@ public class BsonBinaryReader extends AbstractBsonReader {
     protected class Mark extends AbstractBsonReader.Mark {
         private final int startPosition;
         private final int size;
+        private final BsonInputMark bsonInputMark;
 
         protected Mark() {
             super();
             startPosition = BsonBinaryReader.this.getContext().startPosition;
             size = BsonBinaryReader.this.getContext().size;
-            BsonBinaryReader.this.bsonInput.mark(Integer.MAX_VALUE);
+            bsonInputMark = BsonBinaryReader.this.bsonInput.getMark(Integer.MAX_VALUE);
         }
 
         public void reset() {
             super.reset();
-            BsonBinaryReader.this.bsonInput.reset();
+            bsonInputMark.reset();
             BsonBinaryReader.this.setContext(new Context((Context) getParentContext(), getContextType(), startPosition, size));
         }
     }

--- a/bson/src/main/org/bson/io/BsonInput.java
+++ b/bson/src/main/org/bson/io/BsonInput.java
@@ -115,8 +115,19 @@ public interface BsonInput extends Closeable {
      * Marks the current position in the stream. This method obeys the contract as specified in the same method in {@code InputStream}.
      *
      * @param readLimit the maximum limit of bytes that can be read before the mark position becomes invalid
+     * @deprecated Use {@link #getMark(int)} instead
      */
+    @Deprecated
     void mark(int readLimit);
+
+    /**
+     * Gets a mark for the current position in the stream.
+     *
+     * @param readLimit the maximum limit of bytes that can be read before the mark position becomes invalid
+     * @return the mark
+     * @since 3.7
+     */
+    BsonInputMark getMark(int readLimit);
 
     /**
      * Resets the stream to the current mark. This method obeys the contract as specified in the same method in {@code InputStream}.

--- a/bson/src/main/org/bson/io/BsonInputMark.java
+++ b/bson/src/main/org/bson/io/BsonInputMark.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bson.io;
+
+/**
+ * Represents a bookmark that can be used to reset a {@link BsonInput} to its state at the time the mark was created.
+ *
+ * @see BsonInput#getMark(int)
+ *
+ * @since 3.5
+ */
+public interface BsonInputMark {
+    /**
+     * Reset the {@link BsonInput} to its state at the time the mark was created.
+     */
+    void reset();
+}

--- a/bson/src/main/org/bson/io/BsonInputMark.java
+++ b/bson/src/main/org/bson/io/BsonInputMark.java
@@ -21,7 +21,7 @@ package org.bson.io;
  *
  * @see BsonInput#getMark(int)
  *
- * @since 3.5
+ * @since 3.7
  */
 public interface BsonInputMark {
     /**

--- a/bson/src/main/org/bson/io/ByteBufferBsonInput.java
+++ b/bson/src/main/org/bson/io/ByteBufferBsonInput.java
@@ -181,10 +181,23 @@ public class ByteBufferBsonInput implements BsonInput {
         buffer.position(buffer.position() + numBytes);
     }
 
+    @Deprecated
     @Override
     public void mark(final int readLimit) {
         ensureOpen();
         mark = buffer.position();
+    }
+
+    @Override
+    public BsonInputMark getMark(final int readLimit) {
+        return new BsonInputMark() {
+            private int mark = buffer.position();
+            @Override
+            public void reset() {
+                ensureOpen();
+                buffer.position(mark);
+            }
+        };
     }
 
     @Override

--- a/bson/src/test/unit/org/bson/LimitedLookaheadMarkSpecification.groovy
+++ b/bson/src/test/unit/org/bson/LimitedLookaheadMarkSpecification.groovy
@@ -299,6 +299,8 @@ class LimitedLookaheadMarkSpecification extends Specification {
         reader.readInt64() == 52L
 
         when:
+        // make sure it's possible to reset to a mark after getting a new mark
+        reader.getMark()
         // reset to beginning of document * 3
         mark.reset()
         // mark beginning of document * 3

--- a/bson/src/test/unit/org/bson/io/ByteBufferBsonInputSpecification.groovy
+++ b/bson/src/test/unit/org/bson/io/ByteBufferBsonInputSpecification.groovy
@@ -269,6 +269,35 @@ class ByteBufferBsonInputSpecification extends Specification {
         stream.position == 2
     }
 
+    def 'should reset to the BsonInputMark'() {
+        given:
+        def stream = new ByteBufferBsonInput(new ByteBufNIO(ByteBuffer.wrap([0x4a, 0x61, 0x76, 0x61, 0] as byte[])))
+
+        when:
+        BsonInputMark markOne = null
+        BsonInputMark markTwo = null
+
+        stream.with {
+            readByte()
+            readByte()
+            markOne = getMark(1024)
+            readByte()
+            readByte()
+            markTwo = getMark(1025)
+            readByte()
+        }
+        markOne.reset()
+
+        then:
+        stream.position == 2
+
+        when:
+        markTwo.reset()
+
+        then:
+        stream.position == 4
+    }
+
     def 'should have remaining when there are more bytes'() {
         given:
         def stream = new ByteBufferBsonInput(new ByteBufNIO(ByteBuffer.wrap([0x4a, 0x61, 0x76, 0x61, 0] as byte[])))

--- a/config/clirr-exclude.yml
+++ b/config/clirr-exclude.yml
@@ -19,6 +19,8 @@ members:
   - peekBinarySize()
   - getMark()
   - close()
+  org.bson.io.BsonInput:
+  - getMark(int)
   org.bson.BsonWriter:
   - writeDecimal128(org.bson.types.Decimal128)
   - writeDecimal128(java.lang.String,org.bson.types.Decimal128)


### PR DESCRIPTION
https://jira.mongodb.org/browse/JAVA-2754

Support multiple marks on BsonInput, and use that to fix bug in support for multiple marks on a BsonBinaryReader.

(No plans to backport to 3.6 since it involves API changes to BsonInput, a public interface)