### PR TITLE
Add reference documentation for the 3.8 release

### DIFF
--- a/docs/landing/data/releases.toml
+++ b/docs/landing/data/releases.toml
@@ -1,6 +1,12 @@
 current = "3.6.3"
 
 [[versions]]
+  version = "3.8.0-beta1"
+  docs = "./3.8"
+  api = "./3.8/javadoc"
+
+
+[[versions]]
   version = "3.7.0-rc0"
   docs = "./3.7"
   api = "./3.7/javadoc"
@@ -54,24 +60,24 @@ current = "3.6.3"
 [[drivers]]
   name = "mongodb-driver-sync"
   description = "The synchronous driver, new in 3.7.<br/>For older versions of the driver please use the `mongodb-driver` or `mongo-java-driver`."
-  versions = "3.7.0-rc0"
+  versions = "3.8.0-beta1,3.7.0-rc0"
 
 [[drivers]]
   name = "mongodb-driver"
   description = "The synchronous driver plus the legacy driver, new in 3.0.<br/>For older versions of the driver or for OSGi-based applications please use the `mongo-java-driver`."
-  versions = "3.7.0-rc0,3.6.3,3.5.0,3.4.3,3.3.0,3.2.2,3.1.1,3.0.4"
+  versions = "3.8.0-beta1,3.7.0-rc0,3.6.3,3.5.0,3.4.3,3.3.0,3.2.2,3.1.1,3.0.4"
 
 [[drivers]]
   name = "mongo-java-driver"
   description = "An uber jar containing the bson library, the core library and the mongodb-driver.<br/>This artifact is a valid OSGi bundle."
-  versions = "3.7.0-rc0,3.6.3,3.5.0,3.4.3,3.3.0,3.2.2,3.1.1,3.0.4,2.14.2,2.13.3"
+  versions = "3.8.0-beta1,3.7.0-rc0,3.6.3,3.5.0,3.4.3,3.3.0,3.2.2,3.1.1,3.0.4,2.14.2,2.13.3"
 
 [[drivers]]
   name = "mongodb-driver-async"
   description = "The new asynchronous driver, new in 3.0"
-  versions = "3.7.0-rc0,3.6.3,3.5.0,3.4.3,3.3.0,3.2.2,3.1.1,3.0.4"
+  versions = "3.8.0-beta1,3.7.0-rc0,3.6.3,3.5.0,3.4.3,3.3.0,3.2.2,3.1.1,3.0.4"
 
 [[drivers]]
   name = "mongodb-driver-core"
   description = "The core library, new in 3.0"
-  versions = "3.7.0-rc0,3.6.3,3.5.0,3.4.3,3.3.0,3.2.2,3.1.1,3.0.4"
+  versions = "3.8.0-beta1,3.7.0-rc0,3.6.3,3.5.0,3.4.3,3.3.0,3.2.2,3.1.1,3.0.4"

--- a/docs/landing/static/versions.json
+++ b/docs/landing/static/versions.json
@@ -1,1 +1,1 @@
-[{"version": "3.7"}, {"version": "3.6"}, {"version": "3.5"}, {"version": "3.4"}, {"version": "3.3"}, {"version": "3.2"}, {"version": "3 .1"}, {"version": "3 .0"}, {"version": "2.13"}, {"version": "2.14"}]
+[{"version": "3.8"}, {"version": "3.7"}, {"version": "3.6"}, {"version": "3.5"}, {"version": "3.4"}, {"version": "3.3"}, {"version": "3.2"}, {"version": "3 .1"}, {"version": "3 .0"}, {"version": "2.13"}, {"version": "2.14"}]

--- a/docs/reference/config.toml
+++ b/docs/reference/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/mongo-java-driver/3.7"
+baseURL = "/mongo-java-driver/3.8"
 languageCode = "en-us"
 title = "MongoDB Java Driver"
 theme = "mongodb"

