### PR TITLE
JAVA-2859 follow on

### DIFF
--- a/driver-core/src/test/unit/com/mongodb/internal/session/ServerSessionPoolSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/session/ServerSessionPoolSpecification.groovy
@@ -26,7 +26,6 @@ import com.mongodb.connection.ServerDescription
 import com.mongodb.connection.ServerSettings
 import com.mongodb.internal.connection.NoOpSessionContext
 import com.mongodb.internal.validator.NoOpFieldNameValidator
-import com.mongodb.selector.ReadPreferenceServerSelector
 import org.bson.BsonArray
 import org.bson.BsonBinarySubType
 import org.bson.BsonDocument
@@ -269,14 +268,14 @@ class ServerSessionPoolSpecification extends Specification {
 
         then:
         // first batch is the first 10K sessions, final batch is the last one
-        1 * cluster.selectServer { (it as ReadPreferenceServerSelector).readPreference == primaryPreferred() }  >> server
+        1 * cluster.selectServer(_)  >> server
         1 * connection.command('admin',
                 new BsonDocument('endSessions', new BsonArray(sessions*.getIdentifier())),
                 { it instanceof NoOpFieldNameValidator }, primaryPreferred(),
                 { it instanceof BsonDocumentCodec }, NoOpSessionContext.INSTANCE) >> new BsonDocument()
         1 * connection.release()
 
-        1 * cluster.selectServer { (it as ReadPreferenceServerSelector).readPreference == primaryPreferred() }  >> server
+        1 * cluster.selectServer(_)  >> server
         1 * connection.command('admin',
                 new BsonDocument('endSessions', new BsonArray([oneOverBatchSizeSession.getIdentifier()])),
                 { it instanceof NoOpFieldNameValidator }, primaryPreferred(),

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoClientDelegate.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoClientDelegate.java
@@ -123,6 +123,10 @@ public class MongoClientDelegate {
         return cluster;
     }
 
+    public ServerSessionPool getServerSessionPool() {
+        return serverSessionPool;
+    }
+
     private ClusterDescription getConnectedClusterDescription() {
         ClusterDescription clusterDescription = cluster.getDescription();
         if (getServerDescriptionListToConsiderForSessionSupport(clusterDescription).isEmpty()) {


### PR DESCRIPTION
* Don't block selecting server when closing server session pool.  Had to play some tricks with Cluster.selectServer to make it not block
* Remove extra server session pool.  Mongo creates one which is never used, MongoClientDelegate creates another that is used.  And for legacy MongoClient only the former is closed.