### PR TITLE
JAVA-2843: Support codeName in error responses from server

### DIFF
--- a/driver-core/src/main/com/mongodb/MongoCommandException.java
+++ b/driver-core/src/main/com/mongodb/MongoCommandException.java
@@ -60,6 +60,17 @@ public class MongoCommandException extends MongoServerException {
     }
 
     /**
+     * Gets the name associated with the error code.
+     *
+     * @return the error code name, which may be the empty string
+     * @since 3.8
+     * @mongodb.server.release 3.4
+     */
+    public String getErrorCodeName() {
+        return response.getString("codeName", new BsonString("")).getValue();
+    }
+
+    /**
      * Gets the error message associated with the command failure.
      *
      * @return the error message

--- a/driver-core/src/main/com/mongodb/MongoCommandException.java
+++ b/driver-core/src/main/com/mongodb/MongoCommandException.java
@@ -45,7 +45,7 @@ public class MongoCommandException extends MongoServerException {
      */
     public MongoCommandException(final BsonDocument response, final ServerAddress address) {
         super(extractErrorCode(response),
-              format("Command failed with error %s: '%s' on server %s. The full response is %s", extractErrorCode(response),
+              format("Command failed with error %s: '%s' on server %s. The full response is %s", extractErrorCodeAndName(response),
                      extractErrorMessage(response), address, getResponseAsJson(response)), address);
         this.response = response;
     }
@@ -67,7 +67,7 @@ public class MongoCommandException extends MongoServerException {
      * @mongodb.server.release 3.4
      */
     public String getErrorCodeName() {
-        return response.getString("codeName", new BsonString("")).getValue();
+        return extractErrorCodeName(response);
     }
 
     /**
@@ -95,8 +95,22 @@ public class MongoCommandException extends MongoServerException {
         return writer.toString();
     }
 
+    private static String extractErrorCodeAndName(final BsonDocument response) {
+        int errorCode = extractErrorCode(response);
+        String errorCodeName = extractErrorCodeName(response);
+        if (errorCodeName.isEmpty()) {
+            return Integer.toString(errorCode);
+        } else {
+            return String.format("%d (%s)", errorCode, errorCodeName);
+        }
+    }
+
     private static int extractErrorCode(final BsonDocument response) {
         return response.getNumber("code", new BsonInt32(-1)).intValue();
+    }
+
+    private static String extractErrorCodeName(final BsonDocument response) {
+        return response.getString("codeName", new BsonString("")).getValue();
     }
 
     private static String extractErrorMessage(final BsonDocument response) {

--- a/driver-core/src/main/com/mongodb/bulk/WriteConcernError.java
+++ b/driver-core/src/main/com/mongodb/bulk/WriteConcernError.java
@@ -28,8 +28,25 @@ import static com.mongodb.assertions.Assertions.notNull;
  */
 public class WriteConcernError {
     private final int code;
+    private final String codeName;
     private final String message;
     private final BsonDocument details;
+
+
+    /**
+     * Constructs a new instance.
+     *
+     * @param code    the error code
+     * @param codeName the error code name
+     * @param message the error message
+     * @param details any details
+     */
+    public WriteConcernError(final int code, final String codeName, final String message, final BsonDocument details) {
+        this.code = code;
+        this.codeName = notNull("codeName", codeName);
+        this.message = notNull("message", message);
+        this.details = notNull("details", details);
+    }
 
     /**
      * Constructs a new instance.
@@ -37,11 +54,11 @@ public class WriteConcernError {
      * @param code    the error code
      * @param message the error message
      * @param details any details
+     * @deprecated
      */
+    @Deprecated
     public WriteConcernError(final int code, final String message, final BsonDocument details) {
-        this.code = code;
-        this.message = notNull("message", message);
-        this.details = notNull("details", details);
+        this(code, "", message, details);
     }
 
     /**
@@ -51,6 +68,17 @@ public class WriteConcernError {
      */
     public int getCode() {
         return code;
+    }
+
+    /**
+     * Gets the name associated with the error code.
+     *
+     * @return the error code name, which may be the empty string
+     * @since 3.8
+     * @mongodb.server.release 3.4
+     */
+    public String getCodeName() {
+        return codeName;
     }
 
     /**

--- a/driver-core/src/main/com/mongodb/bulk/WriteConcernError.java
+++ b/driver-core/src/main/com/mongodb/bulk/WriteConcernError.java
@@ -113,6 +113,9 @@ public class WriteConcernError {
         if (code != that.code) {
             return false;
         }
+        if (!codeName.equals(that.codeName)) {
+            return false;
+        }
         if (!details.equals(that.details)) {
             return false;
         }
@@ -126,6 +129,7 @@ public class WriteConcernError {
     @Override
     public int hashCode() {
         int result = code;
+        result = 31 * result + codeName.hashCode();
         result = 31 * result + message.hashCode();
         result = 31 * result + details.hashCode();
         return result;
@@ -133,8 +137,9 @@ public class WriteConcernError {
 
     @Override
     public String toString() {
-        return "BulkWriteConcernError{"
+        return "WriteConcernError{"
                + "code=" + code
+               + ", codeName='" + codeName + '\''
                + ", message='" + message + '\''
                + ", details=" + details
                + '}';

--- a/driver-core/src/main/com/mongodb/connection/WriteCommandResultHelper.java
+++ b/driver-core/src/main/com/mongodb/connection/WriteCommandResultHelper.java
@@ -16,10 +16,10 @@
 
 package com.mongodb.connection;
 
+import com.mongodb.MongoBulkWriteException;
 import com.mongodb.MongoInternalException;
 import com.mongodb.ServerAddress;
 import com.mongodb.bulk.BulkWriteError;
-import com.mongodb.MongoBulkWriteException;
 import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.bulk.BulkWriteUpsert;
 import com.mongodb.bulk.WriteConcernError;
@@ -36,6 +36,7 @@ import java.util.List;
 
 import static com.mongodb.bulk.WriteRequest.Type.REPLACE;
 import static com.mongodb.bulk.WriteRequest.Type.UPDATE;
+import static com.mongodb.internal.operation.WriteConcernHelper.createWriteConcernError;
 
 final class WriteCommandResultHelper {
 
@@ -79,9 +80,7 @@ final class WriteCommandResultHelper {
         if (writeConcernErrorDocument == null) {
             return null;
         } else {
-            return new WriteConcernError(writeConcernErrorDocument.getNumber("code").intValue(),
-                                         writeConcernErrorDocument.getString("errmsg").getValue(),
-                                         writeConcernErrorDocument.getDocument("errInfo", new BsonDocument()));
+            return createWriteConcernError(writeConcernErrorDocument);
         }
     }
 

--- a/driver-core/src/main/com/mongodb/internal/operation/ServerVersionHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/ServerVersionHelper.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.operation;
+
+
+import com.mongodb.connection.ConnectionDescription;
+import com.mongodb.connection.ServerVersion;
+
+/**
+ * This class is NOT part of the public API. It may change at any time without notification.
+ */
+public final class ServerVersionHelper {
+
+    public static boolean serverIsAtLeastVersionThreeDotZero(final ConnectionDescription description) {
+        return serverIsAtLeastVersion(description, new ServerVersion(3, 0));
+    }
+
+    public static boolean serverIsAtLeastVersionThreeDotTwo(final ConnectionDescription description) {
+        return serverIsAtLeastVersion(description, new ServerVersion(3, 2));
+    }
+
+    public static boolean serverIsAtLeastVersionThreeDotFour(final ConnectionDescription description) {
+        return serverIsAtLeastVersion(description, new ServerVersion(3, 4));
+    }
+
+    public static boolean serverIsAtLeastVersionThreeDotSix(final ConnectionDescription description) {
+        return serverIsAtLeastVersion(description, new ServerVersion(3, 6));
+    }
+
+    private static boolean serverIsAtLeastVersion(final ConnectionDescription description, final ServerVersion serverVersion) {
+        return description.getServerVersion().compareTo(serverVersion) >= 0;
+    }
+
+    private ServerVersionHelper() {
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/operation/WriteConcernHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/WriteConcernHelper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.mongodb.operation;
+package com.mongodb.internal.operation;
 
 import com.mongodb.MongoWriteConcernException;
 import com.mongodb.ServerAddress;
@@ -26,34 +26,37 @@ import org.bson.BsonDocument;
 
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotFour;
 
-final class WriteConcernHelper {
+/**
+ * This class is NOT part of the public API. It may change at any time without notification.
+ */
+public final class WriteConcernHelper {
 
-    static void appendWriteConcernToCommand(final WriteConcern writeConcern, final BsonDocument commandDocument,
-                                            final ConnectionDescription description) {
+    public static void appendWriteConcernToCommand(final WriteConcern writeConcern, final BsonDocument commandDocument,
+                                                   final ConnectionDescription description) {
         if (writeConcern != null && !writeConcern.isServerDefault() && serverIsAtLeastVersionThreeDotFour(description)) {
             commandDocument.put("writeConcern", writeConcern.asDocument());
         }
     }
 
-    static void throwOnWriteConcernError(final BsonDocument result, final ServerAddress serverAddress) {
+    public static void throwOnWriteConcernError(final BsonDocument result, final ServerAddress serverAddress) {
         if (hasWriteConcernError(result)) {
-            throw createWriteConcernError(result, serverAddress); }
-
+            throw createWriteConcernError(result, serverAddress);
+        }
     }
 
-    static boolean hasWriteConcernError(final BsonDocument result) {
+    public static boolean hasWriteConcernError(final BsonDocument result) {
         return result.containsKey("writeConcernError");
     }
 
-    static MongoWriteConcernException createWriteConcernError(final BsonDocument result, final ServerAddress serverAddress) {
+    public static MongoWriteConcernException createWriteConcernError(final BsonDocument result, final ServerAddress serverAddress) {
         return new MongoWriteConcernException(createWriteConcernError(result.getDocument("writeConcernError")),
-                                                   WriteConcernResult.acknowledged(0, false, null), serverAddress);
+                WriteConcernResult.acknowledged(0, false, null), serverAddress);
     }
 
-    static WriteConcernError createWriteConcernError(final BsonDocument writeConcernErrorDocument) {
+    public static WriteConcernError createWriteConcernError(final BsonDocument writeConcernErrorDocument) {
         return new WriteConcernError(writeConcernErrorDocument.getNumber("code").intValue(),
-                                            writeConcernErrorDocument.getString("errmsg").getValue(),
-                                            writeConcernErrorDocument.getDocument("errInfo", new BsonDocument()));
+                writeConcernErrorDocument.getString("errmsg").getValue(),
+                writeConcernErrorDocument.getDocument("errInfo", new BsonDocument()));
     }
 
     private WriteConcernHelper() {

--- a/driver-core/src/main/com/mongodb/internal/operation/WriteConcernHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/WriteConcernHelper.java
@@ -23,6 +23,7 @@ import com.mongodb.WriteConcernResult;
 import com.mongodb.bulk.WriteConcernError;
 import com.mongodb.connection.ConnectionDescription;
 import org.bson.BsonDocument;
+import org.bson.BsonString;
 
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotFour;
 
@@ -55,6 +56,7 @@ public final class WriteConcernHelper {
 
     public static WriteConcernError createWriteConcernError(final BsonDocument writeConcernErrorDocument) {
         return new WriteConcernError(writeConcernErrorDocument.getNumber("code").intValue(),
+                writeConcernErrorDocument.getString("codeName", new BsonString("")).getValue(),
                 writeConcernErrorDocument.getString("errmsg").getValue(),
                 writeConcernErrorDocument.getDocument("errInfo", new BsonDocument()));
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/WriteConcernHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/WriteConcernHelper.java
@@ -40,7 +40,7 @@ public final class WriteConcernHelper {
 
     public static void throwOnWriteConcernError(final BsonDocument result, final ServerAddress serverAddress) {
         if (hasWriteConcernError(result)) {
-            throw createWriteConcernError(result, serverAddress);
+            throw createWriteConcernException(result, serverAddress);
         }
     }
 
@@ -48,7 +48,7 @@ public final class WriteConcernHelper {
         return result.containsKey("writeConcernError");
     }
 
-    public static MongoWriteConcernException createWriteConcernError(final BsonDocument result, final ServerAddress serverAddress) {
+    public static MongoWriteConcernException createWriteConcernException(final BsonDocument result, final ServerAddress serverAddress) {
         return new MongoWriteConcernException(createWriteConcernError(result.getDocument("writeConcernError")),
                 WriteConcernResult.acknowledged(0, false, null), serverAddress);
     }

--- a/driver-core/src/main/com/mongodb/operation/AggregateOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/AggregateOperation.java
@@ -54,7 +54,7 @@ import static com.mongodb.operation.OperationHelper.CallableWithConnectionAndSou
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.cursorDocumentToQueryResult;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotSix;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotSix;
 import static com.mongodb.operation.OperationHelper.validateReadConcernAndCollation;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.operation.OperationReadConcernHelper.appendReadConcernToCommand;

--- a/driver-core/src/main/com/mongodb/operation/AggregateToCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/AggregateToCollectionOperation.java
@@ -49,7 +49,7 @@ import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotTwo;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
-import static com.mongodb.operation.WriteConcernHelper.writeConcernErrorTransformer;
+import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**
  * An operation that executes an aggregation that writes its results to a collection (which is what makes this a write operation rather than

--- a/driver-core/src/main/com/mongodb/operation/AggregateToCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/AggregateToCollectionOperation.java
@@ -48,7 +48,7 @@ import static com.mongodb.operation.OperationHelper.validateCollation;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
 import static com.mongodb.operation.OperationHelper.withConnection;
-import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
+import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**

--- a/driver-core/src/main/com/mongodb/operation/AggregateToCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/AggregateToCollectionOperation.java
@@ -43,10 +43,10 @@ import static com.mongodb.operation.CommandOperationHelper.executeWrappedCommand
 import static com.mongodb.operation.OperationHelper.AsyncCallableWithConnection;
 import static com.mongodb.operation.OperationHelper.CallableWithConnection;
 import static com.mongodb.operation.OperationHelper.LOGGER;
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotSix;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotSix;
 import static com.mongodb.operation.OperationHelper.validateCollation;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotTwo;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;

--- a/driver-core/src/main/com/mongodb/operation/AsyncQueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/AsyncQueryBatchCursor.java
@@ -48,7 +48,7 @@ import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandli
 import static com.mongodb.operation.CursorHelper.getNumberToReturn;
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.getMoreCursorDocumentToQueryResult;
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotTwo;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
 import static com.mongodb.operation.QueryHelper.translateCommandException;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;

--- a/driver-core/src/main/com/mongodb/operation/BaseFindAndModifyOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/BaseFindAndModifyOperation.java
@@ -33,7 +33,7 @@ import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.operation.CommandOperationHelper.CommandCreator;
 import static com.mongodb.operation.CommandOperationHelper.executeRetryableCommand;
 import static com.mongodb.operation.OperationHelper.isRetryableWrite;
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotTwo;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
 
 /**
  * Abstract base class for findAndModify-based operations

--- a/driver-core/src/main/com/mongodb/operation/BulkWriteBatch.java
+++ b/driver-core/src/main/com/mongodb/operation/BulkWriteBatch.java
@@ -65,6 +65,7 @@ import static com.mongodb.bulk.WriteRequest.Type.DELETE;
 import static com.mongodb.bulk.WriteRequest.Type.INSERT;
 import static com.mongodb.bulk.WriteRequest.Type.REPLACE;
 import static com.mongodb.bulk.WriteRequest.Type.UPDATE;
+import static com.mongodb.internal.operation.WriteConcernHelper.createWriteConcernError;
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.isRetryableWrite;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
@@ -328,9 +329,7 @@ final class BulkWriteBatch {
         if (writeConcernErrorDocument == null) {
             return null;
         } else {
-            return new WriteConcernError(writeConcernErrorDocument.getNumber("code").intValue(),
-                    writeConcernErrorDocument.getString("errmsg").getValue(),
-                    writeConcernErrorDocument.getDocument("errInfo", new BsonDocument()));
+            return createWriteConcernError(writeConcernErrorDocument);
         }
     }
 

--- a/driver-core/src/main/com/mongodb/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/CommandOperationHelper.java
@@ -73,6 +73,16 @@ final class CommandOperationHelper {
         }
     }
 
+    static CommandTransformer<BsonDocument, Void> writeConcernErrorTransformer() {
+        return new CommandTransformer<BsonDocument, Void>() {
+            @Override
+            public Void apply(final BsonDocument result, final ServerAddress serverAddress) {
+                WriteConcernHelper.throwOnWriteConcernError(result, serverAddress);
+                return null;
+            }
+        };
+    }
+
     interface CommandCreator {
         BsonDocument create(ServerDescription serverDescription, ConnectionDescription connectionDescription);
     }

--- a/driver-core/src/main/com/mongodb/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/CommandOperationHelper.java
@@ -34,6 +34,7 @@ import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.Connection;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.connection.ServerDescription;
+import com.mongodb.internal.operation.WriteConcernHelper;
 import com.mongodb.lang.Nullable;
 import com.mongodb.session.SessionContext;
 import com.mongodb.internal.validator.NoOpFieldNameValidator;

--- a/driver-core/src/main/com/mongodb/operation/CreateCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateCollectionOperation.java
@@ -43,7 +43,7 @@ import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.validateCollation;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
-import static com.mongodb.operation.WriteConcernHelper.writeConcernErrorTransformer;
+import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**
  * An operation to create a collection

--- a/driver-core/src/main/com/mongodb/operation/CreateCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateCollectionOperation.java
@@ -42,7 +42,7 @@ import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.validateCollation;
 import static com.mongodb.operation.OperationHelper.withConnection;
-import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
+import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**

--- a/driver-core/src/main/com/mongodb/operation/CreateIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateIndexesOperation.java
@@ -56,7 +56,7 @@ import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.validateIndexRequestCollations;
 import static com.mongodb.operation.OperationHelper.withConnection;
-import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
+import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**

--- a/driver-core/src/main/com/mongodb/operation/CreateIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateIndexesOperation.java
@@ -57,7 +57,7 @@ import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.validateIndexRequestCollations;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
-import static com.mongodb.operation.WriteConcernHelper.writeConcernErrorTransformer;
+import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**
  * An operation that creates one or more indexes.

--- a/driver-core/src/main/com/mongodb/operation/CreateUserOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateUserOperation.java
@@ -39,7 +39,7 @@ import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.operation.UserOperationHelper.asCommandDocument;
 import static com.mongodb.operation.UserOperationHelper.translateUserCommandException;
 import static com.mongodb.operation.UserOperationHelper.userCommandCallback;
-import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
+import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**

--- a/driver-core/src/main/com/mongodb/operation/CreateUserOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateUserOperation.java
@@ -40,7 +40,7 @@ import static com.mongodb.operation.UserOperationHelper.asCommandDocument;
 import static com.mongodb.operation.UserOperationHelper.translateUserCommandException;
 import static com.mongodb.operation.UserOperationHelper.userCommandCallback;
 import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
-import static com.mongodb.operation.WriteConcernHelper.writeConcernErrorTransformer;
+import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**
  * An operation to create a user.

--- a/driver-core/src/main/com/mongodb/operation/CreateViewOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateViewOperation.java
@@ -39,7 +39,7 @@ import static com.mongodb.operation.CommandOperationHelper.executeWrappedCommand
 import static com.mongodb.operation.CommandOperationHelper.executeWrappedCommandProtocolAsync;
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotFour;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotFour;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;

--- a/driver-core/src/main/com/mongodb/operation/CreateViewOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateViewOperation.java
@@ -42,7 +42,7 @@ import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotFour;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
-import static com.mongodb.operation.WriteConcernHelper.writeConcernErrorTransformer;
+import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**
  * An operation to create a view.

--- a/driver-core/src/main/com/mongodb/operation/CreateViewOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateViewOperation.java
@@ -41,7 +41,7 @@ import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotFour;
 import static com.mongodb.operation.OperationHelper.withConnection;
-import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
+import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**

--- a/driver-core/src/main/com/mongodb/operation/CurrentOpOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CurrentOpOperation.java
@@ -25,7 +25,7 @@ import org.bson.BsonInt32;
 import org.bson.codecs.BsonDocumentCodec;
 
 import static com.mongodb.operation.CommandOperationHelper.executeWrappedCommandProtocol;
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotTwo;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
 import static com.mongodb.operation.OperationHelper.withConnection;
 
 /**

--- a/driver-core/src/main/com/mongodb/operation/DropCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DropCollectionOperation.java
@@ -39,7 +39,7 @@ import static com.mongodb.operation.CommandOperationHelper.rethrowIfNotNamespace
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.withConnection;
-import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
+import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**

--- a/driver-core/src/main/com/mongodb/operation/DropCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DropCollectionOperation.java
@@ -40,7 +40,7 @@ import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
-import static com.mongodb.operation.WriteConcernHelper.writeConcernErrorTransformer;
+import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**
  * Operation to drop a Collection in MongoDB.  The {@code execute} method throws MongoCommandFailureException if something goes wrong, but

--- a/driver-core/src/main/com/mongodb/operation/DropDatabaseOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DropDatabaseOperation.java
@@ -33,7 +33,7 @@ import static com.mongodb.operation.CommandOperationHelper.executeWrappedCommand
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.withConnection;
-import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
+import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**

--- a/driver-core/src/main/com/mongodb/operation/DropDatabaseOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DropDatabaseOperation.java
@@ -34,7 +34,7 @@ import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
-import static com.mongodb.operation.WriteConcernHelper.writeConcernErrorTransformer;
+import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**
  * Operation to drop a database in MongoDB.  The {@code execute} method throws MongoCommandFailureException if something goes wrong, but

--- a/driver-core/src/main/com/mongodb/operation/DropIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DropIndexOperation.java
@@ -44,7 +44,7 @@ import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
-import static com.mongodb.operation.WriteConcernHelper.writeConcernErrorTransformer;
+import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**
  * An operation that drops an index.

--- a/driver-core/src/main/com/mongodb/operation/DropIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DropIndexOperation.java
@@ -43,7 +43,7 @@ import static com.mongodb.internal.operation.IndexHelper.generateIndexName;
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.withConnection;
-import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
+import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**

--- a/driver-core/src/main/com/mongodb/operation/DropUserOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DropUserOperation.java
@@ -38,7 +38,7 @@ import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.operation.UserOperationHelper.translateUserCommandException;
 import static com.mongodb.operation.UserOperationHelper.userCommandCallback;
-import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
+import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**

--- a/driver-core/src/main/com/mongodb/operation/DropUserOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DropUserOperation.java
@@ -39,7 +39,7 @@ import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.operation.UserOperationHelper.translateUserCommandException;
 import static com.mongodb.operation.UserOperationHelper.userCommandCallback;
 import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
-import static com.mongodb.operation.WriteConcernHelper.writeConcernErrorTransformer;
+import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**
  * An operation to remove a user.

--- a/driver-core/src/main/com/mongodb/operation/FindAndModifyHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/FindAndModifyHelper.java
@@ -19,11 +19,12 @@ package com.mongodb.operation;
 import com.mongodb.MongoWriteConcernException;
 import com.mongodb.ServerAddress;
 import com.mongodb.WriteConcernResult;
-import com.mongodb.bulk.WriteConcernError;
 import com.mongodb.operation.CommandOperationHelper.CommandTransformer;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
+
+import static com.mongodb.internal.operation.WriteConcernHelper.createWriteConcernError;
 
 final class FindAndModifyHelper {
 
@@ -45,12 +46,6 @@ final class FindAndModifyHelper {
                 return BsonDocumentWrapperHelper.toDocument(result.getDocument("value", null));
             }
         };
-    }
-
-    private static WriteConcernError createWriteConcernError(final BsonDocument writeConcernErrorDocument) {
-        return new WriteConcernError(writeConcernErrorDocument.getNumber("code").intValue(),
-                                     writeConcernErrorDocument.getString("errmsg").getValue(),
-                                     writeConcernErrorDocument.getDocument("errInfo", new BsonDocument()));
     }
 
     private static WriteConcernResult createWriteConcernResult(final BsonDocument result) {

--- a/driver-core/src/main/com/mongodb/operation/FindAndReplaceOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/FindAndReplaceOperation.java
@@ -40,7 +40,7 @@ import static com.mongodb.operation.CommandOperationHelper.CommandCreator;
 import static com.mongodb.operation.DocumentHelper.putIfNotNull;
 import static com.mongodb.operation.DocumentHelper.putIfNotZero;
 import static com.mongodb.operation.DocumentHelper.putIfTrue;
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotTwo;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
 import static com.mongodb.operation.OperationHelper.validateCollation;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 

--- a/driver-core/src/main/com/mongodb/operation/FindAndUpdateOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/FindAndUpdateOperation.java
@@ -42,7 +42,7 @@ import static com.mongodb.operation.CommandOperationHelper.CommandCreator;
 import static com.mongodb.operation.DocumentHelper.putIfNotNull;
 import static com.mongodb.operation.DocumentHelper.putIfNotZero;
 import static com.mongodb.operation.DocumentHelper.putIfTrue;
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotTwo;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
 import static com.mongodb.operation.OperationHelper.validateCollation;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 

--- a/driver-core/src/main/com/mongodb/operation/FindOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/FindOperation.java
@@ -69,7 +69,7 @@ import static com.mongodb.operation.OperationHelper.AsyncCallableWithConnectionA
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.cursorDocumentToQueryResult;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotTwo;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
 import static com.mongodb.operation.OperationHelper.validateReadConcernAndCollation;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.operation.OperationReadConcernHelper.appendReadConcernToCommand;

--- a/driver-core/src/main/com/mongodb/operation/FsyncUnlockOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/FsyncUnlockOperation.java
@@ -26,7 +26,7 @@ import org.bson.BsonInt32;
 import org.bson.codecs.BsonDocumentCodec;
 
 import static com.mongodb.operation.CommandOperationHelper.executeWrappedCommandProtocol;
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotTwo;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
 import static com.mongodb.operation.OperationHelper.withConnection;
 
 /**

--- a/driver-core/src/main/com/mongodb/operation/ListCollectionsOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ListCollectionsOperation.java
@@ -65,7 +65,7 @@ import static com.mongodb.operation.OperationHelper.createEmptyBatchCursor;
 import static com.mongodb.operation.OperationHelper.cursorDocumentToAsyncBatchCursor;
 import static com.mongodb.operation.OperationHelper.cursorDocumentToBatchCursor;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotZero;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotZero;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;

--- a/driver-core/src/main/com/mongodb/operation/ListIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ListIndexesOperation.java
@@ -55,7 +55,7 @@ import static com.mongodb.operation.OperationHelper.createEmptyBatchCursor;
 import static com.mongodb.operation.OperationHelper.cursorDocumentToAsyncBatchCursor;
 import static com.mongodb.operation.OperationHelper.cursorDocumentToBatchCursor;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotZero;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotZero;
 import static com.mongodb.operation.OperationHelper.withConnection;
 
 /**

--- a/driver-core/src/main/com/mongodb/operation/MapReduceToCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/MapReduceToCollectionOperation.java
@@ -52,8 +52,8 @@ import static com.mongodb.operation.OperationHelper.validateCollation;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
 import static com.mongodb.operation.OperationHelper.withConnection;
-import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
-import static com.mongodb.operation.WriteConcernHelper.throwOnWriteConcernError;
+import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
+import static com.mongodb.internal.operation.WriteConcernHelper.throwOnWriteConcernError;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 

--- a/driver-core/src/main/com/mongodb/operation/MapReduceToCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/MapReduceToCollectionOperation.java
@@ -50,7 +50,7 @@ import static com.mongodb.operation.OperationHelper.AsyncCallableWithConnection;
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.validateCollation;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotTwo;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.WriteConcernHelper.throwOnWriteConcernError;

--- a/driver-core/src/main/com/mongodb/operation/MixedBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/MixedBulkWriteOperation.java
@@ -52,7 +52,7 @@ import static com.mongodb.operation.OperationHelper.CallableWithConnectionAndSou
 import static com.mongodb.operation.OperationHelper.ConnectionReleasingWrappedCallback;
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.isRetryableWrite;
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotSix;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotSix;
 import static com.mongodb.operation.OperationHelper.validateWriteRequests;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.operation.OperationHelper.withReleasableConnection;

--- a/driver-core/src/main/com/mongodb/operation/OperationHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/OperationHelper.java
@@ -45,6 +45,7 @@ import com.mongodb.connection.ServerType;
 import com.mongodb.connection.ServerVersion;
 import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
+import com.mongodb.internal.operation.ServerVersionHelper;
 import com.mongodb.session.SessionContext;
 import org.bson.BsonDocument;
 import org.bson.BsonInt64;
@@ -79,7 +80,7 @@ final class OperationHelper {
     }
 
     static void validateReadConcern(final Connection connection, final ReadConcern readConcern) {
-        if (!serverIsAtLeastVersionThreeDotTwo(connection.getDescription()) && !readConcern.isServerDefault()) {
+        if (!ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo(connection.getDescription()) && !readConcern.isServerDefault()) {
             throw new IllegalArgumentException(format("ReadConcern not supported by server version: %s",
                     connection.getDescription().getServerVersion()));
         }
@@ -88,7 +89,7 @@ final class OperationHelper {
     static void validateReadConcern(final AsyncConnection connection, final ReadConcern readConcern,
                                     final AsyncCallableWithConnection callable) {
         Throwable throwable = null;
-        if (!serverIsAtLeastVersionThreeDotTwo(connection.getDescription()) && !readConcern.isServerDefault()) {
+        if (!ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo(connection.getDescription()) && !readConcern.isServerDefault()) {
             throwable = new IllegalArgumentException(format("ReadConcern not supported by server version: %s",
                     connection.getDescription().getServerVersion()));
         }
@@ -110,7 +111,7 @@ final class OperationHelper {
     }
 
     static void validateCollation(final ConnectionDescription connectionDescription, final Collation collation) {
-        if (collation != null && !serverIsAtLeastVersionThreeDotFour(connectionDescription)) {
+        if (collation != null && !ServerVersionHelper.serverIsAtLeastVersionThreeDotFour(connectionDescription)) {
             throw new IllegalArgumentException(format("Collation not supported by server version: %s",
                     connectionDescription.getServerVersion()));
         }
@@ -118,7 +119,7 @@ final class OperationHelper {
 
     static void validateCollationAndWriteConcern(final ConnectionDescription connectionDescription, final Collation collation,
                                                  final WriteConcern writeConcern) {
-        if (collation != null && !serverIsAtLeastVersionThreeDotFour(connectionDescription)) {
+        if (collation != null && !ServerVersionHelper.serverIsAtLeastVersionThreeDotFour(connectionDescription)) {
             throw new IllegalArgumentException(format("Collation not supported by server version: %s",
                     connectionDescription.getServerVersion()));
         } else if (collation != null && !writeConcern.isAcknowledged()) {
@@ -129,7 +130,7 @@ final class OperationHelper {
     static void validateCollation(final AsyncConnection connection, final Collation collation,
                                   final AsyncCallableWithConnection callable) {
         Throwable throwable = null;
-        if (!serverIsAtLeastVersionThreeDotFour(connection.getDescription()) && collation != null) {
+        if (!ServerVersionHelper.serverIsAtLeastVersionThreeDotFour(connection.getDescription()) && collation != null) {
             throwable = new IllegalArgumentException(format("Collation not supported by server version: %s",
                     connection.getDescription().getServerVersion()));
         }
@@ -241,7 +242,7 @@ final class OperationHelper {
 
     static void checkBypassDocumentValidationIsSupported(final ConnectionDescription connectionDescription,
                                                          final Boolean bypassDocumentValidation, final WriteConcern writeConcern) {
-        if (bypassDocumentValidation != null && serverIsAtLeastVersionThreeDotTwo(connectionDescription)
+        if (bypassDocumentValidation != null && ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo(connectionDescription)
                 && !writeConcern.isAcknowledged()) {
             throw new MongoClientException("Specifying bypassDocumentValidation with an unacknowledged WriteConcern is not supported");
         }
@@ -383,26 +384,6 @@ final class OperationHelper {
             source.release();
             return wrapped;
         }
-    }
-
-    static boolean serverIsAtLeastVersionThreeDotZero(final ConnectionDescription description) {
-        return serverIsAtLeastVersion(description, new ServerVersion(3, 0));
-    }
-
-    static boolean serverIsAtLeastVersionThreeDotTwo(final ConnectionDescription description) {
-        return serverIsAtLeastVersion(description, new ServerVersion(3, 2));
-    }
-
-    static boolean serverIsAtLeastVersionThreeDotFour(final ConnectionDescription description) {
-        return serverIsAtLeastVersion(description, new ServerVersion(3, 4));
-    }
-
-    static boolean serverIsAtLeastVersionThreeDotSix(final ConnectionDescription description) {
-        return serverIsAtLeastVersion(description, new ServerVersion(3, 6));
-    }
-
-    static boolean serverIsAtLeastVersion(final ConnectionDescription description, final ServerVersion serverVersion) {
-        return description.getServerVersion().compareTo(serverVersion) >= 0;
     }
 
     static <T> T withConnection(final ReadBinding binding, final CallableWithConnection<T> callable) {

--- a/driver-core/src/main/com/mongodb/operation/QueryBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/QueryBatchCursor.java
@@ -42,7 +42,7 @@ import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.operation.CursorHelper.getNumberToReturn;
 import static com.mongodb.operation.OperationHelper.getMoreCursorDocumentToQueryResult;
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotTwo;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
 import static com.mongodb.operation.QueryHelper.translateCommandException;
 import static java.util.Collections.singletonList;
 

--- a/driver-core/src/main/com/mongodb/operation/RenameCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/RenameCollectionOperation.java
@@ -36,7 +36,7 @@ import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
-import static com.mongodb.operation.WriteConcernHelper.writeConcernErrorTransformer;
+import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**
  * An operation that renames the given collection to the new name.

--- a/driver-core/src/main/com/mongodb/operation/RenameCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/RenameCollectionOperation.java
@@ -35,7 +35,7 @@ import static com.mongodb.operation.CommandOperationHelper.executeWrappedCommand
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.withConnection;
-import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
+import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**

--- a/driver-core/src/main/com/mongodb/operation/TransactionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/TransactionOperation.java
@@ -35,7 +35,7 @@ import static com.mongodb.operation.CommandOperationHelper.executeWrappedCommand
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
 import static com.mongodb.operation.OperationHelper.withConnection;
-import static com.mongodb.operation.WriteConcernHelper.writeConcernErrorTransformer;
+import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**
  * A base class for transaction-related operations

--- a/driver-core/src/main/com/mongodb/operation/UpdateUserOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/UpdateUserOperation.java
@@ -39,7 +39,7 @@ import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.operation.UserOperationHelper.asCommandDocument;
 import static com.mongodb.operation.UserOperationHelper.translateUserCommandException;
 import static com.mongodb.operation.UserOperationHelper.userCommandCallback;
-import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
+import static com.mongodb.internal.operation.WriteConcernHelper.appendWriteConcernToCommand;
 import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**

--- a/driver-core/src/main/com/mongodb/operation/UpdateUserOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/UpdateUserOperation.java
@@ -40,7 +40,7 @@ import static com.mongodb.operation.UserOperationHelper.asCommandDocument;
 import static com.mongodb.operation.UserOperationHelper.translateUserCommandException;
 import static com.mongodb.operation.UserOperationHelper.userCommandCallback;
 import static com.mongodb.operation.WriteConcernHelper.appendWriteConcernToCommand;
-import static com.mongodb.operation.WriteConcernHelper.writeConcernErrorTransformer;
+import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTransformer;
 
 /**
  * An operation that updates a user.

--- a/driver-core/src/main/com/mongodb/operation/UserOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/UserOperationHelper.java
@@ -32,8 +32,8 @@ import org.bson.BsonValue;
 import java.util.Collections;
 
 import static com.mongodb.internal.authentication.NativeAuthenticationHelper.createAuthenticationHash;
-import static com.mongodb.operation.WriteConcernHelper.createWriteConcernError;
-import static com.mongodb.operation.WriteConcernHelper.hasWriteConcernError;
+import static com.mongodb.internal.operation.WriteConcernHelper.createWriteConcernError;
+import static com.mongodb.internal.operation.WriteConcernHelper.hasWriteConcernError;
 
 final class UserOperationHelper {
     private static final ServerVersion FOUR_ZERO = new ServerVersion(3, 7);

--- a/driver-core/src/main/com/mongodb/operation/UserOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/UserOperationHelper.java
@@ -20,6 +20,7 @@ import com.mongodb.MongoCommandException;
 import com.mongodb.MongoCredential;
 import com.mongodb.MongoInternalException;
 import com.mongodb.async.SingleResultCallback;
+import com.mongodb.internal.operation.WriteConcernHelper;
 import com.mongodb.lang.NonNull;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.connection.ServerVersion;
@@ -32,7 +33,6 @@ import org.bson.BsonValue;
 import java.util.Collections;
 
 import static com.mongodb.internal.authentication.NativeAuthenticationHelper.createAuthenticationHash;
-import static com.mongodb.internal.operation.WriteConcernHelper.createWriteConcernError;
 import static com.mongodb.internal.operation.WriteConcernHelper.hasWriteConcernError;
 
 final class UserOperationHelper {
@@ -60,7 +60,7 @@ final class UserOperationHelper {
 
     static void translateUserCommandException(final MongoCommandException e) {
         if (e.getErrorCode() == 100 && hasWriteConcernError(e.getResponse())) {
-            throw createWriteConcernError(e.getResponse(), e.getServerAddress());
+            throw WriteConcernHelper.createWriteConcernException(e.getResponse(), e.getServerAddress());
         } else {
             throw e;
         }
@@ -74,7 +74,7 @@ final class UserOperationHelper {
                     if (t instanceof MongoCommandException
                                 && hasWriteConcernError(((MongoCommandException) t).getResponse())) {
                         wrappedCallback.onResult(null,
-                                createWriteConcernError(((MongoCommandException) t).getResponse(),
+                                WriteConcernHelper.createWriteConcernException(((MongoCommandException) t).getResponse(),
                                         ((MongoCommandException) t).getServerAddress()));
                     } else {
                         wrappedCallback.onResult(null, t);

--- a/driver-core/src/main/com/mongodb/operation/WriteConcernHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/WriteConcernHelper.java
@@ -36,16 +36,6 @@ final class WriteConcernHelper {
         }
     }
 
-    static CommandTransformer<BsonDocument, Void> writeConcernErrorTransformer() {
-        return new CommandTransformer<BsonDocument, Void>() {
-            @Override
-            public Void apply(final BsonDocument result, final ServerAddress serverAddress) {
-                throwOnWriteConcernError(result, serverAddress);
-                return null;
-            }
-        };
-    }
-
     static void throwOnWriteConcernError(final BsonDocument result, final ServerAddress serverAddress) {
         if (hasWriteConcernError(result)) {
             throw createWriteConcernError(result, serverAddress); }

--- a/driver-core/src/main/com/mongodb/operation/WriteConcernHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/WriteConcernHelper.java
@@ -22,10 +22,9 @@ import com.mongodb.WriteConcern;
 import com.mongodb.WriteConcernResult;
 import com.mongodb.bulk.WriteConcernError;
 import com.mongodb.connection.ConnectionDescription;
-import com.mongodb.operation.CommandOperationHelper.CommandTransformer;
 import org.bson.BsonDocument;
 
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotFour;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotFour;
 
 final class WriteConcernHelper {
 

--- a/driver-core/src/test/functional/com/mongodb/operation/AsyncQueryBatchCursorFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/AsyncQueryBatchCursorFunctionalSpecification.groovy
@@ -56,7 +56,7 @@ import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.connection.ServerHelper.waitForLastRelease
 import static com.mongodb.connection.ServerHelper.waitForRelease
 import static com.mongodb.operation.OperationHelper.cursorDocumentToQueryResult
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotTwo
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo
 import static java.util.Arrays.asList
 import static java.util.concurrent.TimeUnit.SECONDS
 import static org.junit.Assert.assertEquals

--- a/driver-core/src/test/functional/com/mongodb/operation/QueryBatchCursorFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/QueryBatchCursorFunctionalSpecification.groovy
@@ -46,7 +46,7 @@ import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.operation.OperationHelper.cursorDocumentToQueryResult
-import static com.mongodb.operation.OperationHelper.serverIsAtLeastVersionThreeDotTwo
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo
 import static java.util.Arrays.asList
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.fail

--- a/driver-core/src/test/unit/com/mongodb/MongoCommandExceptionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/MongoCommandExceptionSpecification.groovy
@@ -44,4 +44,11 @@ class MongoCommandExceptionSpecification extends Specification {
                 .getErrorCode() == -1
     }
 
+    def 'should extract error code name'() {
+        expect:
+        new MongoCommandException(new BsonDocument('ok', BsonBoolean.FALSE).append('code', new BsonInt32(26))
+                .append('codeName', new BsonString('TimeoutError')), new ServerAddress()).getErrorCodeName() == 'TimeoutError'
+        new MongoCommandException(new BsonDocument('ok', BsonBoolean.FALSE), new ServerAddress()).getErrorCodeName() == ''
+    }
+
 }

--- a/driver-core/src/test/unit/com/mongodb/MongoCommandExceptionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/MongoCommandExceptionSpecification.groovy
@@ -51,4 +51,16 @@ class MongoCommandExceptionSpecification extends Specification {
         new MongoCommandException(new BsonDocument('ok', BsonBoolean.FALSE), new ServerAddress()).getErrorCodeName() == ''
     }
 
+    def 'should create message'() {
+        expect:
+        new MongoCommandException(new BsonDocument('ok', BsonBoolean.FALSE).append('code', new BsonInt32(26))
+                .append('codeName', new BsonString('TimeoutError')).append('errmsg', new BsonString('the error message')),
+                new ServerAddress())
+                .getMessage() == 'Command failed with error 26 (TimeoutError): \'the error message\' on server 127.0.0.1:27017. ' +
+                'The full response is { "ok" : false, "code" : 26, "codeName" : "TimeoutError", "errmsg" : "the error message" }'
+        new MongoCommandException(new BsonDocument('ok', BsonBoolean.FALSE).append('code', new BsonInt32(26))
+                .append('errmsg', new BsonString('the error message')), new ServerAddress())
+                .getMessage() == 'Command failed with error 26: \'the error message\' on server 127.0.0.1:27017. ' +
+                'The full response is { "ok" : false, "code" : 26, "errmsg" : "the error message" }'
+    }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/WriteConcernHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/WriteConcernHelperSpecification.groovy
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.operation
+
+class WriteConcernHelperSpecification {
+
+    def 'should create write concern error'() {
+
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/WriteConcernHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/WriteConcernHelperSpecification.groovy
@@ -16,9 +16,24 @@
 
 package com.mongodb.internal.operation
 
-class WriteConcernHelperSpecification {
+import org.bson.BsonDocument
+import org.bson.BsonInt32
+import org.bson.BsonString
+import spock.lang.Specification
+
+import static com.mongodb.internal.operation.WriteConcernHelper.createWriteConcernError
+
+class WriteConcernHelperSpecification extends Specification {
 
     def 'should create write concern error'() {
+        when:
+        def writeConcernError = createWriteConcernError(new BsonDocument('code', new BsonInt32(42))
+                .append('errmsg', new BsonString('a timeout'))
+                .append('errInfo', new BsonDocument('wtimeout', new BsonInt32(1))))
 
-    }
+        then:
+        writeConcernError.getCode() == 42
+        writeConcernError.getMessage() == 'a timeout'
+        writeConcernError.getDetails() == new BsonDocument('wtimeout', new BsonInt32(1))
+   }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/operation/WriteConcernHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/operation/WriteConcernHelperSpecification.groovy
@@ -33,7 +33,20 @@ class WriteConcernHelperSpecification extends Specification {
 
         then:
         writeConcernError.getCode() == 42
+        writeConcernError.getCodeName() == ''
         writeConcernError.getMessage() == 'a timeout'
         writeConcernError.getDetails() == new BsonDocument('wtimeout', new BsonInt32(1))
-   }
+
+        when:
+        writeConcernError = createWriteConcernError(new BsonDocument('code', new BsonInt32(42))
+                .append('codeName', new BsonString('TimeoutError'))
+                .append('errmsg', new BsonString('a timeout'))
+                .append('errInfo', new BsonDocument('wtimeout', new BsonInt32(1))))
+
+        then:
+        writeConcernError.getCode() == 42
+        writeConcernError.getCodeName() == 'TimeoutError'
+        writeConcernError.getMessage() == 'a timeout'
+        writeConcernError.getDetails() == new BsonDocument('wtimeout', new BsonInt32(1))
+    }
 }


### PR DESCRIPTION
The server introduced a codeName field in error responses, which is a
stringified version of the integral error code.

This pull request adds a codeName property to MongoCommandException and
WriteConcernError, which is included in various exception types
including MongoWriteConcernException.

The patch has many commits.  The first five are just a series of automated refactorings and can mostly be ignored. I kept them separate because they affect a large number of files. The second to last adds a missing regression test, and the final one is the actual functional change.