### PR TITLE
JAVA-2824: Stop authenticating server monitor connections

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/DefaultClusterableServerFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/DefaultClusterableServerFactory.java
@@ -64,10 +64,12 @@ class DefaultClusterableServerFactory implements ClusterableServerFactory {
         ConnectionPool connectionPool = new DefaultConnectionPool(new ServerId(clusterId, serverAddress),
                 new InternalStreamConnectionFactory(streamFactory, credentialList, applicationName,
                         mongoDriverInformation, compressorList, commandListener), connectionPoolSettings);
+
+        // no credentials, compressor list, or command listener for the server monitor factory
         ServerMonitorFactory serverMonitorFactory =
             new DefaultServerMonitorFactory(new ServerId(clusterId, serverAddress), serverSettings, clusterClock,
-                    new InternalStreamConnectionFactory(heartbeatStreamFactory, credentialList, applicationName,
-                            mongoDriverInformation, Collections.<MongoCompressor>emptyList(), null), connectionPool);
+                    new InternalStreamConnectionFactory(heartbeatStreamFactory, Collections.<MongoCredentialWithCache>emptyList(),
+                            applicationName, mongoDriverInformation, Collections.<MongoCompressor>emptyList(), null), connectionPool);
 
         return new DefaultServer(new ServerId(clusterId, serverAddress), clusterSettings.getMode(), connectionPool,
                 new DefaultConnectionFactory(), serverMonitorFactory, serverListener, commandListener, clusterClock);

--- a/driver-core/src/main/com/mongodb/connection/DefaultServer.java
+++ b/driver-core/src/main/com/mongodb/connection/DefaultServer.java
@@ -79,7 +79,7 @@ class DefaultServer implements ClusterableServer {
         try {
             return connectionFactory.create(connectionPool.get(), new DefaultServerProtocolExecutor(), clusterConnectionMode);
         } catch (MongoSecurityException e) {
-            invalidate();
+            connectionPool.invalidate();
             throw e;
         } catch (MongoSocketException e) {
             invalidate();
@@ -93,7 +93,9 @@ class DefaultServer implements ClusterableServer {
         connectionPool.getAsync(new SingleResultCallback<InternalConnection>() {
             @Override
             public void onResult(final InternalConnection result, final Throwable t) {
-                if (t instanceof MongoSecurityException || t instanceof MongoSocketException) {
+                if (t instanceof MongoSecurityException) {
+                    connectionPool.invalidate();
+                } else if (t instanceof MongoSocketException) {
                     invalidate();
                 }
                 if (t != null) {

--- a/driver-core/src/test/functional/com/mongodb/operation/UserOperationsSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/UserOperationsSpecification.groovy
@@ -19,8 +19,8 @@ package com.mongodb.operation
 import category.Slow
 import com.mongodb.MongoCredential
 import com.mongodb.MongoNamespace
+import com.mongodb.MongoSecurityException
 import com.mongodb.MongoServerException
-import com.mongodb.MongoTimeoutException
 import com.mongodb.MongoWriteConcernException
 import com.mongodb.OperationFunctionalSpecification
 import com.mongodb.ReadPreference
@@ -135,12 +135,13 @@ class UserOperationsSpecification extends OperationFunctionalSpecification {
         given:
         def credential = createCredential('user', databaseName, 'pencil' as char[])
         def cluster = getCluster(credential, ClusterSettings.builder().serverSelectionTimeout(1, TimeUnit.SECONDS))
+        def server = cluster.selectServer(new WritableServerSelector())
 
         when:
-        cluster.selectServer(new WritableServerSelector())
+        server.getConnection()
 
         then:
-        thrown(MongoTimeoutException)
+        thrown(MongoSecurityException)
 
         cleanup:
         cluster?.close()
@@ -155,12 +156,13 @@ class UserOperationsSpecification extends OperationFunctionalSpecification {
         execute(new CreateUserOperation(credential, true), async)
         execute(new DropUserOperation(databaseName, credential.userName), async)
         def cluster = getCluster(ClusterSettings.builder().serverSelectionTimeout(1, TimeUnit.SECONDS))
+        def server = cluster.selectServer(new WritableServerSelector())
 
         when:
-        cluster.selectServer(new WritableServerSelector())
+        server.getConnection()
 
         then:
-        thrown(MongoTimeoutException)
+        thrown(MongoSecurityException)
 
         cleanup:
         cluster?.close()


### PR DESCRIPTION
This is a significant behavior change in the driver, as authentication
errors will be thrown much faster to applications, as a
MongoSecurityException rather than as a MongoTimeoutException after the
server selection timeout (which defaults to 30 seconds) has expired.