### PR TITLE
JAVA-2815: Fix read concern regression

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/OperationExecutorImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/OperationExecutorImpl.java
@@ -122,7 +122,7 @@ class OperationExecutorImpl implements OperationExecutor {
                                                       @Nullable final ClientSession session, final boolean ownsSession) {
         notNull("readPreference", readPreference);
         AsyncReadWriteBinding readWriteBinding = new AsyncClusterBinding(mongoClient.getCluster(),
-                getReadPreferenceForBinding(readPreference, session));
+                getReadPreferenceForBinding(readPreference, session), readConcern);
         if (session != null) {
             if (!session.hasActiveTransaction() && session.getOptions().getAutoStartTransaction()) {
                 session.startTransaction();

--- a/driver-async/src/test/functional/com/mongodb/async/client/ReadConcernTest.java
+++ b/driver-async/src/test/functional/com/mongodb/async/client/ReadConcernTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.async.client;
+
+import com.mongodb.ClusterFixture;
+import com.mongodb.ReadConcern;
+import com.mongodb.async.SingleResultCallback;
+import com.mongodb.connection.TestCommandListener;
+import com.mongodb.event.CommandEvent;
+import com.mongodb.event.CommandStartedEvent;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static com.mongodb.ClusterFixture.serverVersionAtLeast;
+import static com.mongodb.async.client.Fixture.getDefaultDatabaseName;
+import static com.mongodb.client.CommandMonitoringTestHelper.assertEventsEquality;
+import static org.junit.Assume.assumeTrue;
+
+public class ReadConcernTest {
+    private TestCommandListener commandListener;
+    private MongoClient mongoClient;
+
+    @Before
+    public void setUp() {
+        assumeTrue(canRunTests());
+        commandListener = new TestCommandListener();
+        mongoClient = MongoClients.create(Fixture.getMongoClientBuilderFromConnectionString()
+                .addCommandListener(commandListener)
+                .build());
+    }
+
+    @After
+    public void tearDown() {
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
+    }
+
+    @Test
+    public void shouldIncludeReadConcernInCommand() throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(1);
+        mongoClient.getDatabase(getDefaultDatabaseName()).getCollection("test")
+                .withReadConcern(ReadConcern.LOCAL).count(new SingleResultCallback<Long>() {
+            @Override
+            public void onResult(final Long result, final Throwable t) {
+                latch.countDown();
+            }
+        });
+
+        latch.await(ClusterFixture.TIMEOUT, TimeUnit.SECONDS);
+
+        List<CommandEvent> events = commandListener.getCommandStartedEvents();
+
+        final BsonDocument commandDocument = new BsonDocument("count", new BsonString("test"))
+                .append("readConcern", ReadConcern.LOCAL.asDocument())
+                .append("query", new BsonDocument());
+        if (serverVersionAtLeast(3, 6)) {
+            commandDocument.put("$db", new BsonString(getDefaultDatabaseName()));
+        }
+        assertEventsEquality(Arrays.<CommandEvent>asList(new CommandStartedEvent(1, null, getDefaultDatabaseName(),
+                        "count", commandDocument)), events,
+                commandListener.getSessions());
+
+    }
+
+    private boolean canRunTests() {
+        return serverVersionAtLeast(3, 2);
+    }
+}

--- a/driver-async/src/test/functional/com/mongodb/async/client/TransactionsTest.java
+++ b/driver-async/src/test/functional/com/mongodb/async/client/TransactionsTest.java
@@ -31,7 +31,6 @@ import com.mongodb.client.test.CollectionHelper;
 import com.mongodb.connection.SocketSettings;
 import com.mongodb.connection.TestCommandListener;
 import com.mongodb.event.CommandEvent;
-import com.mongodb.event.CommandStartedEvent;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
@@ -305,7 +304,7 @@ public class TransactionsTest {
             // TODO: null operation may cause test failures, since it's used to grab the read preference
             // TODO: though read-pref.json doesn't declare expectations, so maybe not
             List<CommandEvent> expectedEvents = getExpectedEvents(definition.getArray("expectations"), databaseName, null);
-            List<CommandEvent> events = getCommandStartedEvents();
+            List<CommandEvent> events = commandListener.getCommandStartedEvents();
 
             assertEventsEquality(expectedEvents, events, commandListener.getSessions());
         }
@@ -350,16 +349,6 @@ public class TransactionsTest {
             throw new IllegalArgumentException("clientSession can't be null in this context");
         }
         return clientSession;
-    }
-
-    private List<CommandEvent> getCommandStartedEvents() {
-        List<CommandEvent> commandStartedEvents = new ArrayList<CommandEvent>();
-        for (CommandEvent cur : commandListener.getEvents()) {
-            if (cur instanceof CommandStartedEvent) {
-                commandStartedEvents.add(cur);
-            }
-        }
-        return commandStartedEvents;
     }
 
     @Parameterized.Parameters(name = "{0}: {1}")

