### PR TITLE
JAVA-2778

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/MongoClientImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoClientImpl.java
@@ -161,4 +161,7 @@ class MongoClientImpl implements MongoClient {
         return cluster;
     }
 
+    ServerSessionPool getServerSessionPool() {
+        return serverSessionPool;
+    }
 }

--- a/driver-async/src/test/functional/com/mongodb/async/client/DatabaseTestCase.java
+++ b/driver-async/src/test/functional/com/mongodb/async/client/DatabaseTestCase.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import static com.mongodb.async.client.Fixture.drop;
 import static com.mongodb.async.client.Fixture.getDefaultDatabaseName;
 import static com.mongodb.async.client.Fixture.getMongoClient;
+import static com.mongodb.async.client.Fixture.waitForLastServerSessionPoolRelease;
 
 public class DatabaseTestCase {
     //For ease of use and readability, in this specific case we'll allow protected variables
@@ -49,6 +50,8 @@ public class DatabaseTestCase {
         if (collection != null) {
             drop(collection.getNamespace());
         }
+
+        waitForLastServerSessionPoolRelease();
     }
 
     public abstract class MongoOperation<TResult> {

--- a/driver-async/src/test/functional/com/mongodb/async/client/Fixture.java
+++ b/driver-async/src/test/functional/com/mongodb/async/client/Fixture.java
@@ -16,9 +16,12 @@
 
 package com.mongodb.async.client;
 
+import com.mongodb.ClusterFixture;
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoCommandException;
+import com.mongodb.MongoInterruptedException;
 import com.mongodb.MongoNamespace;
+import com.mongodb.MongoTimeoutException;
 import com.mongodb.async.FutureResultCallback;
 import com.mongodb.connection.ClusterSettings;
 import com.mongodb.connection.ConnectionPoolSettings;
@@ -28,6 +31,7 @@ import com.mongodb.connection.SslSettings;
 import org.bson.Document;
 
 import static com.mongodb.connection.ClusterType.SHARDED;
+import static java.lang.Thread.sleep;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
@@ -150,6 +154,29 @@ public final class Fixture {
         } catch (Throwable t) {
             throw new RuntimeException(t);
         }
+    }
+
+    public static synchronized void waitForLastServerSessionPoolRelease() {
+        if (mongoClient != null) {
+            long startTime = System.currentTimeMillis();
+            int sessionInUseCount = getSessionInUseCount();
+            while (sessionInUseCount > 0) {
+                try {
+                    if (System.currentTimeMillis() > startTime + ClusterFixture.TIMEOUT * 1000) {
+                        throw new MongoTimeoutException("Timed out waiting for server session pool in use count to drop to 0.  Now at: "
+                                + sessionInUseCount);
+                    }
+                    sleep(10);
+                    sessionInUseCount = getSessionInUseCount();
+                } catch (InterruptedException e) {
+                    throw new MongoInterruptedException("Interrupted", e);
+                }
+            }
+        }
+    }
+
+    private static int getSessionInUseCount() {
+        return mongoClient.getServerSessionPool().getInUseCount();
     }
 
     static class ShutdownHook extends Thread {

--- a/driver-async/src/test/functional/com/mongodb/async/client/FunctionalSpecification.groovy
+++ b/driver-async/src/test/functional/com/mongodb/async/client/FunctionalSpecification.groovy
@@ -22,6 +22,7 @@ import spock.lang.Specification
 
 import static Fixture.getDefaultDatabase
 import static Fixture.initializeCollection
+import static com.mongodb.async.client.Fixture.waitForLastServerSessionPoolRelease
 
 class FunctionalSpecification extends Specification {
     protected MongoDatabase database;
@@ -30,6 +31,10 @@ class FunctionalSpecification extends Specification {
     def setup() {
         database = getDefaultDatabase()
         collection = initializeCollection(new MongoNamespace(database.getName(), getClass().getName()))
+    }
+
+    def cleanup() {
+        waitForLastServerSessionPoolRelease();
     }
 
     String getDatabaseName() {

--- a/driver-async/src/test/functional/com/mongodb/async/client/MongoClientSessionSpecification.groovy
+++ b/driver-async/src/test/functional/com/mongodb/async/client/MongoClientSessionSpecification.groovy
@@ -74,6 +74,9 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession.getClusterTime() == null
         clientSession.getOperationTime() == null
         clientSession.getServerSession() != null
+
+        cleanup:
+        clientSession.close()
     }
 
     @IgnoreIf({ !serverVersionAtLeast(3, 6) })
@@ -115,6 +118,9 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
 
         then:
         clientSession.getClusterTime() == secondClusterTime
+
+        cleanup:
+        clientSession.close()
     }
 
     @IgnoreIf({ !serverVersionAtLeast(3, 6) })
@@ -153,6 +159,9 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
 
         then:
         clientSession.getOperationTime() == secondOperationTime
+
+        cleanup:
+        clientSession.close()
     }
 
     @IgnoreIf({ !serverVersionAtLeast(3, 6) })
@@ -179,6 +188,9 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
 
         then:
         thrown(IllegalStateException)
+
+        cleanup:
+        clientSession.close()
     }
 
     @IgnoreIf({ !serverVersionAtLeast(3, 6) })
@@ -207,6 +219,9 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession != null
         clientSession.isCausallyConsistent() == causallyConsistent
 
+        cleanup:
+        clientSession.close()
+
         where:
         causallyConsistent << [true, false]
     }
@@ -225,6 +240,9 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         identifier.get('id').isBinary()
         identifier.getBinary('id').getType() == BsonBinarySubType.UUID_STANDARD.value
         identifier.getBinary('id').data.length == 16
