### PR TITLE
JAVA-2789: Document JVM support for TLS v1.1 and newer

### DIFF
--- a/docs/reference/content/driver-async/tutorials/ssl.md
+++ b/docs/reference/content/driver-async/tutorials/ssl.md
@@ -163,18 +163,20 @@ for the driver to make use of the newest TLS protocols, Java runtime environment
 updates:
 
 * Java 7
-  - TSL 1.1 was first enabled by default in
+  - Starting with
     [Update 131](http://www.oracle.com/technetwork/java/javaseproducts/documentation/javase7supportreleasenotes-1601161.html#R170_131),
-    released October 8, 2016.
-  - TLS 1.1 was first enabled via `jdk.tls.client.protocols` system property in
+    released October 8, 2016, TSL 1.1 and TLS 1.2 are enabled by default.
+  - Starting with
     [Update 95](http://www.oracle.com/technetwork/java/javaseproducts/documentation/javase7supportreleasenotes-1601161.html#R170_95),
-    released January 19, 2016.
+    released January 19, 2016, TLS 1.1 and TLS 1.2 can be enabled by applications via the `jdk.tls.client.protocols` system property.
 
 * Java 6
-  - TSL 1.1 was first enabled by default in
-    [Update 141](http://www.oracle.com/technetwork/java/javase/documentation/overview-156328.html#R160_141), released on January 17, 2017.
-  - TLS 1.1 was first enabled via `jdk.tls.client.protocols` system property in
-    [Update 115 b32](http://www.oracle.com/technetwork/java/javase/documentation/overview-156328.html#6u115-b32), released July 19, 2016.
+  - Starting with
+    [Update 141](http://www.oracle.com/technetwork/java/javase/documentation/overview-156328.html#R160_141), released on January 17, 2017,
+    TSL 1.1 and TLS 1.2 are enabled by default.
+  - Starting with
+    [Update 115 b32](http://www.oracle.com/technetwork/java/javase/documentation/overview-156328.html#6u115-b32), released July 19, 2016,
+    TLS 1.1 and TLS 1.2 can be enabled by applications via the `jdk.tls.client.protocols` system property.
 
 Note that these updates are only available from Oracle via its Java SE commercial support program.  Java 7 Update 131
 is available via [OpenJDK](http://openjdk.java.net/install/).

--- a/docs/reference/content/driver-async/tutorials/ssl.md
+++ b/docs/reference/content/driver-async/tutorials/ssl.md
@@ -155,3 +155,26 @@ command line program.
 For more information on configuring a Java application for TLS/SSL, please
 refer to the [`JSSE Reference Guide`](http://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSS
 ERefGuide.html).
+
+## JVM Support for TLS v1.1 and newer
+
+Industry best practices recommend, and some regulations require, the use of TLS 1.1 or newer. Though no application changes are required
+for the driver to make use of the newest TLS protocols, Java runtime environments prior to Java 8 started to enable TLS 1.1 only in later
+updates:
+
+* Java 7
+  - TSL 1.1 was first enabled by default in
+    [Update 131](http://www.oracle.com/technetwork/java/javaseproducts/documentation/javase7supportreleasenotes-1601161.html#R170_131),
+    released October 8, 2016.
+  - TLS 1.1 was first enabled via `jdk.tls.client.protocols` system property in
+    [Update 95](http://www.oracle.com/technetwork/java/javaseproducts/documentation/javase7supportreleasenotes-1601161.html#R170_95),
+    released January 19, 2016.
+
+* Java 6
+  - TSL 1.1 was first enabled by default in
+    [Update 141](http://www.oracle.com/technetwork/java/javase/documentation/overview-156328.html#R160_141), released on January 17, 2017.
+  - TLS 1.1 was first enabled via `jdk.tls.client.protocols` system property in
+    [Update 115 b32](http://www.oracle.com/technetwork/java/javase/documentation/overview-156328.html#6u115-b32), released July 19, 2016.
+
+Note that these updates are only available from Oracle via its Java SE commercial support program.  Java 7 Update 131
+is available via [OpenJDK](http://openjdk.java.net/install/).

--- a/docs/reference/content/driver/tutorials/ssl.md
+++ b/docs/reference/content/driver/tutorials/ssl.md
@@ -205,18 +205,20 @@ for the driver to make use of the newest TLS protocols, Java runtime environment
 updates:
 
 * Java 7
-  - TSL 1.1 was first enabled by default in
+  - Starting with
     [Update 131](http://www.oracle.com/technetwork/java/javaseproducts/documentation/javase7supportreleasenotes-1601161.html#R170_131),
-    released October 8, 2016.
-  - TLS 1.1 was first enabled via `jdk.tls.client.protocols` system property in
+    released October 8, 2016, TSL 1.1 and TLS 1.2 are enabled by default.
+  - Starting with
     [Update 95](http://www.oracle.com/technetwork/java/javaseproducts/documentation/javase7supportreleasenotes-1601161.html#R170_95),
-    released January 19, 2016.
+    released January 19, 2016, TLS 1.1 and TLS 1.2 can be enabled by applications via the `jdk.tls.client.protocols` system property.
 
 * Java 6
-  - TSL 1.1 was first enabled by default in
-    [Update 141](http://www.oracle.com/technetwork/java/javase/documentation/overview-156328.html#R160_141), released on January 17, 2017.
-  - TLS 1.1 was first enabled via `jdk.tls.client.protocols` system property in
-    [Update 115 b32](http://www.oracle.com/technetwork/java/javase/documentation/overview-156328.html#6u115-b32), released July 19, 2016.
+  - Starting with
+    [Update 141](http://www.oracle.com/technetwork/java/javase/documentation/overview-156328.html#R160_141), released on January 17, 2017,
+    TSL 1.1 and TLS 1.2 are enabled by default.
+  - Starting with
+    [Update 115 b32](http://www.oracle.com/technetwork/java/javase/documentation/overview-156328.html#6u115-b32), released July 19, 2016,
+    TLS 1.1 and TLS 1.2 can be enabled by applications via the `jdk.tls.client.protocols` system property.
 
 Note that these updates are only available from Oracle via its Java SE commercial support program.  Java 7 Update 131
 is available via [OpenJDK](http://openjdk.java.net/install/).

--- a/docs/reference/content/driver/tutorials/ssl.md
+++ b/docs/reference/content/driver/tutorials/ssl.md
@@ -197,3 +197,26 @@ command line program.
 For more information on configuring a Java application for TLS/SSL, please
 refer to the [`JSSE Reference Guide`](http://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSS
 ERefGuide.html).
+
+## JVM Support for TLS v1.1 and newer
+
+Industry best practices recommend, and some regulations require, the use of TLS 1.1 or newer. Though no application changes are required
+for the driver to make use of the newest TLS protocols, Java runtime environments prior to Java 8 started to enable TLS 1.1 only in later
+updates:
+
+* Java 7
+  - TSL 1.1 was first enabled by default in
+    [Update 131](http://www.oracle.com/technetwork/java/javaseproducts/documentation/javase7supportreleasenotes-1601161.html#R170_131),
+    released October 8, 2016.
+  - TLS 1.1 was first enabled via `jdk.tls.client.protocols` system property in
+    [Update 95](http://www.oracle.com/technetwork/java/javaseproducts/documentation/javase7supportreleasenotes-1601161.html#R170_95),
+    released January 19, 2016.
+
+* Java 6
+  - TSL 1.1 was first enabled by default in
+    [Update 141](http://www.oracle.com/technetwork/java/javase/documentation/overview-156328.html#R160_141), released on January 17, 2017.
+  - TLS 1.1 was first enabled via `jdk.tls.client.protocols` system property in
+    [Update 115 b32](http://www.oracle.com/technetwork/java/javase/documentation/overview-156328.html#6u115-b32), released July 19, 2016.
+
+Note that these updates are only available from Oracle via its Java SE commercial support program.  Java 7 Update 131
+is available via [OpenJDK](http://openjdk.java.net/install/).


### PR DESCRIPTION
Published to: [sync ssl guide](http://jyemin.github.io/mongo-java-driver/3.7/driver/tutorials/ssl/#jvm-support-for-tls-v1-1-and-newer) and [async ssl guide](http://jyemin.github.io/mongo-java-driver/3.7/driver-async/tutorials/ssl/#jvm-support-for-tls-v1-1-and-newer)