### PR TITLE
JAVA-2757: Drop index by keys when keys are provided

### DIFF
--- a/driver-core/src/test/functional/com/mongodb/operation/DropIndexOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/DropIndexOperationSpecification.groovy
@@ -24,9 +24,11 @@ import com.mongodb.WriteConcern
 import org.bson.BsonDocument
 import org.bson.BsonInt32
 import org.bson.BsonInt64
+import org.bson.BsonString
 import org.bson.Document
 import org.bson.codecs.DocumentCodec
 import spock.lang.IgnoreIf
+import spock.lang.Unroll
 
 import static com.mongodb.ClusterFixture.disableMaxTimeFailPoint
 import static com.mongodb.ClusterFixture.enableMaxTimeFailPoint
@@ -79,9 +81,9 @@ class DropIndexOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
+    @Unroll
     def 'should drop existing index by keys'() {
         given:
-        def keys = new BsonDocument('theField', new BsonInt32(1))
         collectionHelper.createIndex(keys)
 
         when:
@@ -93,7 +95,15 @@ class DropIndexOperationSpecification extends OperationFunctionalSpecification {
         indexes[0].name == '_id_'
 
         where:
-        async << [true, false]
+        [keys, async] << [
+                [new BsonDocument('theField', new BsonInt32(1)),
+                 new BsonDocument('theField', new BsonInt32(1)).append('theSecondField', new BsonInt32(-1)),
+                 new BsonDocument('theField', new BsonString('2d')),
+                 new BsonDocument('theField', new BsonString('hashed')),
+//                 new BsonDocument('theField', new BsonString('text'))  // Server does not allow this
+                ],
+                [true, false]
+        ].combinations()
     }
 
     @IgnoreIf({ isSharded() })

--- a/driver-legacy/src/test/functional/com/mongodb/DBCollectionFunctionalSpecification.groovy
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCollectionFunctionalSpecification.groovy
@@ -210,7 +210,7 @@ class DBCollectionFunctionalSpecification extends FunctionalSpecification {
 
         then:
         def exception = thrown(MongoCommandException)
-        exception.getErrorMessage().contains('index not found')
+        exception.getErrorMessage().contains('can\'t find index')
     }
 
     def 'should drop nested index'() {
@@ -799,6 +799,17 @@ class DBCollectionFunctionalSpecification extends FunctionalSpecification {
         result == document
     }
 
+    def 'should drop compound index by key'() {
+        given:
+        def indexKeys = new BasicDBObject('x', 1).append('y', -1)
+        collection.createIndex(indexKeys)
+
+        when:
+        collection.dropIndex(indexKeys)
+
+        then:
+        collection.getIndexInfo().size() == 1
+    }
 
     def caseInsensitive = Collation.builder().locale('en').collationStrength(CollationStrength.SECONDARY).build()
 }


### PR DESCRIPTION
When the application drops an index using a method that takes the index
keys, rather than the name, the driver drops the index by those keys
rather than constructing a name from the keys and dropping it by that
name.

This allows the dropping of index by keys even when the index was
created with a name other than the default name.

Patch build: https://evergreen.mongodb.com/version/5b02f62fe3c3311b90617f00