### PR TITLE
JAVA-2834: Temporarily ignore listCollections/listIndexes tests

### DIFF
--- a/driver-core/src/test/functional/com/mongodb/operation/ListCollectionsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ListCollectionsOperationSpecification.groovy
@@ -56,6 +56,7 @@ import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
+@IgnoreIf({ serverVersionAtLeast(3, 7) && isSharded() })
 class ListCollectionsOperationSpecification extends OperationFunctionalSpecification {
 
     def madeUpDatabase = 'MadeUpDatabase'

--- a/driver-core/src/test/functional/com/mongodb/operation/ListIndexesOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ListIndexesOperationSpecification.groovy
@@ -52,8 +52,10 @@ import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint
 import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isSharded
+import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 
+@IgnoreIf({ serverVersionAtLeast(3, 7) && isSharded() })
 class ListIndexesOperationSpecification extends OperationFunctionalSpecification {
 
     def 'should return empty list for nonexistent collection'() {


### PR DESCRIPTION
 for 3.7.x sharded clusters.

This is a temporary patch on top of JAVA-2831 that disables any tests on 3.7.x sharded clusters that force either listCollections or listIndexes to have more than one batch.  Disabling these tests, along with JAVA-2831, works around the server bug linked to those tickets.

This one is important to get us to green.

Patch build: https://evergreen.mongodb.com/version/5ad66dc5e3c3316b150aae05