### PR TITLE
JAVA-2848: Make it easier to run tests with a replica set

### DIFF
--- a/driver-async/src/test/functional/com/mongodb/async/client/Fixture.java
+++ b/driver-async/src/test/functional/com/mongodb/async/client/Fixture.java
@@ -35,11 +35,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * Helper class for asynchronous tests.
  */
 public final class Fixture {
-    public static final String DEFAULT_URI = "mongodb://localhost:27017";
-    public static final String MONGODB_URI_SYSTEM_PROPERTY_NAME = "org.mongodb.test.uri";
     private static final String DEFAULT_DATABASE_NAME = "JavaDriverTest";
 
-    private static ConnectionString connectionString;
     private static MongoClientImpl mongoClient;
 
 
@@ -69,13 +66,7 @@ public final class Fixture {
     }
 
     public static synchronized ConnectionString getConnectionString() {
-        if (connectionString == null) {
-            String mongoURIProperty = System.getProperty(MONGODB_URI_SYSTEM_PROPERTY_NAME);
-            String mongoURIString = mongoURIProperty == null || mongoURIProperty.isEmpty()
-                                    ? DEFAULT_URI : mongoURIProperty;
-            connectionString = new ConnectionString(mongoURIString);
-        }
-        return connectionString;
+        return ClusterFixture.getConnectionString();
     }
 
     public static String getDefaultDatabaseName() {

--- a/driver-legacy/src/test/functional/com/mongodb/Fixture.java
+++ b/driver-legacy/src/test/functional/com/mongodb/Fixture.java
@@ -24,8 +24,6 @@ import java.util.List;
  * Helper class for the acceptance tests.
  */
 public final class Fixture {
-    private static final String DEFAULT_URI = "mongodb://localhost:27017";
-    private static final String MONGODB_URI_SYSTEM_PROPERTY_NAME = "org.mongodb.test.uri";
     private static final String DEFAULT_DATABASE_NAME = "JavaDriverTest";
 
     private static MongoClient mongoClient;
@@ -85,9 +83,7 @@ public final class Fixture {
     }
 
     public static synchronized String getMongoClientURIString() {
-        String mongoURIProperty = System.getProperty(MONGODB_URI_SYSTEM_PROPERTY_NAME);
-        return mongoURIProperty == null || mongoURIProperty.isEmpty()
-               ? DEFAULT_URI : mongoURIProperty;
+        return ClusterFixture.getConnectionString().getConnectionString();
     }
 
     public static synchronized MongoClientURI getMongoClientURI() {

--- a/driver-sync/src/test/functional/com/mongodb/client/Fixture.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/Fixture.java
@@ -17,6 +17,7 @@
 package com.mongodb.client;
 
 import com.mongodb.Block;
+import com.mongodb.ClusterFixture;
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.ServerAddress;
@@ -29,8 +30,6 @@ import java.util.List;
  * Helper class for the acceptance tests.
  */
 public final class Fixture {
-    private static final String DEFAULT_URI = "mongodb://localhost:27017";
-    private static final String MONGODB_URI_SYSTEM_PROPERTY_NAME = "org.mongodb.test.uri";
     private static final String DEFAULT_DATABASE_NAME = "JavaDriverTest";
 
     private static MongoClient mongoClient;
@@ -75,8 +74,7 @@ public final class Fixture {
     }
 
     private static synchronized String getConnectionStringProperty() {
-        String mongoURIProperty = System.getProperty(MONGODB_URI_SYSTEM_PROPERTY_NAME);
-        return mongoURIProperty == null || mongoURIProperty.isEmpty() ? DEFAULT_URI : mongoURIProperty;
+        return ClusterFixture.getConnectionString().getConnectionString();
     }
 
     public static synchronized MongoClientSettings getMongoClientSettings() {


### PR DESCRIPTION
If no org.mongodb.test.uri system property is provided,
try to figure out what it should be by interrogating the server at the
default host and port.  If a setName is found in the response to an
isMaster command, make the uri "mongodb://localhost?/replicaSet=<setName>"

I got sick of having to specify a different uri when running tests in IntelliJ.  This makes it a lot easier.