--- a/docs/reference/content/bson/installation-guide.md
+++ b/docs/reference/content/bson/installation-guide.md
@@ -22,4 +22,4 @@ This library comprehensively supports [BSON](http://www.bsonspec.org),
 the data storage and network transfer format that MongoDB uses for "documents".
 BSON is short for Binary [JSON](http://json.org/), is a binary-encoded serialization of JSON-like documents.
 
-{{< install artifactId="bson" version="3.7.0-rc0" >}}
+{{< install artifactId="bson" version="3.8.0-beta1" >}}

--- a/docs/reference/content/driver-async/getting-started/installation.md
+++ b/docs/reference/content/driver-async/getting-started/installation.md
@@ -23,4 +23,4 @@ The MongoDB Async Driver requires either [Netty](http://netty.io/) or Java 7.
 
 The MongoDB Async Driver provides asynchronous API that can leverage either Netty or Java 7's AsynchronousSocketChannel for fast and non-blocking I/O.
 
-{{< install artifactId="mongodb-driver-async" version="3.7.0-rc0" dependencies="true">}}
+{{< install artifactId="mongodb-driver-async" version="3.8.0-beta1" dependencies="true">}}

--- a/docs/reference/content/driver-async/index.md
+++ b/docs/reference/content/driver-async/index.md
@@ -9,7 +9,7 @@ title = "MongoDB Async Driver"
 
 ## MongoDB Async Java Driver Documentation
 
-The following guide provides information on using the callback-based MongoDB Async Java Driver 3.7.
+The following guide provides information on using the callback-based MongoDB Async Java Driver 3.8.
 
 {{% note %}}
 There are two higher level MongoDB Asynchronous Java Drivers available, that users may find easier to work with due to their friendlier APIs:
@@ -18,7 +18,7 @@ There are two higher level MongoDB Asynchronous Java Drivers available, that use
 * [MongoDB Reactive Streams Java Driver](http://mongodb.github.io/mongo-java-driver-reactivestreams/) A Reactive Streams implementation for the JVM.
 {{% /note %}}
 
-### What's New in 3.7
+### What's New in 3.8
 
 The [What's New]({{< relref "whats-new.md" >}}) guide explains the major new features of the driver.
 

--- a/docs/reference/content/driver/getting-started/installation.md
+++ b/docs/reference/content/driver/getting-started/installation.md
@@ -31,7 +31,7 @@ The `mongodb-driver-sync` artifact is a valid OSGi bundle whose symbolic name is
 
 {{% /note %}}
 
-{{< install artifactId="mongodb-driver-sync" version="3.7.0-rc0" dependencies="true">}}
+{{< install artifactId="mongodb-driver-sync" version="3.8.0-beta1" dependencies="true">}}
 
 ## MongoDB Driver  
 
@@ -46,7 +46,7 @@ It is also *not* a Java 9 module.
 
 {{% /note %}}
 
-{{< install artifactId="mongodb-driver" version="3.7.0-rc0" dependencies="true">}}
+{{< install artifactId="mongodb-driver" version="3.8.0-beta1" dependencies="true">}}
 
 
 ## Uber Jar (Legacy)
@@ -61,4 +61,4 @@ This is a Java 9-compliant module with an Automatic-Module-Name of `org.mongodb.
 The `mongo-java-driver` artifact is a valid OSGi bundle whose symbolic name is `org.mongodb.mongo-java-driver`.
 {{% /note %}}
 
-{{< install artifactId="mongo-java-driver" version="3.7.0-rc0">}}
+{{< install artifactId="mongo-java-driver" version="3.8.0-beta1">}}

--- a/docs/reference/content/driver/index.md
+++ b/docs/reference/content/driver/index.md
@@ -7,12 +7,12 @@ title = "MongoDB Driver"
   pre = "<i class='fa fa-arrows-h'></i>"
 +++
 
-## MongoDB Driver 3.7 Documentation
+## MongoDB Driver 3.8 Documentation
 
 The following guide provides information on using the synchronous
-MongoDB Java Driver 3.7.
+MongoDB Java Driver 3.8.
 
-### What's New in 3.7
+### What's New in 3.8
 
 The [What's New]({{< relref "whats-new.md" >}}) guide explains
 the major new features of the driver.

--- a/docs/reference/content/index.md
+++ b/docs/reference/content/index.md
@@ -6,12 +6,12 @@ type = "index"
 
 ## MongoDB Java Driver Documentation
 
-Welcome to the MongoDB Java driver documentation hub for the 3.7 driver release.
+Welcome to the MongoDB Java driver documentation hub for the 3.8 driver release.
 
 
-### What's New in 3.7
+### What's New in 3.8
 
-For key new features of 3.7, see [What's New]({{< relref "whats-new.md" >}}).
+For key new features of 3.8, see [What's New]({{< relref "whats-new.md" >}}).
 
 ### Upgrade
 

--- a/docs/reference/content/upgrading.md
+++ b/docs/reference/content/upgrading.md
@@ -7,14 +7,20 @@ title = "Upgrade Considerations"
   pre = "<i class='fa fa-level-up'></i>"
 +++
 
-## Upgrading from 3.6.x
+## Upgrading from 3.7.x
 
-The 3.7 release is binary and source compatible with the 3.5 release, except for methods that have been added to interfaces that
+The 3.8 driver introduces a small but significant breaking change to the existing API for any application that already depends on session
+support (introduced in the 3.6 release to support causal consistency): the type of ClientSession changes from
+`com.mongodb.session.ClientSession` to `com.mongodb.client.ClientSession`.  This is both source and binary incompatible with the 3.7
+release.  This change was required in order to introduce support in the driver for transactions that works in both the synchronous and the
+asynchronous drivers.
+
+Otherwise, the 3.8 release is binary and source compatible with the 3.7 release, except for methods that have been added to interfaces that
 have been marked as unstable, and changes to classes or interfaces that have been marked as internal or annotated as Beta.
 
 ## Upgrading from 2.x
 
-You must upgrade first to 3.0 driver.  See the Upgrade guide in the 3.0 driver reference documentation.
+See the Upgrade guide in the 3.0 driver reference documentation for breaking changes in 3.0.
 
 ### System Requirements
 
@@ -30,21 +36,23 @@ its implementation.  See [Async]({{< ref "driver-async/index.md" >}}) for detail
 
 The following table specifies the compatibility of the MongoDB Java driver for use with a specific version of MongoDB.
 
-|Java Driver Version|MongoDB 2.6|MongoDB 3.0 |MongoDB 3.2|MongoDB 3.4|MongoDB 3.6|
-|-------------------|-----------|------------|-----------|-----------|-----------|
-|Version 3.7        |  ✓  |  ✓  |  ✓  |  ✓  |  ✓  |
-|Version 3.6        |  ✓  |  ✓  |  ✓  |  ✓  |  ✓  |
-|Version 3.5        |  ✓  |  ✓  |  ✓  |  ✓  |     |
-|Version 3.4        |  ✓  |  ✓  |  ✓  |  ✓  |     |
-|Version 3.3        |  ✓  |  ✓  |  ✓  |     |     |
-|Version 3.2        |  ✓  |  ✓  |  ✓  |     |     |
-|Version 3.1        |  ✓  |  ✓  |     |     |     |
-|Version 3.0        |  ✓  |  ✓  |     |     |     |
+|Java Driver Version|MongoDB 2.6|MongoDB 3.0 |MongoDB 3.2|MongoDB 3.4|MongoDB 3.6|MongoDB 4.0|
+|-------------------|-----------|------------|-----------|-----------|-----------|-----------|
+|Version 3.8        |  ✓  |  ✓  |  ✓  |  ✓  |  ✓  |  ✓  |
+|Version 3.7        |  ✓  |  ✓  |  ✓  |  ✓  |  ✓  |     |
+|Version 3.6        |  ✓  |  ✓  |  ✓  |  ✓  |  ✓  |     |
+|Version 3.5        |  ✓  |  ✓  |  ✓  |  ✓  |     |     |
+|Version 3.4        |  ✓  |  ✓  |  ✓  |  ✓  |     |     |
+|Version 3.3        |  ✓  |  ✓  |  ✓  |     |     |     |
+|Version 3.2        |  ✓  |  ✓  |  ✓  |     |     |     |
+|Version 3.1        |  ✓  |  ✓  |     |     |     |     |
+|Version 3.0        |  ✓  |  ✓  |     |     |     |     |
 
 The following table specifies the compatibility of the MongoDB Java driver for use with a specific version of Java.
 
 |Java Driver Version|Java 5 | Java 6 | Java 7 | Java 8 |
 |-------------------|-------|--------|--------|--------|
+|Version 3.8        |     | ✓ | ✓ | ✓ |
 |Version 3.7        |     | ✓ | ✓ | ✓ |
 |Version 3.6        |     | ✓ | ✓ | ✓ |
 |Version 3.5        |     | ✓ | ✓ | ✓ |

--- a/docs/reference/content/whats-new.md
+++ b/docs/reference/content/whats-new.md
@@ -7,6 +7,19 @@ title = "What's New"
   pre = "<i class='fa fa-level-up'></i>"
 +++
 
+## What's New in 3.8
+
+Key new features of the 3.8 Java driver release:
+
+### Transactions
+
+The Java driver now provides support for executing CRUD operations within a transaction (requires MongoDB 4.0).
+
+### SCRAM-256 Authentication Mechanism
+
+The Java driver now provides support for the SCRAM-256 authentication mechanism (requires MongoDB 4.0).
+
+
 ## What's New in 3.7
 
 Key new features of the 3.7 Java driver release:

--- a/docs/reference/data/mongodb.toml
+++ b/docs/reference/data/mongodb.toml
@@ -1,6 +1,6 @@
 # Update versions in config.toml as well
 githubRepo = "mongo-java-driver"
 githubBranch = "master"
-currentVersion = "3.7"
+currentVersion = "3.8"
 highlightTheme = "idea.css"
 apiUrl = "/javadoc"


### PR DESCRIPTION
These are really brief but want to get _something_ up.

Published to my fork: http://jyemin.github.io/mongo-java-driver/