### PR TITLE
JAVA-2811: Stop supporting client sessions for standalone servers

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/ClientSessionHelper.java
+++ b/driver-async/src/main/com/mongodb/async/client/ClientSessionHelper.java
@@ -21,8 +21,10 @@ import com.mongodb.TransactionOptions;
 import com.mongodb.async.SingleResultCallback;
 import com.mongodb.connection.ClusterConnectionMode;
 import com.mongodb.connection.ClusterDescription;
+import com.mongodb.connection.ClusterType;
 import com.mongodb.connection.Server;
 import com.mongodb.connection.ServerDescription;
+import com.mongodb.connection.ServerType;
 import com.mongodb.internal.session.ServerSessionPool;
 import com.mongodb.lang.Nullable;
 import com.mongodb.selector.ServerSelector;
@@ -59,7 +61,8 @@ class ClientSessionHelper {
         } else {
             ClusterDescription clusterDescription = mongoClient.getCluster().getCurrentDescription();
             if (!getServerDescriptionListToConsiderForSessionSupport(clusterDescription).isEmpty()
-                    && clusterDescription.getLogicalSessionTimeoutMinutes() != null) {
+                    && clusterDescription.getLogicalSessionTimeoutMinutes() != null
+                    && clusterDescription.getType() != ClusterType.STANDALONE) {
                 callback.onResult(createClientSession(options, executor), null);
             } else {
                 mongoClient.getCluster().selectServerAsync(new ServerSelector() {
@@ -72,7 +75,8 @@ class ClientSessionHelper {
                     public void onResult(final Server server, final Throwable t) {
                         if (t != null) {
                             callback.onResult(null, null);
-                        } else if (server.getDescription().getLogicalSessionTimeoutMinutes() == null) {
+                        } else if (server.getDescription().getLogicalSessionTimeoutMinutes() == null
+                                || server.getDescription().getType() == ServerType.STANDALONE) {
                             callback.onResult(null, null);
                         } else {
                             callback.onResult(createClientSession(options, executor), null);

--- a/driver-async/src/test/functional/com/mongodb/async/client/MongoClientSessionSpecification.groovy
+++ b/driver-async/src/test/functional/com/mongodb/async/client/MongoClientSessionSpecification.groovy
@@ -52,7 +52,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         thrown(IllegalArgumentException)
     }
 
-    @IgnoreIf({ serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionAtLeast(3, 6) && !isStandalone() })
     def 'should throw MongoClientException starting a session when sessions are not supported'() {
         when:
         startSession(ClientSessionOptions.builder().build())
@@ -61,7 +61,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         thrown(MongoClientException)
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone() })
     def 'should create session with correct defaults'() {
         when:
         def options = ClientSessionOptions.builder().build()
@@ -85,7 +85,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone() })
     def 'cluster time should advance'() {
         given:
         def firstOperationTime = new BsonTimestamp(42, 1)
@@ -129,7 +129,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone() })
     def 'operation time should advance'() {
         given:
         def firstOperationTime = new BsonTimestamp(42, 1)
@@ -170,7 +170,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone() })
     def 'methods that use the session should throw if the session is closed'() {
         given:
         def options = ClientSessionOptions.builder().build()
@@ -199,7 +199,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone() })
     def 'informational methods should not throw if the session is closed'() {
         given:
         def options = ClientSessionOptions.builder().build()
@@ -216,7 +216,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         true
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone() })
     def 'should apply causally consistent session option to client session'() {
         when:
         def clientSession = startSession(ClientSessionOptions.builder().causallyConsistent(causallyConsistent).build())
@@ -232,7 +232,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         causallyConsistent << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone() })
     def 'client session should have server session with valid identifier'() {
         given:
         def clientSession = startSession(ClientSessionOptions.builder().build())
@@ -251,7 +251,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone() })
     def 'should use a default session'() {
         given:
         def commandListener = new TestCommandListener()
@@ -270,7 +270,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         client?.close()
     }
 
-    @IgnoreIf({ serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionAtLeast(3, 6) && !isStandalone() })
     def 'should not use a default session when sessions are not supported'() {
         given:
         def commandListener = new TestCommandListener()

--- a/driver-legacy/src/test/functional/com/mongodb/MongoClientSessionSpecification.groovy
+++ b/driver-legacy/src/test/functional/com/mongodb/MongoClientSessionSpecification.groovy
@@ -48,7 +48,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         thrown(IllegalArgumentException)
     }
 
-    @IgnoreIf({ serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionAtLeast(3, 6) && !isStandalone() })
     def 'should throw MongoClientException starting a session when sessions are not supported'() {
         when:
         getMongoClient().startSession()
@@ -63,7 +63,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         thrown(MongoClientException)
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone() })
     def 'should create session with correct defaults'() {
         expect:
         clientSession.getOriginator() == getMongoClient()
@@ -86,7 +86,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
                           getMongoClient().startSession(ClientSessionOptions.builder().build())]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 7) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 7) || isStandalone()  })
     def 'should use mutated client write concern for default transaction options'() {
         given:
         def originalWriteConcern = getMongoClient().getWriteConcern()
@@ -106,7 +106,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession?.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone()  })
     def 'cluster time should advance'() {
         given:
         def firstOperationTime = new BsonTimestamp(42, 1)
@@ -150,7 +150,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession?.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone()  })
     def 'operation time should advance'() {
         given:
         def firstOperationTime = new BsonTimestamp(42, 1)
@@ -191,7 +191,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession?.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone()  })
     def 'methods that use the session should throw if the session is closed'() {
         given:
         def options = ClientSessionOptions.builder().build()
@@ -220,7 +220,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession?.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone()  })
     def 'informational methods should not throw if the session is closed'() {
         given:
         def options = ClientSessionOptions.builder().build()
@@ -240,7 +240,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession?.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone()  })
     def 'should apply causally consistent session option to client session'() {
         when:
         def clientSession = getMongoClient().startSession(ClientSessionOptions.builder()
@@ -258,7 +258,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         causallyConsistent << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone()  })
     def 'client session should have server session with valid identifier'() {
         given:
         def clientSession = getMongoClient().startSession(ClientSessionOptions.builder().build())
@@ -277,13 +277,13 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession?.close()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone()  })
     def 'should use a default session'() {
         given:
         def commandListener = new TestCommandListener()
         def optionsBuilder = MongoClientOptions.builder()
                 .addCommandListener(commandListener)
-        def client = new MongoClient(Fixture.getMongoClientURI(optionsBuilder))
+        def client = new MongoClient(getMongoClientURI(optionsBuilder))
 
         when:
         client.getDatabase('admin').runCommand(new BsonDocument('ping', new BsonInt32(1)))
@@ -297,7 +297,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         client?.close()
     }
 
