### PR TITLE
Tests SSL on latest server with Java 8

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -522,7 +522,15 @@ buildvariants:
      - name: "test"
 
 - matrix_name: "tests-jdk6-secure"
-  matrix_spec: { auth: "auth", ssl: "ssl", jdk: "jdk6", version: "*", topology: "*", os: "*" }
+  matrix_spec:  { auth: "auth", ssl: "ssl", jdk: "jdk6", version: "*", topology: "*", os: "*" }
+  exclude_spec: { auth: "auth", ssl: "ssl", jdk: "jdk6", version: "latest", topology: "*", os: "*" }
+  display_name: "${version} ${topology} ${auth} ${ssl} ${jdk} ${os} "
+  tags: ["tests-variant"]
+  tasks:
+     - name: "test"
+
+- matrix_name: "tests-jdk8-secure"
+  matrix_spec: { auth: "auth", ssl: "ssl", jdk: "jdk8", version: ["latest"], topology: "*", os: "*" }
   display_name: "${version} ${topology} ${auth} ${ssl} ${jdk} ${os} "
   tags: ["tests-variant"]
   tasks:


### PR DESCRIPTION
MongoDB 4.0 by default enables only TLS 1.1 and 1.2, which only work by
default with Java 8 and above.  This ensures that Java 8 is used to test
SSL for the latest server.