### PR TITLE
JAVA-2751: MongoClient changes for reference documentation

### DIFF
--- a/docs/landing/data/releases.toml
+++ b/docs/landing/data/releases.toml
@@ -1,8 +1,13 @@
-current = "3.6.2"
+current = "3.7.0"
+
+[[versions]]
+  version = "3.7.0"
+  status = "current"
+  docs = "./3.7"
+  api = "./3.7/javadoc"
 
 [[versions]]
   version = "3.6.2"
-  status = "current"
   docs = "./3.6"
   api = "./3.6/javadoc"
 
@@ -47,21 +52,26 @@ current = "3.6.2"
   api = "http://api.mongodb.com/java/2.13"
 
 [[drivers]]
+  name = "mongodb-driver-sync"
+  description = "The synchronous driver, new in 3.7.<br/>For older versions of the driver please use the `mongodb-driver` or `mongo-java-driver`."
+  versions = "3.7.0"
+
+[[drivers]]
   name = "mongodb-driver"
-  description = "The synchronous driver, new in 3.0.<br/>For older versions of the driver or for OSGi-based applications please use the `mongo-java-driver`."
-  versions = "3.6.2,3.5.0,3.4.3,3.3.0,3.2.2,3.1.1,3.0.4"
+  description = "The synchronous driver plus the legacy driver, new in 3.0.<br/>For older versions of the driver or for OSGi-based applications please use the `mongo-java-driver`."
+  versions = "3.7.0,3.6.2,3.5.0,3.4.3,3.3.0,3.2.2,3.1.1,3.0.4"
 
 [[drivers]]
   name = "mongo-java-driver"
   description = "An uber jar containing the bson library, the core library and the mongodb-driver.<br/>This artifact is a valid OSGi bundle."
-  versions = "3.6.2,3.5.0,3.4.3,3.3.0,3.2.2,3.1.1,3.0.4,2.14.2,2.13.3"
+  versions = "3.7.0,3.6.2,3.5.0,3.4.3,3.3.0,3.2.2,3.1.1,3.0.4,2.14.2,2.13.3"
 
 [[drivers]]
   name = "mongodb-driver-async"
   description = "The new asynchronous driver, new in 3.0"
-  versions = "3.6.2,3.5.0,3.4.3,3.3.0,3.2.2,3.1.1,3.0.4"
+  versions = "3.7.0,3.6.2,3.5.0,3.4.3,3.3.0,3.2.2,3.1.1,3.0.4"
 
 [[drivers]]
   name = "mongodb-driver-core"
   description = "The core library, new in 3.0"
-  versions = "3.6.2,3.5.0,3.4.3,3.3.0,3.2.2,3.1.1,3.0.4"
+  versions = "3.7.0,3.6.2,3.5.0,3.4.3,3.3.0,3.2.2,3.1.1,3.0.4"

--- a/docs/reference/config.toml
+++ b/docs/reference/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/mongo-java-driver/3.6"
+baseURL = "/mongo-java-driver/3.7"
 languageCode = "en-us"
 title = "MongoDB Java Driver"
 theme = "mongodb"

