### PR TITLE
JAVA-2815: Use mutable write concern property on Mongo

### DIFF
--- a/driver-legacy/src/main/com/mongodb/Mongo.java
+++ b/driver-legacy/src/main/com/mongodb/Mongo.java
@@ -797,7 +797,7 @@ public class Mongo {
 
     @Nullable
     ClientSession createClientSession(final ClientSessionOptions options) {
-        return delegate.createClientSession(options, this.options.getReadConcern(), this.options.getWriteConcern());
+        return delegate.createClientSession(options, readConcern, writeConcern);
     }
 
     private ExecutorService createCursorCleaningService() {


### PR DESCRIPTION
Use mutable write concern property on Mongo for default transaction options.

Thanks to Bruce Lucas for inadvertently discovering this during beta testing