+
+        cleanup:
+        clientSession.close()
     }
 
     @IgnoreIf({ !serverVersionAtLeast(3, 6) })

--- a/driver-async/src/test/functional/com/mongodb/async/client/SmokeTestSpecification.groovy
+++ b/driver-async/src/test/functional/com/mongodb/async/client/SmokeTestSpecification.groovy
@@ -114,6 +114,7 @@ class SmokeTestSpecification extends FunctionalSpecification {
 
         then:
         batchCursor.getBatchSize() == 0
+        batchCursor.close()
 
         when: 'The collection name should be in the collections list'
         def collectionNames = run(database.listCollections().&into, [])

--- a/driver-core/src/main/com/mongodb/internal/session/ServerSessionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/session/ServerSessionPool.java
@@ -96,6 +96,10 @@ public class ServerSessionPool {
         }
     }
 
+    public int getInUseCount() {
+        return serverSessionPool.getInUseCount();
+    }
+
     private void closeSession(final ServerSessionImpl serverSession) {
         serverSession.close();
         // only track closed sessions when pool is in the process of closing

--- a/driver-core/src/main/com/mongodb/operation/AsyncChangeStreamBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/AsyncChangeStreamBatchCursor.java
@@ -124,6 +124,7 @@ final class AsyncChangeStreamBatchCursor<T> implements AsyncBatchCursor<T> {
                     callback.onResult(null, t);
                 } else {
                     wrapped = ((AsyncChangeStreamBatchCursor<T>) result).getWrapped();
+                    binding.release(); // release the new change stream batch cursor's reference to the binding
                     asyncBlock.apply(wrapped, callback);
                 }
             }