-    @IgnoreIf({ serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionAtLeast(3, 6) && !isStandalone() })
     def 'should not use a default session when sessions are not supported'() {
         given:
         def commandListener = new TestCommandListener()

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoClientDelegate.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoClientDelegate.java
@@ -32,6 +32,7 @@ import com.mongodb.client.ClientSession;
 import com.mongodb.connection.Cluster;
 import com.mongodb.connection.ClusterConnectionMode;
 import com.mongodb.connection.ClusterDescription;
+import com.mongodb.connection.ClusterType;
 import com.mongodb.connection.ServerDescription;
 import com.mongodb.internal.session.ServerSessionPool;
 import com.mongodb.lang.Nullable;
@@ -83,7 +84,12 @@ public class MongoClientDelegate {
             return null;
         }
 
-        if (getConnectedClusterDescription().getLogicalSessionTimeoutMinutes() != null) {
+        ClusterDescription connectedClusterDescription = getConnectedClusterDescription();
+
+        if (connectedClusterDescription.getType() == ClusterType.STANDALONE
+                || connectedClusterDescription.getLogicalSessionTimeoutMinutes() == null) {
+            return null;
+        } else {
             ClientSessionOptions mergedOptions = ClientSessionOptions.builder(options)
                     .defaultTransactionOptions(
                             TransactionOptions.merge(
@@ -94,8 +100,6 @@ public class MongoClientDelegate {
                                             .build()))
                     .build();
             return new ClientSessionImpl(serverSessionPool, originator, mergedOptions, this);
-        } else {
-            return null;
         }
     }
 

--- a/driver-sync/src/test/functional/com/mongodb/client/MongoClientSessionSpecification.groovy
+++ b/driver-sync/src/test/functional/com/mongodb/client/MongoClientSessionSpecification.groovy
@@ -19,6 +19,7 @@ package com.mongodb.client
 import category.Slow
 import com.mongodb.ClientSessionOptions
 import com.mongodb.MongoClientException
+import com.mongodb.MongoClientSettings
 import com.mongodb.ReadConcern
 import com.mongodb.ReadPreference
 import com.mongodb.TransactionOptions
@@ -52,7 +53,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         thrown(IllegalArgumentException)
     }
 
-    @IgnoreIf({ serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionAtLeast(3, 6) && !isStandalone() })
     def 'should throw MongoClientException starting a session when sessions are not supported'() {
         when:
         getMongoClient().startSession()
@@ -67,7 +68,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         thrown(MongoClientException)
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone() })
     def 'should create session with correct defaults'() {
         expect:
         clientSession.getOriginator() == getMongoClient()
@@ -90,7 +91,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
                           getMongoClient().startSession(ClientSessionOptions.builder().build())]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone() })
     def 'cluster time should advance'() {
         given:
         def firstOperationTime = new BsonTimestamp(42, 1)
@@ -131,7 +132,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession.getClusterTime() == secondClusterTime
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone() })
     def 'operation time should advance'() {
         given:
         def firstOperationTime = new BsonTimestamp(42, 1)
@@ -169,7 +170,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         clientSession.getOperationTime() == secondOperationTime
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone() })
     def 'methods that use the session should throw if the session is closed'() {
         given:
         def options = ClientSessionOptions.builder().build()
@@ -195,7 +196,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         thrown(IllegalStateException)
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone() })
     def 'informational methods should not throw if the session is closed'() {
         given:
         def options = ClientSessionOptions.builder().build()
@@ -212,7 +213,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         noExceptionThrown()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone() })
     def 'should apply causally consistent session option to client session'() {
         when:
         def clientSession = getMongoClient().startSession(ClientSessionOptions.builder()
@@ -227,7 +228,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         causallyConsistent << [true, false]
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone() })
     def 'client session should have server session with valid identifier'() {
         given:
         def clientSession = getMongoClient().startSession(ClientSessionOptions.builder().build())
@@ -243,7 +244,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         identifier.getBinary('id').data.length == 16
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || isStandalone() })
     def 'should use a default session'() {
         given:
         def commandListener = new TestCommandListener()
@@ -262,7 +263,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
         client?.close()
     }
 
-    @IgnoreIf({ serverVersionAtLeast(3, 6) })
+    @IgnoreIf({ serverVersionAtLeast(3, 6) && !isStandalone() })
     def 'should not use a default session when sessions are not supported'() {
         given:
         def commandListener = new TestCommandListener()


### PR DESCRIPTION
The driver sessions specification requires that client sessions not
be supported when connected to a MongoDB standalone server.  This patch
ensures that explicitly created client sessions are not supported, and
that implicit sessions are not used, when connected to a standalone
server.

Patch build: https://evergreen.mongodb.com/version/5ae8cea2e3c331704506c7da