### PR TITLE
JAVA-2821:

### DIFF
--- a/driver-core/src/main/com/mongodb/operation/QueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/QueryBatchCursor.java
@@ -277,13 +277,15 @@ class QueryBatchCursor<T> implements BatchCursor<T> {
 
     private void killCursor() {
         if (serverCursor != null) {
-            Connection connection = connectionSource.getConnection();
             try {
-                killCursor(connection);
+                Connection connection = connectionSource.getConnection();
+                try {
+                    killCursor(connection);
+                } finally {
+                    connection.release();
+                }
             } catch (MongoException e) {
                 // Ignore exceptions from calling killCursor
-            } finally {
-                connection.release();
             }
         }
     }


### PR DESCRIPTION
When killing a cursor, exceptions are supposed to be suppressed.  The suppression now includes the attempt to get a connection on which to kill the cursor, which may also fail (e.g. if the server has been killed)