--- a/driver-core/src/main/com/mongodb/operation/AsyncQueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/AsyncQueryBatchCursor.java
@@ -62,7 +62,6 @@ class AsyncQueryBatchCursor<T> implements AsyncBatchCursor<T> {
     private final AsyncConnectionSource connectionSource;
     private final AtomicBoolean isClosed = new AtomicBoolean();
     private final AtomicReference<ServerCursor> cursor;
-    private final Object lock = new Object();
     private volatile QueryResult<T> firstBatch;
     private volatile int batchSize;
     private volatile int count;
@@ -80,10 +79,11 @@ class AsyncQueryBatchCursor<T> implements AsyncBatchCursor<T> {
         this.connectionSource = notNull("connectionSource", connectionSource);
         this.count += firstBatch.getResults().size();
 
-        connectionSource.retain();
-        if (firstBatch.getCursor() != null && limitReached()) {
+        if (firstBatch.getCursor() != null) {
             connectionSource.retain();
-            killCursor(connection);
+            if (limitReached()) {
+                killCursor(connection);
+            }
         }
     }
 
@@ -134,8 +134,9 @@ class AsyncQueryBatchCursor<T> implements AsyncBatchCursor<T> {
             firstBatch = null;
             callback.onResult(results, null);
         } else {
-            ServerCursor localCursor = getCursorForNext();
+            ServerCursor localCursor = getServerCursor();
             if (localCursor == null) {
+                isClosed.set(true);
                 callback.onResult(null, null);
             } else {
                 getMore(localCursor, callback, tryNext);
@@ -152,7 +153,6 @@ class AsyncQueryBatchCursor<T> implements AsyncBatchCursor<T> {
             @Override
             public void onResult(final AsyncConnection connection, final Throwable t) {
                 if (t != null) {
-                    connectionSource.release();
                     callback.onResult(null, t);
                 } else {
                     getMore(connection, cursor, callback, tryNext);
@@ -170,13 +170,13 @@ class AsyncQueryBatchCursor<T> implements AsyncBatchCursor<T> {
 
         } else {
             connection.getMoreAsync(namespace, cursor.getId(), getNumberToReturn(limit, batchSize, count),
-                                    decoder, new QueryResultSingleResultCallback(connection, callback, tryNext));
+                    decoder, new QueryResultSingleResultCallback(connection, callback, tryNext));
         }
     }
 
     private BsonDocument asGetMoreCommandDocument(final long cursorId) {
         BsonDocument document = new BsonDocument("getMore", new BsonInt64(cursorId))
-                                .append("collection", new BsonString(namespace.getCollectionName()));
+                .append("collection", new BsonString(namespace.getCollectionName()));
 
         int batchSizeForGetMoreCommand = Math.abs(getNumberToReturn(limit, this.batchSize, count));
         if (batchSizeForGetMoreCommand != 0) {
@@ -201,8 +201,6 @@ class AsyncQueryBatchCursor<T> implements AsyncBatchCursor<T> {
                     }
                 }
             });
-        } else {
-            connectionSource.release();
         }
     }
 
@@ -239,7 +237,7 @@ class AsyncQueryBatchCursor<T> implements AsyncBatchCursor<T> {
 
     private BsonDocument asKillCursorsCommandDocument(final ServerCursor localCursor) {
         return new BsonDocument("killCursors", new BsonString(namespace.getCollectionName()))
-                       .append("cursors", new BsonArray(singletonList(new BsonInt64(localCursor.getId()))));
+                .append("cursors", new BsonArray(singletonList(new BsonInt64(localCursor.getId()))));
     }
 
 
@@ -247,7 +245,6 @@ class AsyncQueryBatchCursor<T> implements AsyncBatchCursor<T> {
                                           final QueryResult<T> result, final boolean tryNext) {
         if (isClosed()) {
             connection.release();
-            connectionSource.release();
             callback.onResult(null, new MongoException(format("The cursor was closed before %s completed.",
                     tryNext ? "tryNext()" : "next()")));
             return;
@@ -263,7 +260,9 @@ class AsyncQueryBatchCursor<T> implements AsyncBatchCursor<T> {
                 connection.release();
             } else {
                 connection.release();
-                connectionSource.release();
+                if (result.getCursor() == null) {
+                    connectionSource.release();
+                }
             }
 
             if (result.getResults().isEmpty()) {
@@ -292,10 +291,9 @@ class AsyncQueryBatchCursor<T> implements AsyncBatchCursor<T> {
         public void onResult(final BsonDocument result, final Throwable t) {
             if (t != null) {
                 Throwable translatedException = t instanceof MongoCommandException
-                                                ? translateCommandException((MongoCommandException) t, cursor)
-                                                : t;
+                        ? translateCommandException((MongoCommandException) t, cursor)
+                        : t;
                 connection.release();
-                connectionSource.release();
                 callback.onResult(null, translatedException);
             } else {
                 QueryResult<T> queryResult = getMoreCursorDocumentToQueryResult(result.getDocument("cursor"),
@@ -321,7 +319,6 @@ class AsyncQueryBatchCursor<T> implements AsyncBatchCursor<T> {
         public void onResult(final QueryResult<T> result, final Throwable t) {
             if (t != null) {
                 connection.release();
-                connectionSource.release();
                 callback.onResult(null, t);
             } else {
                 handleGetMoreQueryResult(connection, callback, result, tryNext);
@@ -329,27 +326,7 @@ class AsyncQueryBatchCursor<T> implements AsyncBatchCursor<T> {
         }
     }
 
-    private ServerCursor getCursorForNext() {
-        ServerCursor localCursor;
-        synchronized (lock) {
-            localCursor = cursor.get();
-            if (localCursor == null) {
-                if (!isClosed.getAndSet(true)) {
-                    connectionSource.release();
-                }
-            } else {
-                connectionSource.retain();
-            }
-        }
-        return localCursor;
-    }
-
     ServerCursor getServerCursor() {
-        ServerCursor localCursor;
-        synchronized (lock) {
-            localCursor = cursor.get();
-        }
-        return localCursor;
+        return cursor.get();
     }
-
 }

--- a/driver-core/src/main/com/mongodb/operation/ChangeStreamBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/ChangeStreamBatchCursor.java
@@ -138,6 +138,7 @@ final class ChangeStreamBatchCursor<T> implements BatchCursor<T> {
         }
         wrapped.close();
         wrapped = ((ChangeStreamBatchCursor<T>) changeStreamOperation.resumeAfter(resumeToken).execute(binding)).getWrapped();
+        binding.release(); // release the new change stream batch cursor's reference to the binding
         return function.apply(wrapped);
     }
 

--- a/driver-core/src/main/com/mongodb/operation/ListDatabasesOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ListDatabasesOperation.java
@@ -172,7 +172,7 @@ public class ListDatabasesOperation<T> implements AsyncReadOperation<AsyncBatchC
                 } else {
                     executeWrappedCommandProtocolAsync(binding,  "admin", getCommand(),
                             CommandResultDocumentCodec.create(decoder, "databases"), connection, asyncTransformer(source, connection),
-                            releasingCallback(errHandlingCallback, connection));
+                            releasingCallback(errHandlingCallback, source, connection));
                 }
             }
         });

--- a/driver-core/src/main/com/mongodb/operation/OperationHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/OperationHelper.java
@@ -375,6 +375,7 @@ final class OperationHelper {
 
         public SingleResultCallback<T> releaseConnectionAndGetWrapped() {
             connection.release();
+            source.release();
             return wrapped;
         }
     }

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -28,6 +28,7 @@ import com.mongodb.binding.AsyncSingleConnectionBinding;
 import com.mongodb.binding.AsyncWriteBinding;
 import com.mongodb.binding.ClusterBinding;
 import com.mongodb.binding.ReadWriteBinding;
+import com.mongodb.binding.ReferenceCounted;
 import com.mongodb.binding.SessionBinding;
 import com.mongodb.binding.SingleConnectionBinding;
 import com.mongodb.connection.AsyncConnection;
@@ -72,6 +73,7 @@ import static com.mongodb.connection.ClusterConnectionMode.MULTIPLE;
 import static com.mongodb.connection.ClusterType.REPLICA_SET;
 import static com.mongodb.connection.ClusterType.SHARDED;
 import static com.mongodb.connection.ClusterType.STANDALONE;
+import static java.lang.String.format;
 import static java.lang.Thread.sleep;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -99,7 +101,7 @@ public final class ClusterFixture {
     static {
         String mongoURIProperty = System.getProperty(MONGODB_URI_SYSTEM_PROPERTY_NAME);
         String mongoURIString = mongoURIProperty == null || mongoURIProperty.isEmpty()
-                                ? DEFAULT_URI : mongoURIProperty;
+                ? DEFAULT_URI : mongoURIProperty;
         connectionString = new ConnectionString(mongoURIString);
         Runtime.getRuntime().addShutdownHook(new ShutdownHook());
     }
@@ -159,7 +161,7 @@ public final class ClusterFixture {
 
     public static Document getServerStatus() {
         return new CommandWriteOperation<Document>("admin", new BsonDocument("serverStatus", new BsonInt32(1)), new DocumentCodec())
-               .execute(getBinding());
+                .execute(getBinding());
     }
 
     @SuppressWarnings("unchecked")
@@ -281,12 +283,12 @@ public final class ClusterFixture {
     @SuppressWarnings("deprecation")
     public static Cluster createCluster(final StreamFactory streamFactory) {
         return new DefaultClusterFactory().createCluster(ClusterSettings.builder().applyConnectionString(getConnectionString()).build(),
-                                                  ServerSettings.builder().build(),
-                                                  ConnectionPoolSettings.builder().applyConnectionString(getConnectionString()).build(),
-                                                  streamFactory,
-                                                  new SocketStreamFactory(SocketSettings.builder().build(), getSslSettings()),
-                                                  getConnectionString().getCredentialList(), null, null, null,
-                                                  getConnectionString().getCompressorList());
+                ServerSettings.builder().build(),
+                ConnectionPoolSettings.builder().applyConnectionString(getConnectionString()).build(),
+                streamFactory,
+                new SocketStreamFactory(SocketSettings.builder().build(), getSslSettings()),
+                getConnectionString().getCredentialList(), null, null, null,
+                getConnectionString().getCompressorList());
     }
 
     public static StreamFactory getAsyncStreamFactory() {
@@ -352,7 +354,7 @@ public final class ClusterFixture {
 
     public static boolean isDiscoverableReplicaSet() {
         return getCluster().getDescription().getType() == REPLICA_SET
-               && getCluster().getDescription().getConnectionMode() == MULTIPLE;
+                && getCluster().getDescription().getConnectionMode() == MULTIPLE;
     }
 
     public static boolean isSharded() {
@@ -496,20 +498,20 @@ public final class ClusterFixture {
         batchCursor.next(new SingleResultCallback<List<T>>() {
             @Override
             public void onResult(final List<T> results, final Throwable t) {
-                    if (t != null || results == null) {
-                        batchCursor.close();
-                        callback.onResult(null, t);
-                    } else {
-                        try {
-                            for (T result : results) {
-                                block.apply(result);
-                            }
-                            loopCursor(batchCursor, block, callback);
-                        } catch (Throwable tr) {
-                            batchCursor.close();
-                            callback.onResult(null, tr);
+                if (t != null || results == null) {
+                    batchCursor.close();
+                    callback.onResult(null, t);
+                } else {
+                    try {
+                        for (T result : results) {
+                            block.apply(result);
                         }
+                        loopCursor(batchCursor, block, callback);
+                    } catch (Throwable tr) {
+                        batchCursor.close();
+                        callback.onResult(null, tr);
                     }
+                }
             }
         });
     }
@@ -551,5 +553,31 @@ public final class ClusterFixture {
         final FutureResultCallback<AsyncConnection> futureResultCallback = new FutureResultCallback<AsyncConnection>();
         source.getConnection(futureResultCallback);
         return futureResultCallback.get(TIMEOUT, SECONDS);
+    }
+
+    public static synchronized void checkReferenceCountReachesTarget(final ReferenceCounted referenceCounted, final int target) {
+        int count = getReferenceCountAfterTimeout(referenceCounted, target);
+        if (count != target) {
+            throw new MongoTimeoutException(
+                    format("Timed out waiting for reference count to drop to %d.  Now at %d for %s", target, count,
+                            referenceCounted));
+        }
+    }
+
+    public static int getReferenceCountAfterTimeout(final ReferenceCounted referenceCounted, final int target) {
+        long startTime = System.currentTimeMillis();
+        int count = referenceCounted.getCount();
+        while (count > target) {
+            try {
+                if (System.currentTimeMillis() > startTime + 5000) {
+                    return count;
+                }
+                sleep(10);
+                count = referenceCounted.getCount();
+            } catch (InterruptedException e) {
+                throw new MongoInterruptedException("Interrupted", e);
+            }
+        }
+        return count;
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
@@ -68,6 +68,7 @@ import static com.mongodb.ClusterFixture.getAsyncBinding
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.getPrimary
 import static com.mongodb.ClusterFixture.loopCursor
+import static com.mongodb.ClusterFixture.checkReferenceCountReachesTarget
 import static com.mongodb.WriteConcern.ACKNOWLEDGED
 
 class OperationFunctionalSpecification extends Specification {
@@ -78,6 +79,8 @@ class OperationFunctionalSpecification extends Specification {
 
     def cleanup() {
         CollectionHelper.drop(getNamespace())
+        checkReferenceCountReachesTarget(getBinding(), 1)
+        checkReferenceCountReachesTarget(getAsyncBinding(), 1)
         ServerHelper.checkPool(getPrimary())
     }
 
@@ -171,6 +174,13 @@ class OperationFunctionalSpecification extends Specification {
             next = cursor.tryNext()
         }
         next
+    }
+
+    def consumeAsyncResults(cursor) {
+        def batch = next(cursor, true)
+        while (batch != null) {
+            batch = next(cursor, true)
+        }
     }
 
     void testOperation(Map params) {

--- a/driver-core/src/test/functional/com/mongodb/operation/AggregateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/AggregateOperationSpecification.groovy
@@ -440,6 +440,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         thrown(MongoExecutionTimeoutException)
 
         cleanup:
+        cursor.close()
         disableMaxTimeFailPoint()
 
         where:

--- a/driver-core/src/test/functional/com/mongodb/operation/AsyncQueryBatchCursorFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/AsyncQueryBatchCursorFunctionalSpecification.groovy
@@ -102,6 +102,40 @@ class AsyncQueryBatchCursorFunctionalSpecification extends OperationFunctionalSp
         !nextBatch()
     }
 
+    def 'should not retain connection and source after cursor is exhausted on first batch'() {
+        given:
+        cursor = new AsyncQueryBatchCursor<Document>(executeQuery(), 0, 0, 0, new DocumentCodec(), connectionSource, connection)
+
+        when:
+        nextBatch()
+
+        then:
+        connection.count == 1
+        connectionSource.count == 1
+    }
+
+    def 'should not retain connection and source after cursor is exhausted on getMore'() {
+        given:
+        cursor = new AsyncQueryBatchCursor<Document>(executeQuery(1, 0), 1, 1, 0, new DocumentCodec(), connectionSource, connection)
+
+        when:
+        nextBatch()
+
+        then:
+        connection.count == 1
+        connectionSource.count == 1
+    }
+
+    def 'should not retain connection and source after cursor is exhausted after first batch'() {
+        when:
+        cursor = new AsyncQueryBatchCursor<Document>(executeQuery(10, 10), 10, 10, 0, new DocumentCodec(), connectionSource,
+                connection)
+
+        then:
+        connection.count == 1
+        connectionSource.count == 1
+    }
+
     def 'should exhaust single batch with limit'() {
         given:
         cursor = new AsyncQueryBatchCursor<Document>(executeQuery(1, 0), 1, 0, 0, new DocumentCodec(), connectionSource, connection)

--- a/driver-core/src/test/functional/com/mongodb/operation/AsyncQueryBatchCursorFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/AsyncQueryBatchCursorFunctionalSpecification.groovy
@@ -49,6 +49,7 @@ import static com.mongodb.ClusterFixture.getAsyncCluster
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.getConnection
 import static com.mongodb.ClusterFixture.getReadConnectionSource
+import static com.mongodb.ClusterFixture.getReferenceCountAfterTimeout
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.connection.ServerHelper.waitForLastRelease
@@ -122,8 +123,8 @@ class AsyncQueryBatchCursorFunctionalSpecification extends OperationFunctionalSp
         nextBatch()
 
         then:
-        connection.count == 1
-        connectionSource.count == 1
+        getReferenceCountAfterTimeout(connection, 1)
+        getReferenceCountAfterTimeout(connectionSource, 1) == 1
     }
 
     def 'should not retain connection and source after cursor is exhausted after first batch'() {
@@ -132,8 +133,8 @@ class AsyncQueryBatchCursorFunctionalSpecification extends OperationFunctionalSp
                 connection)
 
         then:
-        connection.count == 1
-        connectionSource.count == 1
+        getReferenceCountAfterTimeout(connection, 1) == 1
+        getReferenceCountAfterTimeout(connectionSource, 1) == 1
     }
 
     def 'should exhaust single batch with limit'() {

--- a/driver-core/src/test/functional/com/mongodb/operation/AsyncQueryBatchCursorFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/AsyncQueryBatchCursorFunctionalSpecification.groovy
@@ -123,7 +123,7 @@ class AsyncQueryBatchCursorFunctionalSpecification extends OperationFunctionalSp
         nextBatch()
 
         then:
-        getReferenceCountAfterTimeout(connection, 1)
+        getReferenceCountAfterTimeout(connection, 1) == 1
         getReferenceCountAfterTimeout(connectionSource, 1) == 1
     }
 

--- a/driver-core/src/test/functional/com/mongodb/operation/ChangeStreamOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ChangeStreamOperationSpecification.groovy
@@ -163,6 +163,9 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         next.getNamespace() == helper.getNamespace()
         next.getOperationType() == OperationType.INSERT
         next.getUpdateDescription() == null
+
+        cleanup:
+        cursor?.close()
     }
 
     def 'should decode update to ChangeStreamDocument '() {
@@ -186,6 +189,9 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         next.getNamespace() == helper.getNamespace()
         next.getOperationType() == OperationType.UPDATE
         next.getUpdateDescription() == new UpdateDescription(['y'], BsonDocument.parse('{x : 3}'))
+
+        cleanup:
+        cursor?.close()
     }
 
     def 'should decode replace to ChangeStreamDocument '() {
@@ -209,6 +215,9 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         next.getNamespace() == helper.getNamespace()
         next.getOperationType() == OperationType.REPLACE
         next.getUpdateDescription() == null
+
+        cleanup:
+        cursor?.close()
     }
 
     def 'should decode delete to ChangeStreamDocument '() {
@@ -232,6 +241,9 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         next.getNamespace() == helper.getNamespace()
         next.getOperationType() == OperationType.DELETE
         next.getUpdateDescription() == null
+
+        cleanup:
+        cursor?.close()
     }
 
     def 'should decode invalidate to ChangeStreamDocument '() {
@@ -255,6 +267,9 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         next.getNamespace() == null
         next.getOperationType() == OperationType.INVALIDATE
         next.getUpdateDescription() == null
+
+        cleanup:
+        cursor?.close()
     }
 
     def 'should throw if the _id field is projected out'() {
@@ -270,6 +285,9 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
 
         then:
         thrown(MongoChangeStreamException)
+
+        cleanup:
+        cursor?.close()
 
         where:
         async << [true, false]

--- a/driver-core/src/test/functional/com/mongodb/operation/ListCollectionsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ListCollectionsOperationSpecification.groovy
@@ -312,6 +312,9 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
         collections.size() <= 2 // pre 3.0 items may be filtered out the batch by the driver
         cursor.hasNext()
         cursor.getBatchSize() == 2
+
+        cleanup:
+        cursor?.close()
     }
 
     @Category(Async)
@@ -341,6 +344,9 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
         then:
         callback.get().size() <= 2 // pre 3.0 items may be filtered out the batch by the driver
         cursor.getBatchSize() == 2
+
+        cleanup:
+        consumeAsyncResults(cursor)
     }
 
     @IgnoreIf({ isSharded() })

--- a/driver-core/src/test/functional/com/mongodb/operation/ListIndexesOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ListIndexesOperationSpecification.groovy
@@ -179,6 +179,9 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
         collections.size() <= 2 // pre 3.0 items may be filtered out the batch by the driver
         cursor.hasNext()
         cursor.getBatchSize() == 2
+
+        cleanup:
+        cursor?.close()
     }
 
     @Category(Async)
@@ -207,6 +210,9 @@ class ListIndexesOperationSpecification extends OperationFunctionalSpecification
         then:
         callback.get().size() <= 2 // pre 3.0 items may be filtered out the batch by the driver
         cursor.getBatchSize() == 2
+
+        cleanup:
+        consumeAsyncResults(cursor)
     }
 
     @IgnoreIf({ isSharded() })

--- a/driver-core/src/test/functional/com/mongodb/operation/QueryBatchCursorFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/QueryBatchCursorFunctionalSpecification.groovy
@@ -40,6 +40,7 @@ import spock.lang.IgnoreIf
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
+import static com.mongodb.ClusterFixture.checkReferenceCountReachesTarget
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.isSharded
@@ -379,6 +380,35 @@ class QueryBatchCursorFunctionalSpecification extends OperationFunctionalSpecifi
 
         then:
         thrown(MongoCursorNotFoundException)
+    }
+
+    def 'should release connection source if limit is reached on initial query'() throws InterruptedException {
+        given:
+        def firstBatch = executeQuery(5)
+        def connection = connectionSource.getConnection()
+
+        when:
+        cursor = new QueryBatchCursor<Document>(firstBatch, 5, 0, 0, new DocumentCodec(), connectionSource, connection)
+
+        then:
+        checkReferenceCountReachesTarget(connectionSource, 1)
+
+        cleanup:
+        connection?.release()
+    }
+
+    def 'should release connection source if limit is reached on get more'() throws InterruptedException {
+        given:
+        def firstBatch = executeQuery(3)
+
+        cursor = new QueryBatchCursor<Document>(firstBatch, 5, 3, new DocumentCodec(), connectionSource)
+
+        when:
+        cursor.next()
+        cursor.next()
+
+        then:
+        checkReferenceCountReachesTarget(connectionSource, 1)
     }
 
     def 'test limit with get more'() {

--- a/driver-core/src/test/functional/com/mongodb/operation/QueryBatchCursorFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/QueryBatchCursorFunctionalSpecification.groovy
@@ -67,6 +67,7 @@ class QueryBatchCursorFunctionalSpecification extends OperationFunctionalSpecifi
 
     def cleanup() {
         cursor?.close()
+        connectionSource?.release()
     }
 
     def 'server cursor should not be null'() {
@@ -510,6 +511,7 @@ class QueryBatchCursorFunctionalSpecification extends OperationFunctionalSpecifi
     @IgnoreIf({ !isDiscoverableReplicaSet() })
     def 'should get more from a secondary'() {
         given:
+        connectionSource.release() // release the connection source established in setup, since we're substituting our own here
         connectionSource = getBinding(ReadPreference.secondary()).getReadConnectionSource()
 
         def firstBatch = executeQuery(2, ReadPreference.secondary())

--- a/driver-core/src/test/unit/com/mongodb/operation/AsyncQueryBatchCursorSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/AsyncQueryBatchCursorSpecification.groovy
@@ -134,7 +134,7 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         nextBatch(cursor) == FIRST_BATCH
 
         then:
-        connectionSource.getCount() == 1
+        connectionSource.getCount() == 0
 
         then:
         nextBatch(cursor) == null
@@ -203,7 +203,7 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         then:
         batch == thirdBatch
         connectionB.getCount() == 0
-        connectionSource.getCount() == 1
+        connectionSource.getCount() == 0
 
         when:
         batch = tryNextBatch(cursor)
@@ -272,7 +272,7 @@ class AsyncQueryBatchCursorSpecification extends Specification {
         then:
         batch == thirdBatch
         connectionB.getCount() == 0
-        connectionSource.getCount() == 1
+        connectionSource.getCount() == 0
 
         when:
         batch = nextBatch(cursor)
@@ -364,7 +364,7 @@ class AsyncQueryBatchCursorSpecification extends Specification {
 
         then:
         connection.getCount() == 0
-        connectionSource.getCount() == 1
+        connectionSource.getCount() == 0
 
         when:
         cursor.close()
@@ -412,7 +412,7 @@ class AsyncQueryBatchCursorSpecification extends Specification {
 
         then:
         connection.getCount() == 0
-        connectionSource.getCount() == 1
+        connectionSource.getCount() == 0
 
         when:
         cursor.close()

--- a/driver/src/main/com/mongodb/DBCursor.java
+++ b/driver/src/main/com/mongodb/DBCursor.java
@@ -676,7 +676,11 @@ public class DBCursor implements Cursor, Iterable<DBObject> {
      */
     public DBObject one() {
         DBCursor findOneCursor = copy().limit(-1);
-        return findOneCursor.hasNext() ? findOneCursor.next() : null;
+        try {
+            return findOneCursor.hasNext() ? findOneCursor.next() : null;
+        } finally {
+            findOneCursor.close();
+        }
     }
 
     /**

--- a/driver/src/main/com/mongodb/DBCursor.java
+++ b/driver/src/main/com/mongodb/DBCursor.java
@@ -36,13 +36,16 @@ import static com.mongodb.assertions.Assertions.notNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
- * <p>An iterator over database results. Doing a {@code find()} query on a collection returns a {@code DBCursor} thus</p>
- * <pre>
- *    DBCursor cursor = collection.find(query);
- *    if(cursor.hasNext()) {
- *       DBObject obj = cursor.next();
+ * <p>An iterator over database results. Doing a {@code find()} query on a collection returns a {@code DBCursor}.</p>
+ * <p> An application should ensure that a cursor is closed in all circumstances, e.g. using a try-with-resources statement:</p>
+ * <blockquote><pre>
+ *    try (DBCursor cursor = collection.find(query)) {
+ *        while (cursor.hasNext()) {
+ *            System.out.println(cursor.next();
+ *        }
  *    }
- * </pre>
+ * </pre></blockquote>
+ *
  * <p><b>Warning:</b> Calling {@code toArray} or {@code length} on a DBCursor will irrevocably turn it into an array.  This means that, if
  * the cursor was iterating over ten million results (which it was lazily fetching from the database), suddenly there will be a ten-million
  * element array in memory.  Before converting to an array, make sure that there are a reasonable number of results using {@code skip()} and

--- a/driver/src/main/com/mongodb/FindIterableImpl.java
+++ b/driver/src/main/com/mongodb/FindIterableImpl.java
@@ -191,7 +191,11 @@ final class FindIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResu
     public TResult first() {
         FindOperation<TResult> findFirstOperation = createQueryOperation().batchSize(0).limit(-1);
         BatchCursor<TResult> batchCursor = getExecutor().execute(findFirstOperation, getReadPreference(), getClientSession());
-        return batchCursor.hasNext() ? batchCursor.next().iterator().next() : null;
+        try {
+            return batchCursor.hasNext() ? batchCursor.next().iterator().next() : null;
+        } finally {
+            batchCursor.close();
+        }
     }
 
     protected ReadOperation<BatchCursor<TResult>> asReadOperation() {

--- a/driver/src/main/com/mongodb/Mongo.java
+++ b/driver/src/main/com/mongodb/Mongo.java
@@ -782,6 +782,10 @@ public class Mongo {
         return cluster;
     }
 
+    ServerSessionPool getServerSessionPool() {
+        return serverSessionPool;
+    }
+
     Bytes.OptionHolder getOptionHolder() {
         return optionHolder;
     }

--- a/driver/src/main/com/mongodb/client/MongoCursor.java
+++ b/driver/src/main/com/mongodb/client/MongoCursor.java
@@ -24,13 +24,24 @@ import java.io.Closeable;
 import java.util.Iterator;
 
 /**
- * The Mongo Cursor interface implementing the iterator protocol
+ * The Mongo Cursor interface implementing the iterator protocol.
+ * <p>
+ * An application should ensure that a cursor is closed in all circumstances, e.g. using a try-with-resources statement:
+ *
+ * <blockquote><pre>
+ * try (MongoCursor&lt;Document&gt; cursor = collection.find().iterator()) {
+ *     while (cursor.hasNext()) {
+ *         System.out.println(cursor.next());
+ *     }
+ * }
+ * </pre></blockquote>
  *
  * @since 3.0
  * @param <TResult> The type of documents the cursor contains
  */
 @NotThreadSafe
 public interface MongoCursor<TResult> extends Iterator<TResult>, Closeable {
+
     @Override
     void close();
 

--- a/driver/src/test/functional/com/mongodb/DBCursorOldTest.java
+++ b/driver/src/test/functional/com/mongodb/DBCursorOldTest.java
@@ -135,6 +135,8 @@ public class DBCursorOldTest extends DatabaseTestCase {
         assertEquals(null, cur.tryNext());
         assertEquals(secondDBObject, cur.curr());
         assertEquals(2, cur.numSeen());
+
+        cur.close();
     }
 
     @Test
@@ -178,6 +180,8 @@ public class DBCursorOldTest extends DatabaseTestCase {
         // this doc should unblock thread
         c.save(new BasicDBObject("x", 10), WriteConcern.ACKNOWLEDGED);
         assertEquals(10, (long) future.get(5, SECONDS));
+
+        cur.close();
     }
 
     @Test
@@ -220,6 +224,8 @@ public class DBCursorOldTest extends DatabaseTestCase {
         // this doc should unblock thread
         c.save(new BasicDBObject("x", 10), WriteConcern.ACKNOWLEDGED);
         assertEquals(10, (long) future.get(5, SECONDS));
+
+        cur.close();
     }
 
     @Test
@@ -237,6 +243,8 @@ public class DBCursorOldTest extends DatabaseTestCase {
             cur.tryNext();
         } catch (IllegalArgumentException e) {
             fail();
+        } finally {
+            cur.close();
         }
     }
 
@@ -256,6 +264,8 @@ public class DBCursorOldTest extends DatabaseTestCase {
             cur.tryNext();
         } catch (IllegalArgumentException e) {
             fail();
+        } finally {
+            cur.close();
         }
     }
 

--- a/driver/src/test/functional/com/mongodb/DBCursorTest.java
+++ b/driver/src/test/functional/com/mongodb/DBCursorTest.java
@@ -207,14 +207,22 @@ public class DBCursorTest extends DatabaseTestCase {
     @Test
     public void testGetCursorId() {
         DBCursor cursor = collection.find().batchSize(2);
-        assertEquals(0, cursor.getCursorId());
-        cursor.hasNext();
-        assertThat(cursor.getCursorId(), is(not(0L)));
+        try {
+            assertEquals(0, cursor.getCursorId());
+            cursor.hasNext();
+            assertThat(cursor.getCursorId(), is(not(0L)));
+        } finally {
+            cursor.close();
+        }
 
         cursor = collection.find();
-        assertEquals(0, cursor.getCursorId());
-        cursor.hasNext();
-        assertThat(cursor.getCursorId(), is(0L));
+        try {
+            assertEquals(0, cursor.getCursorId());
+            cursor.hasNext();
+            assertThat(cursor.getCursorId(), is(0L));
+        } finally {
+            cursor.close();
+        }
     }
 
     @Test

--- a/driver/src/test/functional/com/mongodb/DatabaseTestCase.java
+++ b/driver/src/test/functional/com/mongodb/DatabaseTestCase.java
@@ -21,6 +21,7 @@ import org.junit.Before;
 
 import static com.mongodb.Fixture.getDefaultDatabaseName;
 import static com.mongodb.Fixture.getMongoClient;
+import static com.mongodb.Fixture.getServerSessionPoolInUseCount;
 
 public class DatabaseTestCase {
     //For ease of use and readability, in this specific case we'll allow protected variables
@@ -43,6 +44,10 @@ public class DatabaseTestCase {
     @After
     public void tearDown() {
         collection.drop();
+
+        if (getServerSessionPoolInUseCount() != 0) {
+            throw new IllegalStateException("Server session in use count is " + getServerSessionPoolInUseCount());
+        }
     }
 
     public MongoClient getClient() {

--- a/driver/src/test/functional/com/mongodb/Fixture.java
+++ b/driver/src/test/functional/com/mongodb/Fixture.java
@@ -44,6 +44,10 @@ public final class Fixture {
         return mongoClient;
     }
 
+    public static int getServerSessionPoolInUseCount() {
+        return getMongoClient().getServerSessionPool().getInUseCount();
+    }
+
     @SuppressWarnings("deprecation") // This is for access to the old API, so it will use deprecated methods
     public static synchronized DB getDefaultDatabase() {
         if (defaultDatabase == null) {

--- a/driver/src/test/functional/com/mongodb/FunctionalSpecification.groovy
+++ b/driver/src/test/functional/com/mongodb/FunctionalSpecification.groovy
@@ -20,6 +20,7 @@ import spock.lang.Specification
 
 import static com.mongodb.Fixture.getDefaultDatabaseName
 import static com.mongodb.Fixture.getMongoClient
+import static com.mongodb.Fixture.getServerSessionPoolInUseCount
 
 class FunctionalSpecification extends Specification {
     protected DB database;
@@ -34,6 +35,9 @@ class FunctionalSpecification extends Specification {
     def cleanup() {
         if (collection != null) {
             collection.drop()
+        }
+        if (getServerSessionPoolInUseCount() != 0) {
+            throw new IllegalStateException('Server session in use count is ' + getServerSessionPoolInUseCount());
         }
     }
 

--- a/driver/src/test/functional/com/mongodb/MongoClientSessionSpecification.groovy
+++ b/driver/src/test/functional/com/mongodb/MongoClientSessionSpecification.groovy
@@ -70,6 +70,9 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession.getClusterTime() == null
         clientSession.getOperationTime() == null
         clientSession.getServerSession() != null
+
+        cleanup:
+        clientSession?.close()
     }
 
     @IgnoreIf({ !serverVersionAtLeast(3, 6) })
@@ -111,6 +114,9 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
 
         then:
         clientSession.getClusterTime() == secondClusterTime
+
+        cleanup:
+        clientSession?.close()
     }
 
     @IgnoreIf({ !serverVersionAtLeast(3, 6) })
@@ -149,6 +155,9 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
 
         then:
         clientSession.getOperationTime() == secondOperationTime
+
+        cleanup:
+        clientSession?.close()
     }
 
     @IgnoreIf({ !serverVersionAtLeast(3, 6) })
@@ -175,6 +184,9 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
 
         then:
         thrown(IllegalStateException)
+
+        cleanup:
+        clientSession?.close()
     }
 
     @IgnoreIf({ !serverVersionAtLeast(3, 6) })
@@ -192,6 +204,9 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
 
         then:
         true
+
+        cleanup:
+        clientSession?.close()
     }
 
     @IgnoreIf({ !serverVersionAtLeast(3, 6) })
@@ -204,6 +219,9 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         then:
         clientSession != null
         clientSession.isCausallyConsistent() == causallyConsistent
+
+        cleanup:
+        clientSession?.close()
 
         where:
         causallyConsistent << [true, false]
@@ -223,6 +241,9 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         identifier.get('id').isBinary()
         identifier.getBinary('id').getType() == BsonBinarySubType.UUID_STANDARD.value
         identifier.getBinary('id').data.length == 16
+
+        cleanup:
+        clientSession?.close()
     }
 
     @IgnoreIf({ !serverVersionAtLeast(3, 6) })

--- a/driver/src/test/functional/com/mongodb/client/DatabaseTestCase.java
+++ b/driver/src/test/functional/com/mongodb/client/DatabaseTestCase.java
@@ -30,6 +30,7 @@ import org.junit.Before;
 import static com.mongodb.Fixture.getDefaultDatabaseName;
 import static com.mongodb.Fixture.getMongoClient;
 import static com.mongodb.Fixture.getPrimary;
+import static com.mongodb.Fixture.getServerSessionPoolInUseCount;
 
 public class DatabaseTestCase {
     //For ease of use and readability, in this specific case we'll allow protected variables
@@ -56,6 +57,10 @@ public class DatabaseTestCase {
             ServerHelper.checkPool(getPrimary());
         } catch (InterruptedException e) {
             // ignore
+        }
+
+        if (getServerSessionPoolInUseCount() != 0) {
+            throw new IllegalStateException("Server session in use count is " + getServerSessionPoolInUseCount());
         }
     }
 


### PR DESCRIPTION
Where there's smoke there's fire.  Turns out there are multiple leakes to plug, including

* QueryBatchCursor: ensure that connection source (and thus the session it's retaining) is released as early as possible, to minimize the effect of unclosed cursors on the number of sessions created
* AsyncQueryBatchCursor: same as QueryBatchCursor, but the code to do it is more complicated
* ListDatabasesOperation: release connection source asynchronously in addition to connection
* ChangeStreamBatchCursor: release connection source after a retry
* AsyncChangeStreamBatchCursor: release connection source after a retry
* MixedBulkWriteOperation: release connection source after a retry

Except for the first two, all these bugs were found by adding additional checks on test cleanup that throw exceptions if binding reference counts (for core) and server session pool in use counts (for high) have not dropped to the expected target count.

Patch build: https://evergreen.mongodb.com/version/5a806fc5e3c331673c428b06