### PR TITLE
JAVA-2815: Conform to transactions specification for options

### DIFF
--- a/driver-core/src/main/com/mongodb/ClientSessionOptions.java
+++ b/driver-core/src/main/com/mongodb/ClientSessionOptions.java
@@ -124,6 +124,21 @@ public final class ClientSessionOptions {
     }
 
     /**
+     * Gets an instance of a builder initialized with the given options
+     *
+     * @param options the options with which to initialize the builder
+     * @return a builder instance
+     * @since 3.8
+     */
+    public static Builder builder(final ClientSessionOptions options) {
+        Builder builder = new Builder();
+        builder.causallyConsistent = options.isCausallyConsistent();
+        builder.autoStartTransaction = options.getAutoStartTransaction();
+        builder.defaultTransactionOptions = options.getDefaultTransactionOptions();
+        return builder;
+    }
+
+    /**
      * A builder for instances of {@code ClientSession}
      */
     @NotThreadSafe

--- a/driver-core/src/main/com/mongodb/ClientSessionOptions.java
+++ b/driver-core/src/main/com/mongodb/ClientSessionOptions.java
@@ -131,6 +131,7 @@ public final class ClientSessionOptions {
      * @since 3.8
      */
     public static Builder builder(final ClientSessionOptions options) {
+        notNull("options", options);
         Builder builder = new Builder();
         builder.causallyConsistent = options.isCausallyConsistent();
         builder.autoStartTransaction = options.getAutoStartTransaction();

--- a/driver-core/src/main/com/mongodb/TransactionOptions.java
+++ b/driver-core/src/main/com/mongodb/TransactionOptions.java
@@ -63,6 +63,22 @@ public final class TransactionOptions {
         return new Builder();
     }
 
+    /**
+     * Merge the two provided transaction options, with the first taking precedence over the second.
+     *
+     * @param options the transaction options, which take precedence for any property that is non-null
+     * @param defaultOptions the default transaction options
+     * @return the merged transaction optoins
+     */
+    public static TransactionOptions merge(final TransactionOptions options, final TransactionOptions defaultOptions) {
+        return TransactionOptions.builder()
+                .writeConcern(options.getWriteConcern() == null
+                        ? defaultOptions.getWriteConcern() : options.getWriteConcern())
+                .readConcern(options.getReadConcern() == null
+                        ? defaultOptions.getReadConcern() : options.getReadConcern())
+                .build();
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {

--- a/driver-core/src/main/com/mongodb/TransactionOptions.java
+++ b/driver-core/src/main/com/mongodb/TransactionOptions.java
@@ -20,6 +20,7 @@ import com.mongodb.annotations.Immutable;
 import com.mongodb.lang.Nullable;
 
 import static com.mongodb.assertions.Assertions.isTrueArgument;
+import static com.mongodb.assertions.Assertions.notNull;
 
 /**
  * Options to apply to transactions.
@@ -68,9 +69,11 @@ public final class TransactionOptions {
      *
      * @param options the transaction options, which take precedence for any property that is non-null
      * @param defaultOptions the default transaction options
-     * @return the merged transaction optoins
+     * @return the merged transaction options
      */
     public static TransactionOptions merge(final TransactionOptions options, final TransactionOptions defaultOptions) {
+        notNull("options", options);
+        notNull("defaultOptions", defaultOptions);
         return TransactionOptions.builder()
                 .writeConcern(options.getWriteConcern() == null
                         ? defaultOptions.getWriteConcern() : options.getWriteConcern())

--- a/driver-core/src/main/com/mongodb/TransactionOptions.java
+++ b/driver-core/src/main/com/mongodb/TransactionOptions.java
@@ -17,9 +17,9 @@
 package com.mongodb;
 
 import com.mongodb.annotations.Immutable;
+import com.mongodb.lang.Nullable;
 
 import static com.mongodb.assertions.Assertions.isTrueArgument;
-import static com.mongodb.assertions.Assertions.notNull;
 
 /**
  * Options to apply to transactions.
@@ -39,6 +39,7 @@ public final class TransactionOptions {
      *
      * @return the read concern, which defaults to {@link ReadConcern#SNAPSHOT}
      */
+    @Nullable
     public ReadConcern getReadConcern() {
         return readConcern;
     }
@@ -48,6 +49,7 @@ public final class TransactionOptions {
      *
      * @return the write concern, which defaults to {@link WriteConcern#ACKNOWLEDGED}
      */
+    @Nullable
     public WriteConcern getWriteConcern() {
         return writeConcern;
     }
@@ -100,8 +102,8 @@ public final class TransactionOptions {
      * The builder for transaction options
      */
     public static final class Builder {
-        private ReadConcern readConcern = ReadConcern.SNAPSHOT;
-        private WriteConcern writeConcern = WriteConcern.ACKNOWLEDGED;
+        private ReadConcern readConcern;
+        private WriteConcern writeConcern;
 
         /**
          * Sets the read concern.
@@ -109,8 +111,8 @@ public final class TransactionOptions {
          * @param readConcern the read concern
          * @return this
          */
-        public Builder readConcern(final ReadConcern readConcern) {
-            this.readConcern = notNull("readConcern", readConcern);
+        public Builder readConcern(@Nullable final ReadConcern readConcern) {
+            this.readConcern = readConcern;
             return this;
         }
 
@@ -120,9 +122,9 @@ public final class TransactionOptions {
          * @param writeConcern the write concern, which must be acknowledged
          * @return this
          */
-        public Builder writeConcern(final WriteConcern writeConcern) {
-            this.writeConcern = notNull("writeConcern", writeConcern);
-            isTrueArgument("acknowleded write concern", writeConcern.isAcknowledged());
+        public Builder writeConcern(@Nullable final WriteConcern writeConcern) {
+            this.writeConcern = writeConcern;
+            isTrueArgument("acknowledged write concern", writeConcern != null && writeConcern.isAcknowledged());
             return this;
         }
 

--- a/driver-core/src/test/resources/transactions/transaction-options.json
+++ b/driver-core/src/test/resources/transactions/transaction-options.json
@@ -1,0 +1,1188 @@
+{
+  "data": [],
+  "tests": [
+    {
+      "description": "no transaction options set",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 2
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "stmtId": 0,
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "stmtId": 1,
+              "startTransaction": null,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "stmtId": 0,
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "stmtId": 1,
+              "startTransaction": null,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "transaction options inherited from client",
+      "clientOptions": {
+        "w": 1,
+        "readConcernLevel": "local"
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 2
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "stmtId": 0,
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "local"
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "stmtId": 1,
+              "startTransaction": null,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": {
+                "w": 1
+              }
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "stmtId": 0,
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "local",
+                "afterClusterTime": 42
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "stmtId": 1,
+              "startTransaction": null,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": {
+                "w": 1
+              }
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "transaction options inherited from defaultTransactionOptions",
+      "sessionOptions": {
+        "session0": {
+          "defaultTransactionOptions": {
+            "readConcern": {
+              "level": "snapshot"
+            },
+            "writeConcern": {
+              "w": 1
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 2
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "stmtId": 0,
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "stmtId": 1,
+              "startTransaction": null,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": {
+                "w": 1
+              }
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "stmtId": 0,
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "snapshot",
+                "afterClusterTime": 42
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "stmtId": 1,
+              "startTransaction": null,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": {
+                "w": 1
+              }
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "startTransaction options override defaults",
+      "clientOptions": {
+        "readConcernLevel": "local",
+        "w": "1"
+      },
+      "sessionOptions": {
+        "session0": {
+          "defaultTransactionOptions": {
+            "readConcern": {
+              "level": "majority"
+            },
+            "writeConcern": {
+              "w": 1
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0",
+            "options": {
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "writeConcern": {
+                "w": "majority"
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0",
+            "options": {
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "writeConcern": {
+                "w": "majority"
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 2
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "stmtId": 0,
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "stmtId": 1,
+              "startTransaction": null,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": {
+                "w": "majority"
+              }
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "stmtId": 0,
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "snapshot",
+                "afterClusterTime": 42
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "stmtId": 1,
+              "startTransaction": null,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": {
+                "w": "majority"
+              }
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "defaultTransactionOptions override client options",
+      "clientOptions": {
+        "readConcernLevel": "local",
+        "w": "1"
+      },
+      "sessionOptions": {
+        "session0": {
+          "defaultTransactionOptions": {
+            "readConcern": {
+              "level": "snapshot"
+            },
+            "writeConcern": {
+              "w": "majority"
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 2
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "stmtId": 0,
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "stmtId": 1,
+              "startTransaction": null,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": {
+                "w": "majority"
+              }
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "stmtId": 0,
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "snapshot",
+                "afterClusterTime": 42
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "stmtId": 1,
+              "startTransaction": null,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": {
+                "w": "majority"
+              }
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "readConcern local in defaultTransactionOptions",
+      "clientOptions": {
+        "w": 1
+      },
+      "sessionOptions": {
+        "session0": {
+          "defaultTransactionOptions": {
+            "readConcern": {
+              "level": "local"
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 2
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "stmtId": 0,
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "local"
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "stmtId": 1,
+              "startTransaction": null,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": {
+                "w": 1
+              }
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "stmtId": 0,
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "local",
+                "afterClusterTime": 42
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "stmtId": 1,
+              "startTransaction": null,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": {
+                "w": 1
+              }
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "readConcern local in startTransaction options",
+      "sessionOptions": {
+        "session0": {
+          "defaultTransactionOptions": {
+            "readConcern": {
+              "level": "majority"
+            }
+          }
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0",
+            "options": {
+              "readConcern": {
+                "level": "snapshot"
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 1
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0",
+            "options": {
+              "readConcern": {
+                "level": "snapshot"
+              }
+            }
+          }
+        },
+        {
+          "name": "insertOne",
+          "arguments": {
+            "document": {
+              "_id": 2
+            },
+            "session": "session0"
+          },
+          "result": {
+            "insertedId": 2
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "stmtId": 0,
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "snapshot"
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "stmtId": 1,
+              "startTransaction": null,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                }
+              ],
+              "ordered": true,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "stmtId": 0,
+              "startTransaction": true,
+              "autocommit": false,
+              "readConcern": {
+                "level": "snapshot",
+                "afterClusterTime": 42
+              },
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "stmtId": 1,
+              "startTransaction": null,
+              "autocommit": false,
+              "readConcern": null,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/unit/com/mongodb/TransactionOptionsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/TransactionOptionsSpecification.groovy
@@ -39,4 +39,17 @@ class TransactionOptionsSpecification extends Specification {
         options.readConcern == ReadConcern.LOCAL
         options.writeConcern == WriteConcern.JOURNALED
     }
+
+    def 'should merge'() {
+        given:
+        def first = TransactionOptions.builder().build();
+        def second = TransactionOptions.builder().readConcern(ReadConcern.MAJORITY).writeConcern(WriteConcern.MAJORITY).build()
+        def third = TransactionOptions.builder().readConcern(ReadConcern.LOCAL).writeConcern(WriteConcern.W2).build()
+
+        expect:
+        TransactionOptions.merge(first, second) == second
+        TransactionOptions.merge(second, first) == second
+        TransactionOptions.merge(second, third) == second
+        TransactionOptions.merge(third, second) == third
+    }
 }

--- a/driver-core/src/test/unit/com/mongodb/TransactionOptionsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/TransactionOptionsSpecification.groovy
@@ -24,8 +24,8 @@ class TransactionOptionsSpecification extends Specification {
         def options = TransactionOptions.builder().build()
 
         then:
-        options.getReadConcern() == ReadConcern.SNAPSHOT
-        options.getWriteConcern() == WriteConcern.ACKNOWLEDGED
+        options.getReadConcern() == null
+        options.getWriteConcern() == null
     }
 
     def 'should apply options set in builder'() {

--- a/driver-legacy/src/main/com/mongodb/Mongo.java
+++ b/driver-legacy/src/main/com/mongodb/Mongo.java
@@ -797,7 +797,7 @@ public class Mongo {
 
     @Nullable
     ClientSession createClientSession(final ClientSessionOptions options) {
-        return delegate.createClientSession(options);
+        return delegate.createClientSession(options, this.options.getReadConcern(), this.options.getWriteConcern());
     }
 
     private ExecutorService createCursorCleaningService() {

--- a/driver-legacy/src/test/functional/com/mongodb/MongoClientSessionSpecification.groovy
+++ b/driver-legacy/src/test/functional/com/mongodb/MongoClientSessionSpecification.groovy
@@ -68,7 +68,12 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         expect:
         clientSession.getOriginator() == getMongoClient()
         clientSession.isCausallyConsistent()
-        clientSession.getOptions() == ClientSessionOptions.builder().build()
+        clientSession.getOptions() == ClientSessionOptions.builder()
+                .defaultTransactionOptions(TransactionOptions.builder()
+                .readConcern(ReadConcern.DEFAULT)
+                .writeConcern(WriteConcern.ACKNOWLEDGED)
+                .build())
+                .build()
         clientSession.getClusterTime() == null
         clientSession.getOperationTime() == null
         clientSession.getServerSession() != null

--- a/driver-legacy/src/test/unit/com/mongodb/ClientSessionOptionsSpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/ClientSessionOptionsSpecification.groovy
@@ -48,4 +48,20 @@ class ClientSessionOptionsSpecification extends Specification {
         autoStartTransaction << [true, false]
         transactionOptions << [TransactionOptions.builder().build(), TransactionOptions.builder().readConcern(ReadConcern.LOCAL).build()]
     }
+
+    def 'should apply options to builder'() {
+        expect:
+        ClientSessionOptions.builder(baseOptions).build() == baseOptions
+
+        where:
+        baseOptions << [ClientSessionOptions.builder().build(),
+                        ClientSessionOptions.builder()
+                                .causallyConsistent(true)
+                                .autoStartTransaction(false)
+                                .defaultTransactionOptions(TransactionOptions.builder()
+                                .writeConcern(WriteConcern.MAJORITY)
+                                .readConcern(ReadConcern
+                                .MAJORITY).build())
+                                .build()]
+    }
 }

--- a/driver-sync/src/main/com/mongodb/client/MongoClientImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/MongoClientImpl.java
@@ -23,6 +23,7 @@ import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoCredential;
 import com.mongodb.MongoDriverInformation;
 import com.mongodb.ReadPreference;
+import com.mongodb.TransactionOptions;
 import com.mongodb.client.internal.ListDatabasesIterableImpl;
 import com.mongodb.client.internal.MongoClientDelegate;
 import com.mongodb.client.internal.MongoDatabaseImpl;
@@ -98,12 +99,19 @@ final class MongoClientImpl implements MongoClient {
 
     @Override
     public ClientSession startSession() {
-        return startSession(ClientSessionOptions.builder().build());
+        return startSession(ClientSessionOptions
+                .builder()
+                .defaultTransactionOptions(TransactionOptions.builder()
+                        .readConcern(settings.getReadConcern())
+                        .writeConcern(settings.getWriteConcern())
+                        .build())
+                .build());
     }
 
     @Override
     public ClientSession startSession(final ClientSessionOptions options) {
-        ClientSession clientSession = delegate.createClientSession(notNull("options", options));
+        ClientSession clientSession = delegate.createClientSession(notNull("options", options),
+                settings.getReadConcern(), settings.getWriteConcern());
         if (clientSession == null) {
             throw new MongoClientException("Sessions are not supported by the MongoDB cluster to which this client is connected");
         }

--- a/driver-sync/src/main/com/mongodb/client/internal/ClientSessionImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ClientSessionImpl.java
@@ -24,7 +24,6 @@ import com.mongodb.TransactionOptions;
 import com.mongodb.client.ClientSession;
 import com.mongodb.internal.session.BaseClientSessionImpl;
 import com.mongodb.internal.session.ServerSessionPool;
-import com.mongodb.lang.Nullable;
 import com.mongodb.operation.AbortTransactionOperation;
 import com.mongodb.operation.CommitTransactionOperation;
 
@@ -59,30 +58,22 @@ final class ClientSessionImpl extends BaseClientSessionImpl implements ClientSes
 
     @Override
     public void startTransaction() {
-        startTransactionInternal(null);
+        startTransaction(TransactionOptions.builder().build());
     }
 
     @Override
     public void startTransaction(final TransactionOptions transactionOptions) {
         notNull("transactionOptions", transactionOptions);
-        startTransactionInternal(transactionOptions);
-    }
-
-    private void startTransactionInternal(@Nullable final TransactionOptions transactionOptions) {
         if (inTransaction) {
             throw new IllegalStateException("Transaction already in progress");
         }
         inTransaction = true;
-        if (transactionOptions == null) {
-            this.transactionOptions = getOptions().getDefaultTransactionOptions();
-        } else {
-            TransactionOptions.Builder newOptionsBuilder = TransactionOptions.builder();
-            newOptionsBuilder.writeConcern(transactionOptions.getWriteConcern() == null
-                    ? getOptions().getDefaultTransactionOptions().getWriteConcern() : transactionOptions.getWriteConcern());
-            newOptionsBuilder.readConcern(transactionOptions.getReadConcern() == null
-                    ? getOptions().getDefaultTransactionOptions().getReadConcern() : transactionOptions.getReadConcern());
-            this.transactionOptions = newOptionsBuilder.build();
-        }
+        TransactionOptions.Builder newOptionsBuilder = TransactionOptions.builder();
+        newOptionsBuilder.writeConcern(transactionOptions.getWriteConcern() == null
+                ? getOptions().getDefaultTransactionOptions().getWriteConcern() : transactionOptions.getWriteConcern());
+        newOptionsBuilder.readConcern(transactionOptions.getReadConcern() == null
+                ? getOptions().getDefaultTransactionOptions().getReadConcern() : transactionOptions.getReadConcern());
+        this.transactionOptions = newOptionsBuilder.build();
     }
 
     @Override

--- a/driver-sync/src/main/com/mongodb/client/internal/ClientSessionImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ClientSessionImpl.java
@@ -68,12 +68,7 @@ final class ClientSessionImpl extends BaseClientSessionImpl implements ClientSes
             throw new IllegalStateException("Transaction already in progress");
         }
         inTransaction = true;
-        TransactionOptions.Builder newOptionsBuilder = TransactionOptions.builder();
-        newOptionsBuilder.writeConcern(transactionOptions.getWriteConcern() == null
-                ? getOptions().getDefaultTransactionOptions().getWriteConcern() : transactionOptions.getWriteConcern());
-        newOptionsBuilder.readConcern(transactionOptions.getReadConcern() == null
-                ? getOptions().getDefaultTransactionOptions().getReadConcern() : transactionOptions.getReadConcern());
-        this.transactionOptions = newOptionsBuilder.build();
+        this.transactionOptions = TransactionOptions.merge(transactionOptions, getOptions().getDefaultTransactionOptions());
     }
 
     @Override

--- a/driver-sync/src/test/functional/com/mongodb/client/MongoClientSessionSpecification.groovy
+++ b/driver-sync/src/test/functional/com/mongodb/client/MongoClientSessionSpecification.groovy
@@ -21,6 +21,7 @@ import com.mongodb.ClientSessionOptions
 import com.mongodb.MongoClientException
 import com.mongodb.ReadConcern
 import com.mongodb.ReadPreference
+import com.mongodb.TransactionOptions
 import com.mongodb.WriteConcern
 import com.mongodb.connection.TestCommandListener
 import com.mongodb.event.CommandStartedEvent
@@ -71,7 +72,12 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         expect:
         clientSession.getOriginator() == getMongoClient()
         clientSession.isCausallyConsistent()
-        clientSession.getOptions() == ClientSessionOptions.builder().build()
+        clientSession.getOptions() == ClientSessionOptions.builder()
+                .defaultTransactionOptions(TransactionOptions.builder()
+                .readConcern(ReadConcern.DEFAULT)
+                .writeConcern(WriteConcern.ACKNOWLEDGED)
+                .build())
+                .build()
         clientSession.getClusterTime() == null
         clientSession.getOperationTime() == null
         clientSession.getServerSession() != null


### PR DESCRIPTION
The spec now requires that read and write concern default to the values from the MongoClient settings, so this introduces multiple levels of defaulting.  

I'm really not a fan of this commit, so looking for suggestions to improve it.  