--- a/docs/reference/content/bson/installation-guide.md
+++ b/docs/reference/content/bson/installation-guide.md
@@ -22,4 +22,4 @@ This library comprehensively supports [BSON](http://www.bsonspec.org),
 the data storage and network transfer format that MongoDB uses for "documents".
 BSON is short for Binary [JSON](http://json.org/), is a binary-encoded serialization of JSON-like documents.
 
-{{< install artifactId="bson" version="3.6.0" >}}
+{{< install artifactId="bson" version="3.7.0" >}}

--- a/docs/reference/content/driver-async/getting-started/installation.md
+++ b/docs/reference/content/driver-async/getting-started/installation.md
@@ -23,4 +23,4 @@ The MongoDB Async Driver requires either [Netty](http://netty.io/) or Java 7.
 
 The MongoDB Async Driver provides asynchronous API that can leverage either Netty or Java 7's AsynchronousSocketChannel for fast and non-blocking I/O.
 
-{{< install artifactId="mongodb-driver-async" version="3.6.0" dependencies="true">}}
+{{< install artifactId="mongodb-driver-async" version="3.7.0" dependencies="true">}}

--- a/docs/reference/content/driver-async/getting-started/quick-start-pojo.md
+++ b/docs/reference/content/driver-async/getting-started/quick-start-pojo.md
@@ -151,7 +151,8 @@ There are multiple ways to set the `pojoCodecRegistry` for use:
  - You can set it when instantiating a MongoClient object:
  
  ```java
- MongoClient mongoClient = new MongoClient("localhost", MongoClientOptions.builder().codecRegistry(pojoCodecRegistry).build());
+ MongoClient mongoClient = MongoClients.create(MongoClientSettings.builder()
+                                           .codecRegistry(pojoCodecRegistry).build());
 ```
 
 - You can use an alternative `CodecRegistry` with a `MongoDatabase`:

--- a/docs/reference/content/driver-async/index.md
+++ b/docs/reference/content/driver-async/index.md
@@ -9,7 +9,7 @@ title = "MongoDB Async Driver"
 
 ## MongoDB Async Java Driver Documentation
 
-The following guide provides information on using the callback-based MongoDB Async Java Driver 3.6.
+The following guide provides information on using the callback-based MongoDB Async Java Driver 3.7.
 
 {{% note %}}
 There are two higher level MongoDB Asynchronous Java Drivers available, that users may find easier to work with due to their friendlier APIs:
@@ -18,7 +18,7 @@ There are two higher level MongoDB Asynchronous Java Drivers available, that use
 * [MongoDB Reactive Streams Java Driver](http://mongodb.github.io/mongo-java-driver-reactivestreams/) A Reactive Streams implementation for the JVM.
 {{% /note %}}
 
-### What's New in 3.6
+### What's New in 3.7
 
 The [What's New]({{< relref "whats-new.md" >}}) guide explains the major new features of the driver.
 

--- a/docs/reference/content/driver/getting-started/installation.md
+++ b/docs/reference/content/driver/getting-started/installation.md
@@ -13,32 +13,52 @@ title = "Installation"
 The recommended way to get started using one of the drivers in your
 project is with a dependency management system.
 
-There are two Maven artifacts available in the release. The preferred artifact for new applications is `mongodb-driver`
-however, we still publish the legacy `mongo-java-driver` uber-jar.
+There are two Maven artifacts available in the release. The preferred artifact for new applications is `mongodb-driver-sync`
+however, we still publish the legacy `mongo-java-driver` uber-jar as well as the `mongodb-driver` jar introduced in 3.0.
 
 {{< distroPicker >}}
 
+## MongoDB Driver Sync 
+
+The MongoDB Driver `mongodb-driver-sync` is the synchronous Java driver containing only the generic `MongoCollection` interface that 
+complies with a new cross-driver CRUD specification.  It does *not* include the legacy API (e.g. `DBCollection`).
+
+{{% note class="important" %}}
+
+This is a Java 9-compliant module with an Automatic-Module-Name of `org.mongodb.driver.sync.client`.
+
+The `mongodb-driver-sync` artifact is a valid OSGi bundle whose symbolic name is `org.mongodb.driver-sync`.
+
+{{% /note %}}
+
+{{< install artifactId="mongodb-driver-sync" version="3.7.0" dependencies="true">}}
+
 ## MongoDB Driver  
 
-The MongoDB Driver ``mongodb-driver`` is the updated synchronous Java driver that includes the legacy API as well as a new generic `MongoCollection` interface that complies with a new cross-driver CRUD specification.
+The MongoDB Driver `mongodb-driver` is the updated synchronous Java driver that includes the legacy API as well as a new generic `MongoCollection` interface that complies with a new cross-driver CRUD specification.
 
 {{% note class="important" %}}
 `mongodb-driver` is *not* an OSGi bundle: both `mongodb-driver` and `mongodb-driver-core`, a dependency of `mongodb-driver`, include classes from the `com.mongodb` package.
 
-For OSGi-based applications, use the [mongo-java-driver](#uber-jar-legacy) uber jar instead.
+For OSGi-based applications, use the [mongodb-driver-sync](#mongodb-driver-sync) or the [mongo-java-driver](#uber-jar-legacy) uber jar instead.
+
+It is also *not* a Java 9 module.
 
 {{% /note %}}
 
-{{< install artifactId="mongodb-driver" version="3.6.0" dependencies="true">}}
+{{< install artifactId="mongodb-driver" version="3.7.0" dependencies="true">}}
 
 
 ## Uber Jar (Legacy)
 
-For new applications, the preferred artifact is [mongodb-driver](#mongodb-driver); however, the legacy `mongo-java-driver` uber jar is still available.  The uber jar contains: the BSON library, the core library, and the `mongodb-driver`.
+For new applications, the preferred artifact is [mongodb-driver-sync](#mongodb-driver-sync); however, the legacy `mongo-java-driver` uber
+jar is still available.  The uber jar contains: the BSON library, the core library, and the `mongodb-driver`.
 
 
 {{% note %}}
-The `mongo-java-driver` artifact is a valid OSGi bundle.
+This is a Java 9-compliant module with an Automatic-Module-Name of `org.mongodb.driver.sync.client`.
+
+The `mongo-java-driver` artifact is a valid OSGi bundle whose symbolic name is `org.mongodb.mongo-java-driver`.
 {{% /note %}}
 
-{{< install artifactId="mongo-java-driver" version="3.6.0">}}
+{{< install artifactId="mongo-java-driver" version="3.7.0">}}

--- a/docs/reference/content/driver/getting-started/quick-start-pojo.md
+++ b/docs/reference/content/driver/getting-started/quick-start-pojo.md
@@ -149,7 +149,10 @@ There are multiple ways to set the `pojoCodecRegistry` for use:
  - You can set it when instantiating a MongoClient object:
  
  ```java
- MongoClient mongoClient = new MongoClient("localhost", MongoClientOptions.builder().codecRegistry(pojoCodecRegistry).build());
+MongoClientSettings settings = MongoClientSettings.builder()
+        .codecRegistry(pojoCodecRegistry)
+        .build();
+MongoClient mongoClient = MongoClients.create(settings);
 ```
 
 - You can use an alternative `CodecRegistry` with a `MongoDatabase`:

--- a/docs/reference/content/driver/getting-started/quick-start.md
+++ b/docs/reference/content/driver/getting-started/quick-start.md
@@ -23,9 +23,24 @@ that can be found with the driver source on github.
 
 - The following import statements:
 
+New MongoClient API (since 3.7):
+
+```java
+import com.mongodb.ConnectionString;
+import com.mongodb.clients.MongoClients;
+import com.mongodb.clients.MongoClient;
+```
+
+Legacy MongoClient API:
+
 ```java
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
+```
+
+And the common elements between the legacy and new APIs:
+
+```java
 import com.mongodb.ServerAddress;
 
 import com.mongodb.client.MongoDatabase;
@@ -45,7 +60,9 @@ import java.util.List;
 ```
 ## Make a Connection
 
-Use [`MongoClient()`]({{< apiref "com/mongodb/MongoClient.html">}}) to make a connection to a running MongoDB instance.
+Use [`MongoClients.create()`]({{< apiref "com/mongodb/client/MongoClients.html">}}), 
+or [`MongoClient()`]({{< apiref "com/mongodb/MongoClient.html">}}) for the legacy MongoClient API, 
+to make a connection to a running MongoDB instance.
 
 The `MongoClient` instance represents a pool of connections to the database; you will only need one instance of class `MongoClient` even with multiple threads.
 
@@ -61,9 +78,46 @@ The `MongoClient` instance represents a pool of connections to the database; you
 
 ### Connect to a Single MongoDB instance
 
-The following example shows five ways to connect to the
-database `mydb` on the local machine. If the database does not exist, MongoDB
-will create it for you.
+The following example shows several ways to connect to a single MongoDB server.
+
+##### New MongoClient API (since 3.7)
+
+To connect to a single MongoDB instance:
+
+- You can instantiate a MongoClient object without any parameters to connect to a MongoDB instance running on localhost on port ``27017``:
+
+```java
+MongoClient mongoClient = MongoClients.create();
+```
+
+- You can explicitly specify the hostname to connect to a MongoDB instance running on the specified host on port ``27017``:
+
+```java
+MongoClient mongoClient = MongoClients.create(
+        MongoClientSettings.builder()
+                .applyToClusterSettings(builder ->
+                        builder.hosts(Arrays.asList(new ServerAddress("hostOne"))))
+                .build());
+```
+
+- You can explicitly specify the hostname and the port:
+
+```java
+MongoClient mongoClient = MongoClients.create(
+        MongoClientSettings.builder()
+                .applyToClusterSettings(builder ->
+                        builder.hosts(Arrays.asList(new ServerAddress("hostOne", 27018))))
+                .build());
+```
+
+- You can specify the [`ConnectionString`]({{< apiref "/com/mongodb/ConnectionString.html">}}):
+
+```java
+MongoClient mongoClient = MongoClients.create("mongodb://hostOne:27017,hostTwo:27018");
+```
+
+
+##### Legacy MongoClient API
 
 To connect to a single MongoDB instance:
 
@@ -76,24 +130,26 @@ MongoClient mongoClient = new MongoClient();
 - You can explicitly specify the hostname to connect to a MongoDB instance running on the specified host on port ``27017``:
 
 ```java
-MongoClient mongoClient = new MongoClient( "localhost" );
+MongoClient mongoClient = new MongoClient( "hostOne" );
 ```
 
 - You can explicitly specify the hostname and the port:
 
 ```java
-MongoClient mongoClient = new MongoClient( "localhost" , 27017 );
+MongoClient mongoClient = new MongoClient( "hostOne" , 27018 );
 ```
 
 - You can specify the
 [`MongoClientURI`]({{< apiref "/com/mongodb/MongoClientURI.html">}}) connection string:
 
 ```java
- MongoClientURI connectionString = new MongoClientURI("mongodb://localhost:27017");
+ MongoClientURI connectionString = new MongoClientURI("mongodb://hostOne:27017,hostTwo:27017");
  MongoClient mongoClient = new MongoClient(connectionString);
 ```
 
-The connection string mostly follows [RFC 3986](http://tools.ietf.org/html/rfc3986), with the exception of the domain name. For MongoDB, it is possible to list multiple domain names separated by a comma. For more information on the connection string, see [connection string]({{< docsref "reference/connection-string" >}}).
+The connection string mostly follows [RFC 3986](http://tools.ietf.org/html/rfc3986), with the exception of the domain name. For MongoDB, 
+it is possible to list multiple domain names separated by a comma. For more information on the connection string, see 
+[connection string]({{< docsref "reference/connection-string" >}}).
 
 ## Access a Database
 

--- a/docs/reference/content/driver/index.md
+++ b/docs/reference/content/driver/index.md
@@ -7,12 +7,12 @@ title = "MongoDB Driver"
   pre = "<i class='fa fa-arrows-h'></i>"
 +++
 
-## MongoDB Driver 3.6 Documentation
+## MongoDB Driver 3.7 Documentation
 
 The following guide provides information on using the synchronous
-MongoDB Java Driver 3.6.
+MongoDB Java Driver 3.7.
 
-### What's New in 3.6
+### What's New in 3.7
 
 The [What's New]({{< relref "whats-new.md" >}}) guide explains
 the major new features of the driver.

--- a/docs/reference/content/driver/reference/monitoring.md
+++ b/docs/reference/content/driver/reference/monitoring.md
@@ -100,10 +100,11 @@ public class TestCommandListener implements CommandListener {
 and an instance of `MongoClientOptions` configured with an instance of `TestCommandListener`:
 
 ```java
-MongoClientOptions options = MongoClientOptions.builder()
-                                       .addCommandListener(new TestCommandListener())
-                                       .build();
-MongoClient client = new MongoClient(new ServerAddress(), options);
+MongoClientSettings settings = MongoClientSettings.builder()
+        .addCommandListener(new TestCommandListener())
+        .build();
+MongoClient client = MongoClients.create(settings);
+
 ```
 
 A `MongoClient` configured with these options will print a message to `System.out` before sending each command to a MongoDB server, and
@@ -177,10 +178,11 @@ and an instance of `MongoClientOptions` configured with an instance of `TestClus
 
 ```java
 List<ServerAddress> seedList = ...
-MongoClientOptions options = MongoClientOptions.builder()
-                                       .addClusterListener(new TestClusterListener(ReadPreference.secondary()))
-                                       .build();
-MongoClient client = new MongoClient(seedList, options);
+MongoClientSettings settings = MongoClientSettings.builder()
+        .applyToClusterSettings(builder -> 
+                builder.addClusterListener(new TestClusterListener(ReadPreference.secondary())))
+        .build();
+MongoClient client = MongoClients.create(settings);
 ```
 
 A `MongoClient` configured with these options will print a message to `System.out` when the MongoClient is created with these options,
@@ -248,10 +250,11 @@ and an instance of `MongoClientOptions` configured with an instance of `TestConn
 
 ```java
 List<ServerAddress> seedList = ...
-MongoClientOptions options = MongoClientOptions.builder()
-                                      .addConnectionPoolListener(new TestConnectionPoolListener())
-                                      .build();
-MongoClient client = new MongoClient(new ServerAddress(), options);
+MongoClientSettings settings = MongoClientSettings.builder()
+        .applyToConnectionPoolSettings(builder -> 
+                builder.addConnectionPoolListener(new TestConnectionPoolListener()))
+        .build();
+MongoClient client = MongoClients.create(settings);
 ```
 
 A `MongoClient` configured with these options will print a message to `System.out` for each connection pool-related event for each MongoDB

--- a/docs/reference/content/driver/tutorials/aggregation.md
+++ b/docs/reference/content/driver/tutorials/aggregation.md
@@ -20,7 +20,8 @@ The [aggregation pipeline]({{<docsref "core/aggregation-pipeline">}}) is a frame
 
      ```java
      import com.mongodb.Block;
-     import com.mongodb.MongoClient;
+     import com.mongodb.client.MongoClients;
+     import com.mongodb.client.MongoClient;
      import com.mongodb.client.MongoCollection;
      import com.mongodb.client.MongoDatabase;
      import com.mongodb.client.model.Aggregates;
@@ -49,7 +50,7 @@ Connect to a MongoDB deployment and declare and define a `MongoDatabase` and a `
 For example, include the following code to connect to a standalone MongoDB deployment running on localhost on port `27017` and define `database` to refer to the `test` database and `collection` to refer to the `restaurants` collection.
 
 ```java
-MongoClient mongoClient = new MongoClient();
+MongoClient mongoClient = MongoClients.create();
 MongoDatabase database = mongoClient.getDatabase("test");
 MongoCollection<Document> collection = database.getCollection("restaurants");
 ```

--- a/docs/reference/content/driver/tutorials/authentication.md
+++ b/docs/reference/content/driver/tutorials/authentication.md
@@ -19,6 +19,21 @@ The Java driver supports all [MongoDB authentication mechanisms]({{<docsref "cor
 import com.mongodb.MongoCredential;
 ```
 
+New MongoClient API (since 3.7):
+
+```java
+import com.mongodb.ConnectionString;
+import com.mongodb.clients.MongoClients;
+import com.mongodb.clients.MongoClient;
+```
+
+Legacy MongoClient API:
+
+```java
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientURI;
+```
+
 An authentication credential is represented as an instance of the
 [`MongoCredential`]({{<apiref "com/mongodb/MongoCredential.html">}}) class. The [`MongoCredential`]({{<apiref "com/mongodb/MongoCredential.html">}}) class includes static
 factory methods for each of the supported authentication mechanisms.
@@ -38,15 +53,37 @@ credential using the [`createCredential`]({{<apiref "com/mongodb/MongoCredential
 static factory method:
 
 ```java
-String user; // the user name
+String user;     // the user name
 String database; // the name of the database in which the user is defined
 char[] password; // the password as a character array
 // ...
 MongoCredential credential = MongoCredential.createCredential(user, database, password);
+```
+
+and then construct a MongoClient with that credential.  Using the new (since 3.7) MongoClient API:
+
+```java
+MongoClient mongoClient = MongoClients.create(
+        MongoClientSettings.builder()
+                .applyToClusterSettings(builder -> 
+                        builder.hosts(Arrays.asList(new ServerAddress("host1", 27017))))
+                .credential(credential)
+                .build());
+```
+
+or using the legacy MongoClient API:
+
+```java
 MongoClient mongoClient = new MongoClient(new ServerAddress("host1", 27017), credential);
 ```
-Or use a connection string without explicitly specifying the
-authentication mechanism:
+
+Or use a connection string without explicitly specifying the authentication mechanism. Using the new MongoClient API:
+
+```java
+MongoClient mongoClient = MongoClients.create("mongodb://user1:pwd1@host1/?authSource=db1");
+```
+
+or using the legacy MongoClient API:
 
 ```java
 MongoClientURI uri = new MongoClientURI("mongodb://user1:pwd1@host1/?authSource=db1");
@@ -60,27 +97,48 @@ upgrading from MongoDB 2.6 to MongoDB 3.0 seamless, even after
 
 ## SCRAM-SHA-1
 
-To explicitly create a credential of type [`SCRAM-SHA-1`]({{<docsref "core/security-scram-sha-1/">}}), use the [`createScramSha1Credential`]({{<apiref "com/mongodb/MongoCredential.html#createScramSha1Credential-java.lang.String-java.lang.String-char:A-">}}) method:
+To explicitly create a credential of type [`SCRAM-SHA-1`]({{<docsref "core/security-scram-sha-1/">}}), use the 
+[`createScramSha1Credential`]({{<apiref "com/mongodb/MongoCredential.html#createScramSha1Credential-java.lang.String-java.lang.String-char:A-">}}) 
+method:
 
 ```java
-
-String user; // the user name
+String user;     // the user name
 String database; // the name of the database in which the user is defined
 char[] password; // the password as a character array
 // ...
-MongoCredential credential = MongoCredential.createScramSha1Credential(user,
-                                                                      database,
-                                                                      password);
+MongoCredential credential = MongoCredential.createScramSha1Credential(user, database, password);
+```
+
+and then construct a MongoClient with that credential.  Using the new (since 3.7) MongoClient API:
+
+```java
+MongoClient mongoClient = MongoClients.create(
+        MongoClientSettings.builder()
+                .applyToClusterSettings(builder -> 
+                        builder.hosts(Arrays.asList(new ServerAddress("host1", 27017))))
+                .credential(credential)
+                .build());
+```
+
+or using the legacy MongoClient API:
+
+```java
 MongoClient mongoClient = new MongoClient(new ServerAddress("host1", 27017), credential);
 ```
 
-Or use a connection string  that explicitly specifies the
-`authMechanism=SCRAM-SHA-1`:
+Or use a connection string that explicitly specifies the `authMechanism=SCRAM-SHA-1`. Using the new MongoClient API:
+
+```java
+MongoClient mongoClient = MongoClients.create("mongodb://user1:pwd1@host1/?authSource=db1&authMechanism=SCRAM-SHA-1");
+```
+
+or using the legacy MongoClient API:
 
 ```java
 MongoClientURI uri = new MongoClientURI("mongodb://user1:pwd1@host1/?authSource=db1&authMechanism=SCRAM-SHA-1");
 MongoClient mongoClient = new MongoClient(uri);
 ```
+
 ## MONGODB-CR
 
 To explicitly create a credential of type [`MONGODB-CR`]({{<docsref "core/security-mongodb-cr">}}) use the [`createMongCRCredential`]({{<apiref "com/mongodb/MongoCredential.html#createMongoCRCredential-java.lang.String-java.lang.String-char:A-">}})
@@ -94,10 +152,32 @@ char[] password; // the password as a character array
 MongoCredential credential = MongoCredential.createMongoCRCredential(user,
                                                                     database,
                                                                     password);
+```
+
+and then construct a MongoClient with that credential.  Using the new (since 3.7) MongoClient API:
+
+```java
+MongoClient mongoClient = MongoClients.create(
+        MongoClientSettings.builder()
+                .applyToClusterSettings(builder -> 
+                        builder.hosts(Arrays.asList(new ServerAddress("host1", 27017))))
+                .credential(credential)
+                .build());
+```
+
+or using the legacy MongoClient API:
+
+```java
 MongoClient mongoClient = new MongoClient(new ServerAddress("host1", 27017), credential);
 ```
-Or use a connection string that explicitly specifies the
-`authMechanism=MONGODB-CR`:
+
+Or use a connection string that explicitly specifies the `authMechanism=MONGODB-CR`. Using the new MongoClient API:
+
+```java
+MongoClient mongoClient = MongoClients.create("mongodb://user1:pwd1@host1/?authSource=db1&authMechanism=MONGODB-CR");
+```
+
+or using the legacy MongoClient API:
 
 ```java
 MongoClientURI uri = new MongoClientURI("mongodb://user1:pwd1@host1/?authSource=db1&authMechanism=MONGODB-CR");
@@ -126,13 +206,32 @@ String user;     // The X.509 certificate derived user name, e.g. "CN=user,OU=Or
 // ...
 MongoCredential credential = MongoCredential.createMongoX509Credential(user);
 MongoClientOptions options = MongoClientOptions.builder().sslEnabled(true).build();
+```
 
+and then construct a MongoClient with that credential.  Using the new (since 3.7) MongoClient API:
 
+```java
+MongoClient mongoClient = MongoClients.create(
+        MongoClientSettings.builder()
+                .applyToClusterSettings(builder -> 
+                        builder.hosts(Arrays.asList(new ServerAddress("host1", 27017))))
+                .credential(credential)
+                .build());
+```
+
+or using the legacy MongoClient API:
+
+```java
 MongoClient mongoClient = new MongoClient(new ServerAddress("host1", 27017), credential, options);
 ```
 
-Or use a connection string that explicitly specifies the
-`authMechanism=MONGODB-X509`:
+Or use a connection string that explicitly specifies the `authMechanism=MONGODB-X509`. Using the new MongoClient API:
+                                                                                      
+```java
+MongoClient mongoClient = MongoClients.create("mongodb://subjectName@host1/?authMechanism=MONGODB-X509&ssl=true");
+```
+
+or using the legacy MongoClient API:
 
 ```java
 MongoClientURI uri = new MongoClientURI("mongodb://subjectName@host1/?authMechanism=MONGODB-X509&ssl=true");
@@ -155,10 +254,32 @@ static factory method:
 String user;   // The Kerberos user name, including the realm, e.g. "user1@MYREALM.ME"
 // ...
 MongoCredential credential = MongoCredential.createGSSAPICredential(user);
+```
+
+and then construct a MongoClient with that credential.  Using the new (since 3.7) MongoClient API:
+
+```java
+MongoClient mongoClient = MongoClients.create(
+        MongoClientSettings.builder()
+                .applyToClusterSettings(builder -> 
+                        builder.hosts(Arrays.asList(new ServerAddress("host1", 27017))))
+                .credential(credential)
+                .build());
+```
+
+or using the legacy MongoClient API:
+
+```java
 MongoClient mongoClient = new MongoClient(new ServerAddress("host1", 27017), credential);
 ```
-Or use a connection string that explicitly specifies the
-`authMechanism=GSSAPI`:
+
+Or use a connection string that explicitly specifies the `authMechanism=GSSAPI`. Using the new MongoClient API:
+                                                                                      
+```java
+MongoClient mongoClient = MongoClients.create("mongodb://username%40REALM.ME@host1/?authMechanism=GSSAPI");
+```
+
+or using the legacy MongoClient API:
 
 ```java
 MongoClientURI uri = new MongoClientURI("mongodb://username%40REALM.ME@host1/?authMechanism=GSSAPI");
@@ -226,10 +347,32 @@ String user;          // The LDAP user name
 char[] password;      // The LDAP password
 // ...
 MongoCredential credential = MongoCredential.createPlainCredential(user, "$external", password);
+```
+
+and then construct a MongoClient with that credential.  Using the new (since 3.7) MongoClient API:
+
+```java
+MongoClient mongoClient = MongoClients.create(
+        MongoClientSettings.builder()
+                .applyToClusterSettings(builder -> 
+                        builder.hosts(Arrays.asList(new ServerAddress("host1", 27017))))
+                .credential(credential)
+                .build());
+```
+
+or using the legacy MongoClient API:
+
+```java
 MongoClient mongoClient = new MongoClient(new ServerAddress("host1", 27017), credential);
 ```
-Or use a connection string that explicitly specifies the
-`authMechanism=PLAIN`:
+
+Or use a connection string that explicitly specifies the `authMechanism=PLAIN`.  Using the new MongoClient API:
+                                                                                      
+```java
+MongoClient mongoClient = MongoClients.create("mongodb://user1@host1/?authSource=$external&authMechanism=PLAIN");
+```
+
+or using the legacy MongoClient API:
 
 ```java
 MongoClientURI uri = new MongoClientURI("mongodb://user1@host1/?authSource=$external&authMechanism=PLAIN");

--- a/docs/reference/content/driver/tutorials/change-streams.md
+++ b/docs/reference/content/driver/tutorials/change-streams.md
@@ -25,8 +25,9 @@ to resume if it encounters a potentially recoverable error.
 
 ```java
 import com.mongodb.Block;
-import com.mongodb.MongoClient;
-import com.mongodb.MongoClientURI;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoClient;
+import com.mongodb.ConnectionString;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.changestream.FullDocument;
@@ -53,7 +54,7 @@ For example, include the following code to connect to a replicaSet MongoDB deplo
 It also defines `database` to refer to the `test` database and `collection` to refer to the `restaurants` collection.
 
 ```java
-MongoClient mongoClient = new MongoClient(new MongoClientURI("mongodb://localhost:27017,localhost:27018,localhost:27019"));
+MongoClient mongoClient = MongoClients.create(new ConnectionString("mongodb://localhost:27017,localhost:27018,localhost:27019"));
 MongoDatabase database = mongoClient.getDatabase("test");
 MongoCollection<Document> collection = database.getCollection("restaurants");
 ```

--- a/docs/reference/content/driver/tutorials/commands.md
+++ b/docs/reference/content/driver/tutorials/commands.md
@@ -32,7 +32,7 @@ Connect to a MongoDB deployment and declare and define a `MongoDatabase` instanc
 For example, include the following code to connect to a standalone MongoDB deployment running on localhost on port `27017` and define `database` to refer to the `test` database:
 
 ```java
-MongoClient mongoClient = MongoClient.create();
+MongoClient mongoClient = MongoClients.create();
 MongoDatabase database = mongoClient.getDatabase("test");
 ```
 

--- a/docs/reference/content/driver/tutorials/commands.md
+++ b/docs/reference/content/driver/tutorials/commands.md
@@ -19,7 +19,8 @@ Not all commands have a specific helper. However you can run any [MongoDB comman
 - Include the following import statements:
 
      ```java
-     import com.mongodb.MongoClient;
+     import com.mongodb.client.MongoClients;
+     import com.mongodb.client.MongoClient;
      import com.mongodb.client.MongoDatabase;
      import org.bson.Document;
      ```
@@ -31,7 +32,7 @@ Connect to a MongoDB deployment and declare and define a `MongoDatabase` instanc
 For example, include the following code to connect to a standalone MongoDB deployment running on localhost on port `27017` and define `database` to refer to the `test` database:
 
 ```java
-MongoClient mongoClient = new MongoClient();
+MongoClient mongoClient = MongoClient.create();
 MongoDatabase database = mongoClient.getDatabase("test");
 ```
 

--- a/docs/reference/content/driver/tutorials/compression.md
+++ b/docs/reference/content/driver/tutorials/compression.md
@@ -23,31 +23,32 @@ the [ismaster]({{<docsref "reference/command/isMaster/">}}) command response.
 ### Specify compression via `MongoClientURI`
 
 ```java
-import com.mongodb.MongoClientURI;
-import com.mongodb.MongoClient;
+import com.mongodb.ConnectionString;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoClient;
 ```
 
 To specify compression with [`MongoClientURI`]({{<apiref "com/mongodb/MongoClientURI">}}), specify `compressors` as part of the connection
 string, as in:
 
 ```java
-MongoClientURI uri = new MongoClientURI("mongodb://localhost/?compressors=snappy");
-MongoClient mongoClient = new MongoClient(uri);
+ConnectionString connectionString = new ConnectionString("mongodb://localhost/?compressors=snappy");
+MongoClient mongoClient = MongoClients.create(connectionString);
 ```
 
 for Snappy compression, or
 
 ```java
-MongoClientURI uri = new MongoClientURI("mongodb://localhost/?compressors=zlib");
-MongoClient mongoClient = new MongoClient(uri);
+ConnectionString connectionString = new ConnectionString("mongodb://localhost/?compressors=zlib");
+MongoClient mongoClient = MongoClients.create(connectionString);
 ```
 
 for zlib compression, or 
 
 
 ```java
-MongoClientURI uri = new MongoClientURI("mongodb://localhost/?compressors=snappy,zlib");
-MongoClient mongoClient = new MongoClient(uri);
+ConnectionString connectionString = new ConnectionString("mongodb://localhost/?compressors=snappy,zlib");
+MongoClient mongoClient = MongoClients.create(connectionString);
 ```
 
 to configure multiple compressors. 
@@ -62,33 +63,33 @@ import com.mongodb.MongoCompressor;
 import java.util.Arrays;
 ```
 
-To specify compression with [`MongoClientOptions`]({{<apiref "com/mongodb/MongoClientOptions">}}), set the `compressors` property 
+To specify compression with [`MongoClientSettings`]({{<apiref "com/mongodb/MongoClientSettings">}}), set the `compressors` property 
 to a list of `MongoCompressor` instances:
 
 ```java
- MongoClientOptions options = MongoClientOptions.builder()
-                                                .compressorList(Arrays.asList(MongoCompressor.createSnappyCompressor()))
-                                                .build();
- MongoClient client = new MongoClient("localhost", options);
+MongoClientSettings settings = MongoClientSettings.builder()
+        .compressorList(Arrays.asList(MongoCompressor.createSnappyCompressor()))
+        .build();
+MongoClient client = MongoClients.create(settings);
 ```
 
 for Snappy compression, or
 
 ```java
- MongoClientOptions options = MongoClientOptions.builder()
-                                                .compressorList(Arrays.asList(MongoCompressor.createZlibCompressor()))
-                                                .build();
- MongoClient client = new MongoClient("localhost", options);
+MongoClientSettings settings = MongoClientSettings.builder()
+        .compressorList(Arrays.asList(MongoCompressor.createZlibCompressor()))
+        .build();
+MongoClient client = MongoClients.create(settings);
 ```
 
 for zlib compression, or
 
 ```java
- MongoClientOptions options = MongoClientOptions.builder()
-                                                .compressorList(Arrays.asList(MongoCompressor.createSnappyCompressor(), 
-                                                                              MongoCompressor.createZlibCompressor()))
-                                                .build();
- MongoClient client = new MongoClient("localhost", options);
+MongoClientSettings settings = MongoClientSettings.builder()
+        .compressorList(Arrays.asList(MongoCompressor.createSnappyCompressor(),
+                                      MongoCompressor.createZlibCompressor()))
+        .build();
+MongoClient client = MongoClients.create(settings);
 ```
 
 to configure multiple compressors. 

--- a/docs/reference/content/driver/tutorials/connect-to-mongodb.md
+++ b/docs/reference/content/driver/tutorials/connect-to-mongodb.md
@@ -10,13 +10,15 @@ title = "Connect to MongoDB"
 
 ## Connect to MongoDB
 
-Use [`MongoClient()`]({{< apiref "com/mongodb/MongoClient.html">}}) to make a connection to a running MongoDB instance.
+Use [`MongoClients.create()`]({{< apiref "com/mongodb/client/MongoClients.html">}}) (as of the 3.7 release), or 
+[`MongoClient()`]({{< apiref "com/mongodb/MongoClient .html">}}) for the legacy MongoClient API, to make a connection to a running MongoDB instance.
 
 {{% note class="important" %}}
 The following examples are not meant to provide an exhaustive list
-of ways to instantiate `MongoClient`. For a complete list of the
-MongoClient constructors, see
-[`MongoClient() API documentation`]({{< apiref "com/mongodb/MongoClient.html">}}).
+of ways to instantiate `MongoClient`. For a complete list of MongoClients factory methods, see the 
+[`MongoClients API documentation`]({{< apiref "com/mongodb/client/MongoClient.html">}}), or for the legacy MongoClient API see 
+the [`MongoClient() API documentation`]({{< apiref "com/mongodb/MongoClient.html">}}).
+
 {{% /note %}}
 
 {{% note %}}
@@ -36,21 +38,193 @@ documentation for more information.
 
 - The following import statements:
 
-    ```java
-    import com.mongodb.MongoClient;
-    import com.mongodb.MongoClientURI;
-    import com.mongodb.ServerAddress;
-    import com.mongodb.MongoCredential;
-    import com.mongodb.MongoClientOptions;
+```java
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoClient;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.ConnectionString;
+import com.mongodb.ServerAddress;
+import com.mongodb.MongoCredential;
+import com.mongodb.MongoClientOptions;
 
-    import java.util.Arrays;
+import java.util.Arrays;
+```
+
+or for the legacy MongoClient API:
+
+```java
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientURI;
+import com.mongodb.ServerAddress;
+import com.mongodb.MongoCredential;
+import com.mongodb.MongoClientOptions;
+
+import java.util.Arrays;
+```
+
+## `MongoClient` (since 3.7 release)
+
+A [`MongoClient`]({{< apiref "com/mongodb/client/MongoClient.html">}}) instance represents a pool of connections
+to the database; you will only need one instance of class `MongoClient` even with multiple threads.
+
+{{% note class="important" %}}
+
+Typically you only create one `MongoClient` instance for a given MongoDB deployment (e.g. standalone, replica set, or a sharded cluster)
+ and use it across your application. However, if you do create multiple instances:
+
+ - All resource usage limits (e.g. max connections, etc.) apply per `MongoClient` instance.
+
+ - To dispose of an instance, call `MongoClient.close()` to clean up resources.
+{{% /note %}}
+
+## Connect to a Standalone MongoDB Instance
+
+To connect to a standalone MongoDB instance:
+
+- You can create a `MongoClient` object without any parameters to
+  connect to a MongoDB instance running on localhost on port `27017`:
+
+```java
+    MongoClient mongoClient = MongoClients.create()
+```
+
+- You can explicitly specify the hostname to connect to a MongoDB
+  instance running on the specified host on port `27017`:
+
+```java
+    MongoClient mongoClient = MongoClients.create("mongodb://host1");
+```
+
+- You can explicitly specify the hostname and the port:
+
+    ```java
+    MongoClient mongoClient = MongoClients.create("mongodb://host1:27017");
     ```
 
-## `MongoClient`
+## Connect to a Replica Set
 
-The [`MongoClient()`]({{< apiref "com/mongodb/MongoClient.html">}}) instance represents a pool of connections
-to the database; you will only need one instance of class
-`MongoClient` even with multiple threads.
+To connect to a [replica set]({{<docsref "replication/">}}), you must specify one or more members to the `MongoClients` create method.
+
+{{% note %}}
+MongoDB will auto-discover the primary and the secondaries.
+{{% /note %}}
+
+- You can specify the members using a [`ConnectionString`]({{< apiref "/com/mongodb/ConnectionString.html">}}):
+
+  - To specify at least two members of the replica set:
+
+```java
+    MongoClient mongoClient = MongoClients.create("mongodb://host1:27017,host2:27017,host3:27017");
+```
+
+  - With at least one member of the replica set and the `replicaSet` option specifying the replica set name:
+
+```java
+    MongoClient mongoClient = MongoClients.create("mongodb://host1:27017,host2:27017,host3:27017/?replicaSet=myReplicaSet");
+```
+
+- You can specify a list of the all the replica set members' [`ServerAddress`]({{<apiref "com/mongodb/ServerAddress.html">}}):
+
+```java
+    MongoClient mongoClient = MongoClients.create(
+            MongoClientSettings.builder()
+                    .applyToClusterSettings(builder ->
+                            builder.hosts(Arrays.asList(
+                                    new ServerAddress("host1", 27017),
+                                    new ServerAddress("host2", 27017),
+                                    new ServerAddress("host3", 27017))))
+                    .build());
+```
+
+
+## Connect to a Sharded Cluster
+
+To connect to a [sharded cluster]({{<docsref "sharding/">}}), specify the `mongos` instance
+or instances to a `MongoClients` create method.
+
+To connect to a single `mongos` instance:
+
+- You can specify the hostname and the port in a [`ConnectionString`]({{< apiref "/com/mongodb/ConnectionString.html">}})
+
+```java
+    MongoClient mongoClient = MongoClients.create( "mongodb://localhost:27017" );
+```
+
+or leave the connection string out if the `mongos` is running on localhost:27017:
+
+```java
+    MongoClient mongoClient = MongoClients.create();
+```
+
+To connect to multiple `mongos` instances:
+
+- You can specify the [`ConnectionString`]({{< apiref "/com/mongodb/ConnectionString.html">}}) with their hostnames and ports:
+
+    ```java
+    MongoClient mongoClient = MongoClients.create("mongodb://host1:27017,host2:27017");
+    ```
+
+- You can specify a list of the `mongos` instances' [`ServerAddress`]({{ <apiref "com/mongodb/ServerAddress.html">}}):
+
+```java
+    MongoClient mongoClient = MongoClients.create(
+            MongoClientSettings.builder()
+                    .applyToClusterSettings(builder ->
+                            builder.hosts(Arrays.asList(
+                                    new ServerAddress("host1", 27017),
+                                    new ServerAddress("host2", 27017))))
+                    .build());
+```
+
+## Connection Options
+
+You can specify the connection settings using either the
+`ConnectionString` or `MongoClientSettings` or both.
+
+For example, you can specify TLS/SSL and authentication setting in the
+`MongoClientURI` connection string:
+
+```java
+    MongoClient mongoClient = MongoClients.create("mongodb://user1:pwd1@host1/?authSource=db1&ssl=true");
+```
+
+You can also use `MongoClientSettings` to specify TLS/SSL and the `MongoCredential` for the authentication information:
+
+```java
+    String user; // the user name
+    String database; // the name of the database in which the user is defined
+    char[] password; // the password as a character array
+    // ...
+
+    MongoCredential credential = MongoCredential.createCredential(user, database, password);
+
+    MongoClientSettings settings = MongoClientSettings.builder()
+            .credential(credential)
+            .applyToSslSettings(builder -> builder.enabled(true))
+            .applyToClusterSettings(builder -> 
+                builder.hosts(Arrays.asList(new ServerAddress("host1", 27017))))
+            .build();
+
+    MongoClient mongoClient = MongoClients.create(settings);
+```
+
+Finally, in some cases you may need to combine a connection string with programmatic configuration:
+
+```java
+    ConnectionString connectionString = new ConnectionString("mongodb://host1:27107,host2:27017/?ssl=true");
+    CommandListener myCommandListener = ...;
+    MongoClientSettings settings = MongoClientSettings.builder()
+            .addCommandListener(myCommandListener)
+            .applyConnectionString(connectionString)
+            .build();
+
+    MongoClient mongoClient = MongoClients.create(settings);
+```
+
+## `MongoClient` (legacy API)
+
+A [`MongoClient`]({{< apiref "com/mongodb/MongoClient.html">}}) instance represents a pool of connections
+to the database; you will only need one instance of class `MongoClient` even with multiple threads.
 
 {{% note class="important" %}}
 

--- a/docs/reference/content/driver/tutorials/databases-collections.md
+++ b/docs/reference/content/driver/tutorials/databases-collections.md
@@ -16,7 +16,8 @@ MongoDB stores documents in collections; the collections in databases.
 - Include following import statements:
 
     ```java
-    import com.mongodb.MongoClient;
+    import com.mongodb.client.MongoClients;
+    import com.mongodb.client.MongoClient;
     import com.mongodb.client.MongoCollection;
     import com.mongodb.client.MongoDatabase;
     import static com.mongodb.client.model.Filters.*;
@@ -31,7 +32,7 @@ Connect to a running MongoDB deployment.
 For example, include the following code to connect to a standalone MongoDB deployment running on localhost on port `27017`.
 
 ```java
-MongoClient mongoClient = new MongoClient();
+MongoClient mongoClient = MongoClients.create();
 ```
 
 For more information on connecting to running MongoDB deployments, see
@@ -185,12 +186,12 @@ that with a `CodecRegistry`.
 // Replaces the default UuidCodec with one that uses the new standard UUID representation
 CodecRegistry codecRegistry =
 CodecRegistries.fromRegistries(CodecRegistries.fromCodecs(new UuidCodec(UuidRepresentation.STANDARD)),
-                               MongoClient.getDefaultCodecRegistry());
+                               MongoClientSettings.getDefaultCodecRegistry());
 
 // globally
-MongoClientOptions options = MongoClientOptions.builder()
-                                                .codecRegistry(codecRegistry).build();
-MongoClient client = new MongoClient(new ServerAddress(), options);  
+MongoClientSettings settings = MongoClientSettings.builder()
+        .codecRegistry(codecRegistry).build();
+MongoClient client = MongoClients.create(settings);
 
 // or per database
 MongoDatabase database = client.getDatabase("mydb")

--- a/docs/reference/content/driver/tutorials/geospatial-search.md
+++ b/docs/reference/content/driver/tutorials/geospatial-search.md
@@ -20,7 +20,8 @@ To support geospatial queries, MongoDB provides various geospatial indexes as we
 
      ```java
      import com.mongodb.Block;
-     import com.mongodb.MongoClient;
+     import com.mongodb.client.MongoClients;
+     import com.mongodb.client.MongoClient;
      import com.mongodb.client.MongoCollection;
      import com.mongodb.client.MongoDatabase;
      import com.mongodb.client.MongoCursor;
@@ -48,7 +49,7 @@ Connect to a MongoDB deployment and declare and define a `MongoDatabase` instanc
 For example, include the following code to connect to a standalone MongoDB deployment running on localhost on port `27017` and define `database` to refer to the `test` database:
 
 ```java
-MongoClient mongoClient = new MongoClient();
+MongoClient mongoClient = MongoClients.create();
 MongoDatabase database = mongoClient.getDatabase("test");
 ```
 

--- a/docs/reference/content/driver/tutorials/gridfs.md
+++ b/docs/reference/content/driver/tutorials/gridfs.md
@@ -24,7 +24,8 @@ Include the following import statements:
 
 ```java
 import com.mongodb.Block;
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.gridfs.*;
 import com.mongodb.client.gridfs.model.*;
@@ -43,7 +44,7 @@ Connect to a MongoDB deployment and declare and define a `MongoDatabase` instanc
 For example, include the following code to connect to a standalone MongoDB deployment running on localhost on port `27017`:
 
 ```java
-MongoClient mongoClient = new MongoClient();
+MongoClient mongoClient = MongoClients.create();
 ```
 
 For additional information on connecting to MongoDB, see [Connect to MongoDB]({{< ref "connect-to-mongodb.md">}}).

--- a/docs/reference/content/driver/tutorials/indexes.md
+++ b/docs/reference/content/driver/tutorials/indexes.md
@@ -26,7 +26,8 @@ MongoDB only creates an index if an index of the same specification does not alr
 - Include the following import statements:
 
      ```java
-     import com.mongodb.MongoClient;
+     import com.mongodb.client.MongoClient;
+     import com.mongodb.client.MongoClients;
      import com.mongodb.client.MongoDatabase;
      import com.mongodb.client.MongoCollection;
      import org.bson.Document;
@@ -43,7 +44,7 @@ Connect to a MongoDB deployment and declare and define a `MongoDatabase` and a `
 For example, include the following code to connect to a standalone MongoDB deployment running on localhost on port `27017` and define `database` to refer to the `test` database and `collection` to refer to the `restaurants` collection:
 
 ```java
-MongoClient mongoClient = new MongoClient();
+MongoClient mongoClient = MongoClients.create();
 MongoDatabase database = mongoClient.getDatabase("test");
 MongoCollection<Document> collection = database.getCollection("restaurants");
 ```

--- a/docs/reference/content/driver/tutorials/jndi.md
+++ b/docs/reference/content/driver/tutorials/jndi.md
@@ -28,7 +28,7 @@ The configuration of the `MongoClientFactory` differs depending on the applicati
 
         <module xmlns="urn:jboss:module:1.3" name="org.mongodb">
            <resources>
-               <resource-root path="mongo-java-driver-3.6.0.jar"/>
+               <resource-root path="mongo-java-driver-3.7.0.jar"/>
            </resources>
            <dependencies>
                <module name="javax.api"/>

--- a/docs/reference/content/driver/tutorials/perform-read-operations.md
+++ b/docs/reference/content/driver/tutorials/perform-read-operations.md
@@ -20,7 +20,8 @@ Find operations retrieve documents from a collection. You can specify a filter t
 
      ```java
      import com.mongodb.*;
-     import com.mongodb.MongoClient;
+     import com.mongodb.client.MongoClients;
+     import com.mongodb.client.MongoClient;
      import com.mongodb.client.MongoCollection;
      import com.mongodb.client.MongoDatabase;
      import com.mongodb.client.model.Projections;
@@ -50,7 +51,7 @@ Connect to a MongoDB deployment and declare and define a `MongoDatabase` instanc
 For example, include the following code to connect to a standalone MongoDB deployment running on localhost on port `27017` and define `database` to refer to the `test` database and `collection` to refer to the `restaurants` collection:
 
 ```java
-MongoClient mongoClient = new MongoClient();
+MongoClient mongoClient = MongoClients.create();
 MongoDatabase database = mongoClient.getDatabase("test");
 MongoCollection<Document> collection = database.getCollection("restaurants");
 ```
@@ -195,23 +196,21 @@ The [`MongoIterable`]({{< apiref "com/mongodb/client/MongoIterable.html" >}}) in
 
 For read operations on [replica sets]({{<docsref "replication/">}}) or [sharded clusters]({{<docsref "sharding/">}}), applications can configure the [read preference]({{<docsref "reference/read-preference">}}) at three levels:
 
-- In a [`MongoClient()`]({{< apiref "com/mongodb/MongoClient.html">}})
+- In a [`MongoClient()`]({{< apiref "com/mongodb/client/MongoClient.html">}})
 
-  - Via [`MongoClientOptions`]({{<apiref "com/mongodb/MongoClientOptions.html">}}):
+  - Via [`MongoClientSettings`]({{<apiref "com/mongodb/MongoClientSettings.html">}}):
 
       ```java
-      MongoClientOptions options = MongoClientOptions.builder().readPreference(
-                                      ReadPreference.secondary()).build();
-      MongoClient mongoClient = new MongoClient(Arrays.asList(
-                                      new ServerAddress("host1", 27017),
-                                      new ServerAddress("host2", 27017)), options);
+      MongoClient mongoClient = MongoClients.create(MongoClientSettings.builder()
+                                                    .applyConnectionString(new ConnectionString("mongodb://host1,host2"))
+                                                    .readPreference(ReadPreference.secondary())
+                                                    .build());
       ```
 
-  - Via [`MongoClientURI`]({{< apiref "/com/mongodb/MongoClientURI.html">}}), as in the following example:
+  - Via [`ConnectionString`]({{< apiref "/com/mongodb/ConnectionString.html">}}), as in the following example:
 
       ```java
-      MongoClient mongoClient = new MongoClient(
-        new MongoClientURI("mongodb://host1:27017,host2:27017/?readPreference=secondary"));
+      MongoClient mongoClient = MongoClients.create("mongodb://host1:27017,host2:27017/?readPreference=secondary");
       ```
 
 - In a [`MongoDatabase`]({{<apiref "com/mongodb/client/MongoDatabase.html">}}) via its [`withReadPreference`]({{<apiref "com/mongodb/client/MongoDatabase.html#withReadPreference-com.mongodb.ReadPreference-">}}) method.
@@ -233,7 +232,7 @@ For read operations on [replica sets]({{<docsref "replication/">}}) or [sharded 
 For example, in the following, the `collectionWithReadPref` instance has the read preference of primaryPreferred whereas the read preference of the `collection` is unaffected.
 
 ```java
-  MongoCollection<Document> collectionWithReadPref =  collection.withReadPreference(ReadPreference.primaryPreferred());
+  MongoCollection<Document> collectionWithReadPref = collection.withReadPreference(ReadPreference.primaryPreferred());
 ```
 
 ## Read Concern

--- a/docs/reference/content/driver/tutorials/perform-write-operations.md
+++ b/docs/reference/content/driver/tutorials/perform-write-operations.md
@@ -20,7 +20,8 @@ Perform write operations to insert new documents into a collection, update exist
 
      ```java
      import com.mongodb.*;
-     import com.mongodb.MongoClient;
+     import com.mongodb.client.MongoClients;
+     import com.mongodb.clientMongoClient;
      import com.mongodb.client.MongoCollection;
      import com.mongodb.client.MongoDatabase;
      import com.mongodb.client.model.Filters;
@@ -43,7 +44,7 @@ Connect to a MongoDB deployment and declare and define a `MongoDatabase` instanc
 For example, include the following code to connect to a standalone MongoDB deployment running on localhost on port `27017` and define `database` to refer to the `test` database and `collection` to refer to the `restaurants` collection:
 
 ```java
-MongoClient mongoClient = new MongoClient();
+MongoClient mongoClient = MongoClients.create();
 MongoDatabase database = mongoClient.getDatabase("test");
 MongoCollection<Document> collection = database.getCollection("restaurants");
 ```

--- a/docs/reference/content/driver/tutorials/ssl.md
+++ b/docs/reference/content/driver/tutorials/ssl.md
@@ -11,14 +11,77 @@ title = "TLS/SSL"
 ## TLS/SSL
 
 The Java driver supports TLS/SSL connections to MongoDB servers using
-the underlying support for TLS/SSL provided by the JDK. You can
-configure the driver to use TLS/SSL either with [`MongoClientURI`]({{<apiref "com/mongodb/MongoClientURI">}}) or with
+the underlying support for TLS/SSL provided by the JDK. 
+You can configure the driver to use TLS/SSL either with [`ConnectionString`]({{<apiref "com/mongodb/ConnectionString">}}) or with
+[`MongoClientSettings`]({{<apiref "com/mongodb/MongoClientSettings">}}).
+With the legacy MongoClient API you can use either [`MongoClientURI`]({{<apiref "com/mongodb/MongoClientURI">}}) or 
 [`MongoClientOptions`]({{<apiref "com/mongodb/MongoClientOptions">}}).
 
-## Specify TLS/SSL via `MongoClientURI`
+## MongoClient API (since 3.7)
+
+### Specify TLS/SSL via `ConnectionString`
+
+```java
+com.mongodb.client.MongoClients;
+com.mongodb.client.MongoClient;
+```
+
+To specify TLS/SSL with [`ConnectionString`]({{<apiref "com/mongodb/ConnectionString">}}), specify `ssl=true` as part of the connection
+string, as in:
+
+```java
+MongoClient mongoClient = MongoClients.create("mongodb://localhost/?ssl=true");
+```
+
+### Specify TLS/SSL via `MongoClientSettings`
+
+```java
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoClient;
+```
+
+To specify TLS/SSL with with [`MongoClientSettings`]({{<apiref "com/mongodb/MongoClientSettings">}}), set the `enabled` property to 
+`true`, as in:
+
+```java
+MongoClientSettings settings = MongoClientSettings.builder()
+        .applyToSslSettings(builder -> 
+            builder.enabled(true))
+        .build();
+MongoClient client = MongoClients.create(settings);
+```
+
+### Specify `SSLContext` via `MongoClientSettings`
+
+```java
+import javax.net.ssl.SSLContext;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoClient;
+```
+
+To specify the [`javax.net.ssl.SSLContext`](https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLContext.html) with 
+[`MongoClientOptions`]({{<apiref "com/mongodb/MongoClientOptions">}}), set the `sslContext` property, as in:
+
+```java
+SSLContext sslContext = ...
+MongoClientSettings settings = MongoClientSettings.builder()
+        .applyToSslSettings(builder -> {
+                    builder.enabled(true);
+                    builder.context(sslContext);
+                })
+        .build();
+MongoClient client = MongoClients.create(settings);
+```
+
+## Legacy MongoClient API
+
+### Specify TLS/SSL via `MongoClientURI`
 
 ```java
 import com.mongodb.MongoClientURI;
+import com.mongodb.MongoClient;
 ```
 
 To specify TLS/SSL with [`MongoClientURI`]({{<apiref "com/mongodb/MongoClientURI">}}), specify `ssl=true` as part of the connection
@@ -29,20 +92,23 @@ MongoClientURI uri = new MongoClientURI("mongodb://localhost/?ssl=true");
 MongoClient mongoClient = new MongoClient(uri);
 ```
 
-## Specify TLS/SSL via `MongoClientOptions`
+### Specify TLS/SSL via `MongoClientOptions`
 
 ```java
 import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoClient;
 ```
 
 To specify TLS/SSL with with [`MongoClientOptions`]({{<apiref "com/mongodb/MongoClientOptions">}}), set the `sslEnabled` property to `true`, as in:
 
 ```java
- MongoClientOptions options = MongoClientOptions.builder().sslEnabled(true).build();
- MongoClient client = new MongoClient("localhost", options);
+MongoClientOptions options = MongoClientOptions.builder()
+        .sslEnabled(true)
+        .build();
+MongoClient client = new MongoClient("localhost", options);
 ```
 
-## Specify `SSLContext` via `MongoClientOptions`
+### Specify `SSLContext` via `MongoClientOptions`
 
 ```java
 import javax.net.ssl.SSLContext;
@@ -54,11 +120,11 @@ To specify the [`javax.net.ssl.SSLContext`](https://docs.oracle.com/javase/8/doc
 [`MongoClientOptions`]({{<apiref "com/mongodb/MongoClientOptions">}}), set the `sslContext` property, as in:
 
 ```java
- SSLContext sslContext = ...
- MongoClientOptions options = MongoClientOptions.builder()
-                                                .sslEnabled(true)
-                                                .sslContext(sslContext)
-                                                .build();
+SSLContext sslContext = ...
+MongoClientOptions options = MongoClientOptions.builder()
+        .sslEnabled(true)
+        .sslContext(sslContext)
+        .build();
  MongoClient client = new MongoClient("localhost", options);
 ```
 
@@ -72,11 +138,24 @@ to the `javax.net.SSLParameters` class.
 
 If your application must run on Java 6, or for some other reason you
 need to disable hostname verification, you must explicitly indicate
-this in [`MongoClientOptions`]({{<apiref "com/mongodb/MongoClientOptions">}}) using the `sslInvalidHostNameAllowed`
-property:
+this in `MongoClientSettings`]({{<apiref "com/mongodb/MongoClientSettings">}}) 
 
 ```java
-MongoClientOptions.builder().sslEnabled(true).sslInvalidHostNameAllowed(true).build();
+MongoClientSettings settings = MongoClientSettings.builder()
+        .applyToSslSettings(builder -> {
+                    builder.enabled(true);
+                    builder.invalidHostNameAllowed(true);
+                })
+        .build();
+```
+
+or, with the legacy `MongoClientOptions`]({{<apiref "com/mongodb/MongoClientOptions">}}), using the `sslInvalidHostNameAllowed` property:
+
+```java
+MongoClientOptions.builder()
+        .sslEnabled(true)
+        .sslInvalidHostNameAllowed(true)
+        .build();
 ```
 
 ## JVM System Properties for TLS/SSL

--- a/docs/reference/content/driver/tutorials/text-search.md
+++ b/docs/reference/content/driver/tutorials/text-search.md
@@ -22,7 +22,8 @@ The Java driver provides the [`Filters.text()`]({{<apiref "com/mongodb/client/mo
 
      ```java
      import com.mongodb.Block;
-     import com.mongodb.MongoClient;
+     import com.mongodb.client.MongoClients;
+     import com.mongodb.client.MongoClient;
      import com.mongodb.client.MongoCollection;
      import com.mongodb.client.MongoDatabase;
 
@@ -52,7 +53,7 @@ Connect to a MongoDB deployment and declare and define a `MongoDatabase` instanc
 For example, include the following code to connect to a standalone MongoDB deployment running on localhost on port `27017` and define `database` to refer to the `test` database:
 
 ```java
-MongoClient mongoClient = new MongoClient();
+MongoClient mongoClient = MongoClients.create();
 MongoDatabase database = mongoClient.getDatabase("test");
 ```
 

--- a/docs/reference/content/index.md
+++ b/docs/reference/content/index.md
@@ -6,12 +6,12 @@ type = "index"
 
 ## MongoDB Java Driver Documentation
 
-Welcome to the MongoDB Java driver documentation hub for the 3.6 driver release.
+Welcome to the MongoDB Java driver documentation hub for the 3.7 driver release.
 
 
-### What's New in 3.6
+### What's New in 3.7
 
-For key new features of 3.6, see [What's New]({{< relref "whats-new.md" >}}).
+For key new features of 3.7, see [What's New]({{< relref "whats-new.md" >}}).
 
 ### Upgrade
 

--- a/docs/reference/content/upgrading.md
+++ b/docs/reference/content/upgrading.md
@@ -2,14 +2,14 @@
 date = "2015-03-19T12:53:39-04:00"
 title = "Upgrade Considerations"
 [menu.main]
-  identifier = "Upgrading to 3.6"
+  identifier = "Upgrading to 3.7"
   weight = 80
   pre = "<i class='fa fa-level-up'></i>"
 +++
 
-## Upgrading from 3.5.x
+## Upgrading from 3.6.x
 
-The 3.6 release is binary and source compatible with the 3.5 release, except for methods that have been added to interfaces that
+The 3.7 release is binary and source compatible with the 3.5 release, except for methods that have been added to interfaces that
 have been marked as unstable, and changes to classes or interfaces that have been marked as internal or annotated as Beta.
 
 ## Upgrading from 2.x
@@ -32,6 +32,7 @@ The following table specifies the compatibility of the MongoDB Java driver for u
 
 |Java Driver Version|MongoDB 2.6|MongoDB 3.0 |MongoDB 3.2|MongoDB 3.4|MongoDB 3.6|
 |-------------------|-----------|------------|-----------|-----------|-----------|
+|Version 3.7        |  ✓  |  ✓  |  ✓  |  ✓  |  ✓  |
 |Version 3.6        |  ✓  |  ✓  |  ✓  |  ✓  |  ✓  |
 |Version 3.5        |  ✓  |  ✓  |  ✓  |  ✓  |     |
 |Version 3.4        |  ✓  |  ✓  |  ✓  |  ✓  |     |
@@ -44,6 +45,7 @@ The following table specifies the compatibility of the MongoDB Java driver for u
 
 |Java Driver Version|Java 5 | Java 6 | Java 7 | Java 8 |
 |-------------------|-------|--------|--------|--------|
+|Version 3.7        |     | ✓ | ✓ | ✓ |
 |Version 3.6        |     | ✓ | ✓ | ✓ |
 |Version 3.5        |     | ✓ | ✓ | ✓ |
 |Version 3.4        |     | ✓ | ✓ | ✓ |

--- a/docs/reference/content/whats-new.md
+++ b/docs/reference/content/whats-new.md
@@ -11,7 +11,40 @@ title = "What's New"
 
 Key new features of the 3.7 Java driver release:
 
-...
+### Java 9 support
+
+#### Modules
+
+The Java driver now provides a set of JAR files that are compliant with the Java 9 
+[module specification](http://cr.openjdk.java.net/~mr/jigsaw/spec/), and `Automatic-Module-Name` declarations have been added 
+to the manifests of those JAR files. See the [Installation Guide]({{<ref "driver/getting-started/installation.md">}}) 
+for information on which JAR files are now Java 9-compliant modules as well as what each of their module names is.  
+
+Note that it was not possible to modularize all the existing JAR files due to the fact that, for some of them, packages are split amongst 
+multiple JAR files, and this violates a core rule of the Java 9 module system which states that at most one module contains classes for any 
+given package. For instance, the `mongodb-driver` and `mongodb-driver-core` JAR files both contain classes in the `com.mongodb` package, 
+and thus it's not possible to make both `mongodb-driver` and `mongodb-driver-core` Java 9 modules. Also so-called 
+"uber jars" like `mongo-java-driver` are not appropriate for Java 9 modularization, as they can conflict with their non-uber brethren, and 
+thus have not been given module names. 
+
+Note that none of the modular JAR files contain `module-info` class files yet.  Addition of these classes will be considered in a future 
+release.
+
+#### New Entry Point
+
+So that the driver can offer a modular option, a new entry point has been added to the `com.mongodb.client` package. 
+Static methods in this entry point, `com.mongodb.client.MongoClients`, returns instances of a new `com.mongodb.client.MongoClient` 
+interface.  This interface, while similar to the existing `com.mongodb.MongoClient` class in that it is a factory for 
+`com.mongodb.client.MongoDatabase` instances, does not support the legacy `com.mongodb.DBCollection`-based API, and thus does not suffer 
+from the aforementioned package-splitting issue that prevents Java 9 modularization. This new entry point is encapsulated in the new 
+`mongodb-driver-sync` JAR file, which is also a Java 9-compliant module.
+
+The new entry point also moves the driver further in the direction of effective deprecation of the legacy API, which is now only available
+only via the `mongo-java-driver` and `mongodb-driver` uber-jars, which are not Java 9 modules. At this point there are no plans to offer 
+the legacy API as a Java 9 module.
+
+See [Connect To MongoDB]({{<ref "driver/tutorials/connect-to-mongodb.md">}}) for details on the new `com.mongodb.client.MongoClients`
+and how it compares to the existing `com.mongodb.MongoClient` class.   
 
 ## What's New in 3.6
 

--- a/docs/reference/content/whats-new.md
+++ b/docs/reference/content/whats-new.md
@@ -7,6 +7,12 @@ title = "What's New"
   pre = "<i class='fa fa-level-up'></i>"
 +++
 
+## What's New in 3.7
+
+Key new features of the 3.7 Java driver release:
+
+...
+
 ## What's New in 3.6
 
 Key new features of the 3.6 Java driver release:

--- a/docs/reference/data/mongodb.toml
+++ b/docs/reference/data/mongodb.toml
@@ -1,6 +1,6 @@
 # Update versions in config.toml as well
 githubRepo = "mongo-java-driver"
 githubBranch = "master"
-currentVersion = "3.6"
+currentVersion = "3.7"
 highlightTheme = "idea.css"
 apiUrl = "/javadoc"


### PR DESCRIPTION
Pushed to http://jyemin.github.io/mongo-java-driver/3.7/

General strategy: 

* for the pages that are focused on connecting to MongoDB, I show both old and new APIs.  
* for the pages that are focused on running operations, I show only the new API.

A few things I debated:

* I use the work "legacy" to refer to com.mongodb.MongoClient.  I'm not sure if that's a good idea, but not sure what else to call it.  
* I don't call out the new API as "new in 3.7" because we generally don't do that elsewhere for new things, but perhaps it's called for here.  I'll definitely add it to the What's New section though.