### PR TITLE
JAVA-2855: Add javax.naming to OSGI imports

### DIFF
--- a/driver-core/build.gradle
+++ b/driver-core/build.gradle
@@ -47,6 +47,8 @@ jar {
                     'javax.crypto.*',
                     'javax.crypto.spec.*',
                     'javax.management.*',
+                    'javax.naming.*',
+                    'javax.naming.directory.*',
                     'javax.net.*',
                     'javax.net.ssl.*',
                     'javax.security.sasl.*',

--- a/mongo-java-driver/build.gradle
+++ b/mongo-java-driver/build.gradle
@@ -49,6 +49,8 @@ jar {
                     'javax.crypto.*',
                     'javax.crypto.spec.*',
                     'javax.management.*',
+                    'javax.naming.*',
+                    'javax.naming.directory.*',
                     'javax.naming.spi.*',
                     'javax.net.*',
                     'javax.net.ssl.*',


### PR DESCRIPTION
The driver took a dependency on javax.naming and javax.naming.directory
packages to support mongodb+srv connection strings.  These packages have
to be added to the OSGI imports for mongodb-driver-core and
mongo-java-driver.