### PR TITLE
JAVA-2685: Deprecate CreateCollectionOptions autoIndex property

### DIFF
--- a/driver-core/src/main/com/mongodb/client/model/CreateCollectionOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/CreateCollectionOptions.java
@@ -42,7 +42,9 @@ public class CreateCollectionOptions {
      * Gets if auto-index is enabled
      *
      * @return true if auto-index is enabled
+     * @deprecated this option was deprecated in MongoDB 3.2 and removed in MongodB 4.0
      */
+    @Deprecated
     public boolean isAutoIndex() {
         return autoIndex;
     }
@@ -52,7 +54,9 @@ public class CreateCollectionOptions {
      *
      * @param autoIndex true if auto-index is enabled
      * @return this
+     * @deprecated this option was deprecated in MongoDB 3.2 and removed in MongodB 4.0
      */
+    @Deprecated
     public CreateCollectionOptions autoIndex(final boolean autoIndex) {
         this.autoIndex = autoIndex;
         return this;

--- a/driver-core/src/main/com/mongodb/operation/CreateCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateCollectionOperation.java
@@ -36,6 +36,7 @@ import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
 import static com.mongodb.operation.CommandOperationHelper.executeWrappedCommandProtocol;
 import static com.mongodb.operation.CommandOperationHelper.executeWrappedCommandProtocolAsync;
+import static com.mongodb.operation.DocumentHelper.putIfFalse;
 import static com.mongodb.operation.DocumentHelper.putIfNotZero;
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
@@ -412,7 +413,7 @@ public class CreateCollectionOperation implements AsyncWriteOperation<Void>, Wri
 
     private BsonDocument getCommand(final ConnectionDescription description) {
         BsonDocument document = new BsonDocument("create", new BsonString(collectionName));
-        document.put("autoIndexId", BsonBoolean.valueOf(autoIndex));
+        putIfFalse(document, "autoIndexId", autoIndex);
         document.put("capped", BsonBoolean.valueOf(capped));
         if (capped) {
             putIfNotZero(document, "size", sizeInBytes);

--- a/driver-core/src/main/com/mongodb/operation/DocumentHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/DocumentHelper.java
@@ -33,6 +33,12 @@ final class DocumentHelper {
         }
     }
 
+    static void putIfFalse(final BsonDocument command, final String key, final boolean condition) {
+        if (!condition) {
+            command.put(key, BsonBoolean.FALSE);
+        }
+    }
+
     static void putIfNotNullOrEmpty(final BsonDocument command, final String key, final BsonDocument documentValue) {
         if (documentValue != null && !documentValue.isEmpty()) {
             command.put(key, documentValue);

--- a/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
@@ -127,6 +127,7 @@ public final class CollectionHelper<T> {
         create(collectionName, options, WriteConcern.ACKNOWLEDGED);
     }
 
+    @SuppressWarnings("deprecation")
     public void create(final String collectionName, final CreateCollectionOptions options, final WriteConcern writeConcern) {
         drop(namespace, writeConcern);
         CreateCollectionOperation operation = new CreateCollectionOperation(namespace.getDatabaseName(), collectionName, writeConcern)

--- a/driver-core/src/test/functional/com/mongodb/operation/CreateCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/CreateCollectionOperationSpecification.groovy
@@ -146,7 +146,6 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
         assert !collectionNameExists(getCollectionName())
         def operation = new CreateCollectionOperation(getDatabaseName(), getCollectionName())
                 .capped(true)
-                .autoIndex(false)
                 .maxDocuments(100)
                 .sizeInBytes(40 * 1024)
 
@@ -172,6 +171,7 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
         async << [true, false]
     }
 
+    @IgnoreIf({ serverVersionAtLeast(3, 7) })
     def 'should create collection in respect to the autoIndex option'() {
         given:
         assert !collectionNameExists(getCollectionName())


### PR DESCRIPTION
This property was deprecated in MongoDB 3.2 and removed in MongoDB 4.0.

Along with deprecating the property, ensure that the field is only
included in the "create" command if the property has explicitly been
set to false.  Otherwise, a 4.0 server will reject the command.

Getting this in has taken on urgency, as the removal of support for this property just hit server master.