--- a/driver-core/src/main/com/mongodb/binding/AsyncClusterBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/AsyncClusterBinding.java
@@ -125,7 +125,7 @@ public class AsyncClusterBinding extends AbstractReferenceCounted implements Asy
         public SessionContext getSessionContext() {
             return new ReadConcernAwareNoOpSessionContext(readConcern);
         }
-        
+
         @Override
         public void getConnection(final SingleResultCallback<AsyncConnection> callback) {
             server.getConnectionAsync(callback);

--- a/driver-core/src/main/com/mongodb/binding/AsyncClusterBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/AsyncClusterBinding.java
@@ -16,17 +16,18 @@
 
 package com.mongodb.binding;
 
+import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
 import com.mongodb.async.SingleResultCallback;
 import com.mongodb.connection.AsyncConnection;
 import com.mongodb.connection.Cluster;
 import com.mongodb.connection.Server;
 import com.mongodb.connection.ServerDescription;
-import com.mongodb.session.SessionContext;
-import com.mongodb.internal.connection.NoOpSessionContext;
+import com.mongodb.internal.connection.ReadConcernAwareNoOpSessionContext;
 import com.mongodb.selector.ReadPreferenceServerSelector;
 import com.mongodb.selector.ServerSelector;
 import com.mongodb.selector.WritableServerSelector;
+import com.mongodb.session.SessionContext;
 
 import static com.mongodb.assertions.Assertions.notNull;
 
@@ -39,16 +40,32 @@ import static com.mongodb.assertions.Assertions.notNull;
 public class AsyncClusterBinding extends AbstractReferenceCounted implements AsyncReadWriteBinding {
     private final Cluster cluster;
     private final ReadPreference readPreference;
+    private final ReadConcern readConcern;
 
     /**
      * Creates an instance.
      *
      * @param cluster        a non-null Cluster which will be used to select a server to bind to
      * @param readPreference a non-null ReadPreference for read operations
+     * @deprecated Prefer {@link #AsyncClusterBinding(Cluster, ReadPreference, ReadConcern)}
      */
+    @Deprecated
     public AsyncClusterBinding(final Cluster cluster, final ReadPreference readPreference) {
+        this(cluster, readPreference, ReadConcern.DEFAULT);
+    }
+
+    /**
+     * Creates an instance.
+     *
+     * @param cluster        a non-null Cluster which will be used to select a server to bind to
+     * @param readPreference a non-null ReadPreference for read operations
+     * @param readConcern    a non-null read concern
+     * @since 3.8
+     */
+    public AsyncClusterBinding(final Cluster cluster, final ReadPreference readPreference, final ReadConcern readConcern) {
         this.cluster = notNull("cluster", cluster);
         this.readPreference = notNull("readPreference", readPreference);
+        this.readConcern = (notNull("readConcern", readConcern));
     }
 
     @Override
@@ -64,7 +81,7 @@ public class AsyncClusterBinding extends AbstractReferenceCounted implements Asy
 
     @Override
     public SessionContext getSessionContext() {
-        return NoOpSessionContext.INSTANCE;
+        return new ReadConcernAwareNoOpSessionContext(readConcern);
     }
 
     @Override
@@ -106,9 +123,9 @@ public class AsyncClusterBinding extends AbstractReferenceCounted implements Asy
 
         @Override
         public SessionContext getSessionContext() {
-            return NoOpSessionContext.INSTANCE;
+            return new ReadConcernAwareNoOpSessionContext(readConcern);
         }
-
+        
         @Override
         public void getConnection(final SingleResultCallback<AsyncConnection> callback) {
             server.getConnectionAsync(callback);

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -254,7 +254,7 @@ public final class ClusterFixture {
     }
 
     public static AsyncReadWriteBinding getAsyncBinding(final Cluster cluster) {
-        return new AsyncClusterBinding(cluster, ReadPreference.primary());
+        return new AsyncClusterBinding(cluster, ReadPreference.primary(), ReadConcern.DEFAULT);
     }
 
     public static AsyncReadWriteBinding getAsyncBinding() {
@@ -267,7 +267,7 @@ public final class ClusterFixture {
 
     public static AsyncReadWriteBinding getAsyncBinding(final Cluster cluster, final ReadPreference readPreference) {
         if (!asyncBindingMap.containsKey(readPreference)) {
-            AsyncReadWriteBinding binding = new AsyncClusterBinding(cluster, readPreference);
+            AsyncReadWriteBinding binding = new AsyncClusterBinding(cluster, readPreference, ReadConcern.DEFAULT);
             if (serverVersionAtLeast(3, 6)) {
                 binding = new AsyncSessionBinding(binding);
             }

--- a/driver-core/src/test/functional/com/mongodb/connection/TestCommandListener.java
+++ b/driver-core/src/test/functional/com/mongodb/connection/TestCommandListener.java
@@ -71,6 +71,17 @@ public class TestCommandListener implements CommandListener {
         return events;
     }
 
+    public List<CommandEvent> getCommandStartedEvents() {
+        List<CommandEvent> commandStartedEvents = new ArrayList<CommandEvent>();
+        for (CommandEvent cur : getEvents()) {
+            if (cur instanceof CommandStartedEvent) {
+                commandStartedEvents.add(cur);
+            }
+        }
+        return commandStartedEvents;
+    }
+
+
     @Override
     public void commandStarted(final CommandStartedEvent event) {
         events.add(new CommandStartedEvent(event.getRequestId(), event.getConnectionDescription(), event.getDatabaseName(),

--- a/driver-sync/src/test/functional/com/mongodb/client/ReadConcernTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ReadConcernTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2008 - 2013 10gen, Inc. <http://10gen.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.client;
+
+import com.mongodb.Block;
+import com.mongodb.ReadConcern;
+import com.mongodb.connection.SocketSettings;
+import com.mongodb.connection.TestCommandListener;
+import com.mongodb.event.CommandEvent;
+import com.mongodb.event.CommandStartedEvent;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static com.mongodb.ClusterFixture.serverVersionAtLeast;
+import static com.mongodb.client.CommandMonitoringTestHelper.assertEventsEquality;
+import static com.mongodb.client.Fixture.getDefaultDatabaseName;
+import static com.mongodb.client.Fixture.getMongoClientSettingsBuilder;
+import static org.junit.Assume.assumeTrue;
+
+public class ReadConcernTest {
+    private MongoClient mongoClient;
+    private TestCommandListener commandListener;
+
+    @Before
+    public void setUp() {
+        assumeTrue(canRunTests());
+
+        commandListener = new TestCommandListener();
+        mongoClient = MongoClients.create(getMongoClientSettingsBuilder()
+                .addCommandListener(commandListener)
+                .applyToSocketSettings(new Block<SocketSettings.Builder>() {
+                    @Override
+                    public void apply(final SocketSettings.Builder builder) {
+                        builder.readTimeout(5, TimeUnit.SECONDS);
+                    }
+                })
+                .build());
+    }
+
+    @After
+    public void cleanUp() {
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
+    }
+
+    @Test
+    public void shouldIncludeReadConcernInCommand() {
+        mongoClient.getDatabase(getDefaultDatabaseName()).getCollection("test")
+                .withReadConcern(ReadConcern.LOCAL).count();
+
+        List<CommandEvent> events = commandListener.getCommandStartedEvents();
+
+        final BsonDocument commandDocument = new BsonDocument("count", new BsonString("test"))
+                .append("readConcern", ReadConcern.LOCAL.asDocument())
+                .append("query", new BsonDocument());
+        if (serverVersionAtLeast(3, 6)) {
+            commandDocument.put("$db", new BsonString(getDefaultDatabaseName()));
+        }
+        assertEventsEquality(Arrays.<CommandEvent>asList(new CommandStartedEvent(1, null, getDefaultDatabaseName(),
+                        "count", commandDocument)), events,
+                commandListener.getSessions());
+    }
+
+    private boolean canRunTests() {
+        return serverVersionAtLeast(3, 2);
+    }
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/ReadConcernTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ReadConcernTest.java
@@ -18,6 +18,7 @@ package com.mongodb.client;
 
 import com.mongodb.Block;
 import com.mongodb.ReadConcern;
+import com.mongodb.ReadPreference;
 import com.mongodb.connection.SocketSettings;
 import com.mongodb.connection.TestCommandListener;
 import com.mongodb.event.CommandEvent;
@@ -32,6 +33,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import static com.mongodb.ClusterFixture.isStandalone;
 import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.client.CommandMonitoringTestHelper.assertEventsEquality;
 import static com.mongodb.client.Fixture.getDefaultDatabaseName;
@@ -72,11 +74,14 @@ public class ReadConcernTest {
 
         List<CommandEvent> events = commandListener.getCommandStartedEvents();
 
-        final BsonDocument commandDocument = new BsonDocument("count", new BsonString("test"))
+        BsonDocument commandDocument = new BsonDocument("count", new BsonString("test"))
                 .append("readConcern", ReadConcern.LOCAL.asDocument())
                 .append("query", new BsonDocument());
         if (serverVersionAtLeast(3, 6)) {
             commandDocument.put("$db", new BsonString(getDefaultDatabaseName()));
+        }
+        if (isStandalone() && serverVersionAtLeast(3, 6)) {
+            commandDocument.put("$readPreference", ReadPreference.primaryPreferred().toDocument());
         }
         assertEventsEquality(Arrays.<CommandEvent>asList(new CommandStartedEvent(1, null, getDefaultDatabaseName(),
                         "count", commandDocument)), events,

--- a/driver-sync/src/test/functional/com/mongodb/client/ReadConcernTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ReadConcernTest.java
@@ -1,18 +1,17 @@
 /*
- * Copyright (c) 2008 - 2013 10gen, Inc. <http://10gen.com>
+ * Copyright 2008-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package com.mongodb.client;

--- a/driver-sync/src/test/functional/com/mongodb/client/TransactionsTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/TransactionsTest.java
@@ -31,7 +31,6 @@ import com.mongodb.client.test.CollectionHelper;
 import com.mongodb.connection.SocketSettings;
 import com.mongodb.connection.TestCommandListener;
 import com.mongodb.event.CommandEvent;
-import com.mongodb.event.CommandStartedEvent;
 import com.mongodb.lang.Nullable;
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
@@ -292,7 +291,7 @@ public class TransactionsTest {
             // TODO: null operation may cause test failures, since it's used to grab the read preference
             // TODO: though read-pref.json doesn't declare expectations, so maybe not
             List<CommandEvent> expectedEvents = getExpectedEvents(definition.getArray("expectations"), databaseName, null);
-            List<CommandEvent> events = getCommandStartedEvents();
+            List<CommandEvent> events = commandListener.getCommandStartedEvents();
 
             assertEventsEquality(expectedEvents, events, commandListener.getSessions());
         }
@@ -337,16 +336,6 @@ public class TransactionsTest {
             throw new IllegalArgumentException("clientSession can't be null in this context");
         }
         return clientSession;
-    }
-
-    private List<CommandEvent> getCommandStartedEvents() {
-        List<CommandEvent> commandStartedEvents = new ArrayList<CommandEvent>();
-        for (CommandEvent cur : commandListener.getEvents()) {
-            if (cur instanceof CommandStartedEvent) {
-                commandStartedEvents.add(cur);
-            }
-        }
-        return commandStartedEvents;
     }
 
     @Parameterized.Parameters(name = "{0}: {1}")


### PR DESCRIPTION
In implementing transactions, a regression in the async driver was
introduced in sending read concern outside of transactions. This
commit fixes the regression and adds an integration test for both the
sync and async drivers.

Will open a spec ticket to get read/write concern integration tests added to the read/write concern spec.

Patch build: https://evergreen.mongodb.com/version/5af9e909e3c3310ed3a2a456