### PR TITLE
 JAVA-2788: Prohibit unacknowledged writes within an explicit session

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/ClientSessionBinding.java
+++ b/driver-async/src/main/com/mongodb/async/client/ClientSessionBinding.java
@@ -153,6 +153,11 @@ class ClientSessionBinding implements AsyncReadWriteBinding {
 
 
         @Override
+        public boolean isImplicitSession() {
+            return ownsSession;
+        }
+
+        @Override
         public boolean notifyMessageSent() {
             return clientSession.notifyMessageSent();
         }

--- a/driver-async/src/test/unit/com/mongodb/async/client/ClientSessionBindingSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/ClientSessionBindingSpecification.groovy
@@ -163,7 +163,7 @@ class ClientSessionBindingSpecification extends Specification {
         where:
         ownsSession << [true, false]
     }
-    
+
     private AsyncReadWriteBinding createStubBinding() {
         def cluster = Mock(Cluster) {
             selectServerAsync(_, _) >> {

--- a/driver-async/src/test/unit/com/mongodb/async/client/ClientSessionBindingSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/ClientSessionBindingSpecification.groovy
@@ -149,6 +149,21 @@ class ClientSessionBindingSpecification extends Specification {
         0 * session.close()
     }
 
+    def 'owned session is implicit'() {
+        given:
+        def session = Mock(ClientSession)
+        def wrappedBinding = createStubBinding()
+
+        when:
+        def binding = new ClientSessionBinding(session, ownsSession, wrappedBinding)
+
+        then:
+        binding.getSessionContext().isImplicitSession() == ownsSession
+
+        where:
+        ownsSession << [true, false]
+    }
+    
     private AsyncReadWriteBinding createStubBinding() {
         def cluster = Mock(Cluster) {
             selectServerAsync(_, _) >> {

--- a/driver-core/src/main/com/mongodb/connection/ClusterClockAdvancingSessionContext.java
+++ b/driver-core/src/main/com/mongodb/connection/ClusterClockAdvancingSessionContext.java
@@ -37,6 +37,11 @@ final class ClusterClockAdvancingSessionContext implements SessionContext {
     }
 
     @Override
+    public boolean isImplicitSession() {
+        return wrapped.isImplicitSession();
+    }
+
+    @Override
     public BsonDocument getSessionId() {
         return wrapped.getSessionId();
     }

--- a/driver-core/src/main/com/mongodb/internal/connection/NoOpSessionContext.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/NoOpSessionContext.java
@@ -39,6 +39,11 @@ public class NoOpSessionContext implements SessionContext {
     }
 
     @Override
+    public boolean isImplicitSession() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public BsonDocument getSessionId() {
         throw new UnsupportedOperationException();
     }

--- a/driver-core/src/main/com/mongodb/operation/BulkWriteBatch.java
+++ b/driver-core/src/main/com/mongodb/operation/BulkWriteBatch.java
@@ -17,6 +17,7 @@
 package com.mongodb.operation;
 
 import com.mongodb.MongoBulkWriteException;
+import com.mongodb.MongoClientException;
 import com.mongodb.MongoInternalException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.WriteConcern;
@@ -97,6 +98,10 @@ final class BulkWriteBatch {
                                                       final Boolean bypassDocumentValidation, final boolean retryWrites,
                                                       final List<? extends WriteRequest> writeRequests,
                                                       final SessionContext sessionContext) {
+        if (sessionContext.hasSession() && !sessionContext.isImplicitSession() && !sessionContext.hasActiveTransaction()
+                && !writeConcern.isAcknowledged()) {
+            throw new MongoClientException("Unacknowledged writes are not supported when using an explicit session");
+        }
         boolean canRetryWrites = isRetryableWrite(retryWrites, writeConcern, serverDescription, connectionDescription, sessionContext);
         List<WriteRequestWithIndex> writeRequestsWithIndex = new ArrayList<WriteRequestWithIndex>();
         boolean writeRequestsAreRetryable = true;

--- a/driver-core/src/main/com/mongodb/session/SessionContext.java
+++ b/driver-core/src/main/com/mongodb/session/SessionContext.java
@@ -35,6 +35,14 @@ public interface SessionContext {
     boolean hasSession();
 
     /**
+     * Returns true if the session is implicit, and false if the application started the session explicity.
+     *
+     * @return true if the session is implicit
+     * @since 3.8
+     */
+    boolean isImplicitSession();
+
+    /**
      * Gets the session identifier if this context has a session backing it.
      *
      * @return the session id

--- a/driver-core/src/test/functional/com/mongodb/binding/SimpleSessionContext.java
+++ b/driver-core/src/test/functional/com/mongodb/binding/SimpleSessionContext.java
@@ -39,6 +39,11 @@ class SimpleSessionContext implements SessionContext {
 
     @Override
     public boolean hasSession() {
+        return false;
+    }
+
+    @Override
+    public boolean isImplicitSession() {
         return true;
     }
 

--- a/driver-core/src/test/unit/com/mongodb/connection/TestSessionContext.java
+++ b/driver-core/src/test/unit/com/mongodb/connection/TestSessionContext.java
@@ -40,6 +40,11 @@ class TestSessionContext implements SessionContext {
     }
 
     @Override
+    public boolean isImplicitSession() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public BsonDocument getSessionId() {
         throw new UnsupportedOperationException();
     }

--- a/driver-core/src/test/unit/com/mongodb/internal/session/ClientSessionContextSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/session/ClientSessionContextSpecification.groovy
@@ -39,6 +39,11 @@ class ClientSessionContextSpecification extends Specification {
         }
 
         @Override
+        boolean isImplicitSession() {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
         boolean notifyMessageSent() {
             throw new UnsupportedOperationException()
         }

--- a/driver-legacy/src/test/functional/com/mongodb/MongoClientSessionSpecification.groovy
+++ b/driver-legacy/src/test/functional/com/mongodb/MongoClientSessionSpecification.groovy
@@ -384,7 +384,7 @@ class MongoClientSessionSpecification extends FunctionalSpecification {
     }
 
     @IgnoreIf({ !serverVersionAtLeast(3, 6) })
-    def 'should not use a session for an unacknowledged write'() {
+    def 'should not use an implicit session for an unacknowledged write'() {
         given:
         def commandListener = new TestCommandListener()
         def optionsBuilder = MongoClientOptions.builder()

--- a/driver-sync/src/main/com/mongodb/client/internal/ClientSessionBinding.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ClientSessionBinding.java
@@ -139,6 +139,10 @@ public class ClientSessionBinding implements ReadWriteBinding {
             this.clientSession = clientSession;
         }
 
+        @Override
+        public boolean isImplicitSession() {
+            return ownsSession;
+        }
 
         @Override
         public boolean notifyMessageSent() {

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/ClientSessionBindingSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/ClientSessionBindingSpecification.groovy
@@ -133,6 +133,21 @@ class ClientSessionBindingSpecification extends Specification {
         0 * session.close()
     }
 
+    def 'owned session is implicit'() {
+        given:
+        def session = Mock(ClientSession)
+        def wrappedBinding = createStubBinding()
+
+        when:
+        def binding = new ClientSessionBinding(session, ownsSession, wrappedBinding)
+
+        then:
+        binding.getSessionContext().isImplicitSession() == ownsSession
+
+        where:
+        ownsSession << [true, false]
+    }
+
     private ReadWriteBinding createStubBinding() {
         def cluster = Stub(Cluster)
         new ClusterBinding(cluster, ReadPreference.primary())


### PR DESCRIPTION
Please review after #134, as this is rebased on top of that one.

Patch build: https://evergreen.mongodb.com/version/5aea1176e3c331252d08fe8d