### PR TITLE
JAVA-2862: Support nameOnly field for listCollections command

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/ListCollectionsIterableImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/ListCollectionsIterableImpl.java
@@ -37,12 +37,14 @@ final class ListCollectionsIterableImpl<TResult> extends MongoIterableImpl<TResu
     private final Class<TResult> resultClass;
 
     private Bson filter;
+    private boolean collectionNamesOnly;
     private long maxTimeMS;
 
-    ListCollectionsIterableImpl(@Nullable final ClientSession clientSession, final String databaseName, final Class<TResult> resultClass,
-                                final CodecRegistry codecRegistry,
-                                final ReadPreference readPreference, final OperationExecutor executor) {
+    ListCollectionsIterableImpl(@Nullable final ClientSession clientSession, final String databaseName, final boolean collectionNamesOnly,
+                                final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
+                                final OperationExecutor executor) {
         super(clientSession, executor, ReadConcern.DEFAULT, readPreference); // TODO: read concern?
+        this.collectionNamesOnly = collectionNamesOnly;
         this.operations = new AsyncOperations<BsonDocument>(BsonDocument.class, readPreference, codecRegistry);
         this.databaseName = notNull("databaseName", databaseName);
         this.resultClass = notNull("resultClass", resultClass);
@@ -70,7 +72,7 @@ final class ListCollectionsIterableImpl<TResult> extends MongoIterableImpl<TResu
 
     @Override
     AsyncReadOperation<AsyncBatchCursor<TResult>> asAsyncReadOperation() {
-        return operations.listCollections(databaseName, resultClass, filter, getBatchSize(), maxTimeMS);
+        return operations.listCollections(databaseName, resultClass, filter, collectionNamesOnly, getBatchSize(), maxTimeMS);
     }
 
 }

--- a/driver-async/src/main/com/mongodb/async/client/MongoDatabaseImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoDatabaseImpl.java
@@ -121,7 +121,7 @@ class MongoDatabaseImpl implements MongoDatabase {
     }
 
     private MongoIterable<String> createListCollectionNamesIterable(@Nullable final ClientSession clientSession) {
-        return createListCollectionsIterable(clientSession, BsonDocument.class)
+        return createListCollectionsIterable(clientSession, BsonDocument.class, true)
                 .map(new Function<BsonDocument, String>() {
                     @Override
                     public String apply(final BsonDocument result) {
@@ -137,7 +137,7 @@ class MongoDatabaseImpl implements MongoDatabase {
 
     @Override
     public <TResult> ListCollectionsIterable<TResult> listCollections(final Class<TResult> resultClass) {
-        return createListCollectionsIterable(null, resultClass);
+        return createListCollectionsIterable(null, resultClass, false);
     }
 
     @Override
@@ -148,13 +148,14 @@ class MongoDatabaseImpl implements MongoDatabase {
     @Override
     public <TResult> ListCollectionsIterable<TResult> listCollections(final ClientSession clientSession, final Class<TResult> resultClass) {
         notNull("clientSession", clientSession);
-        return createListCollectionsIterable(clientSession, resultClass);
+        return createListCollectionsIterable(clientSession, resultClass, false);
     }
 
     private <TResult> ListCollectionsIterable<TResult> createListCollectionsIterable(@Nullable final ClientSession clientSession,
-                                                                                     final Class<TResult> resultClass) {
-        return new ListCollectionsIterableImpl<TResult>(clientSession, name, resultClass, codecRegistry, ReadPreference.primary(),
-                executor);
+                                                                                     final Class<TResult> resultClass,
+                                                                                     final boolean collectionNamesOnly) {
+        return new ListCollectionsIterableImpl<TResult>(clientSession, name, collectionNamesOnly, resultClass, codecRegistry,
+                ReadPreference.primary(), executor);
     }
 
     @Override

--- a/driver-async/src/test/unit/com/mongodb/async/client/ListCollectionsIterableSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/ListCollectionsIterableSpecification.groovy
@@ -49,9 +49,11 @@ class ListCollectionsIterableSpecification extends Specification {
                 it[0].onResult(null, null)
             }
         }
-        def executor = new TestOperationExecutor([cursor, cursor]);
-        def listCollectionIterable = new ListCollectionsIterableImpl<Document>(null, 'db', Document, codecRegistry, readPreference,
+        def executor = new TestOperationExecutor([cursor, cursor, cursor]);
+        def listCollectionIterable = new ListCollectionsIterableImpl<Document>(null, 'db', false, Document, codecRegistry, readPreference,
                 executor).filter(new Document('filter', 1)).batchSize(100).maxTime(1000, MILLISECONDS)
+        def listCollectionNamesIterable = new ListCollectionsIterableImpl<Document>(null, 'db', true, Document, codecRegistry,
+                readPreference, executor)
 
         when: 'default input should be as expected'
         listCollectionIterable.into([]) { result, t -> }
@@ -72,6 +74,14 @@ class ListCollectionsIterableSpecification extends Specification {
         then: 'should use the overrides'
         expect operation, isTheSameAs(new ListCollectionsOperation<Document>('db', new DocumentCodec())
                 .filter(new BsonDocument('filter', new BsonInt32(2))).batchSize(99).maxTime(999, MILLISECONDS))
+
+        when: 'requesting collection names only'
+        listCollectionNamesIterable.into([]) { result, t -> }
+
+        operation = executor.getReadOperation() as ListCollectionsOperation<Document>
+
+        then: 'should create operation with nameOnly'
+        expect operation, isTheSameAs(new ListCollectionsOperation<Document>('db', new DocumentCodec()).nameOnly(true))
     }
 
     def 'should follow the MongoIterable interface as expected'() {
@@ -93,7 +103,7 @@ class ListCollectionsIterableSpecification extends Specification {
             }
         }
         def executor = new TestOperationExecutor([cursor(), cursor(), cursor(), cursor(), cursor()]);
-        def mongoIterable = new ListCollectionsIterableImpl<Document>(null, 'db', Document, codecRegistry, readPreference, executor)
+        def mongoIterable = new ListCollectionsIterableImpl<Document>(null, 'db', false, Document, codecRegistry, readPreference, executor)
 
         when:
         def results = new FutureResultCallback()
@@ -155,7 +165,7 @@ class ListCollectionsIterableSpecification extends Specification {
 
     def 'should check variables using notNull'() {
         given:
-        def mongoIterable = new ListCollectionsIterableImpl<Document>(null, 'db', Document, codecRegistry, readPreference,
+        def mongoIterable = new ListCollectionsIterableImpl<Document>(null, 'db', false, Document, codecRegistry, readPreference,
                 Stub(OperationExecutor))
         def callback = Stub(SingleResultCallback)
         def block = Stub(Block)
@@ -201,7 +211,7 @@ class ListCollectionsIterableSpecification extends Specification {
     def 'should get and set batchSize as expected'() {
         when:
         def batchSize = 5
-        def mongoIterable = new ListCollectionsIterableImpl<Document>(null, 'db', Document, codecRegistry, readPreference,
+        def mongoIterable = new ListCollectionsIterableImpl<Document>(null, 'db', false, Document, codecRegistry, readPreference,
                 Stub(OperationExecutor))
 
         then:

--- a/driver-async/src/test/unit/com/mongodb/async/client/MongoDatabaseSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/MongoDatabaseSpecification.groovy
@@ -222,14 +222,15 @@ class MongoDatabaseSpecification extends Specification {
         def listCollectionIterable = execute(listCollectionsMethod, session)
 
         then:
-        expect listCollectionIterable, isTheSameAs(new ListCollectionsIterableImpl<Document>(session, name, Document, codecRegistry,
+        expect listCollectionIterable, isTheSameAs(new ListCollectionsIterableImpl<Document>(session, name, false, Document, codecRegistry,
                 primary(), executor))
 
         when:
         listCollectionIterable = execute(listCollectionsMethod, session, BsonDocument)
 
         then:
-        expect listCollectionIterable, isTheSameAs(new ListCollectionsIterableImpl<BsonDocument>(session, name, BsonDocument, codecRegistry,
+        expect listCollectionIterable, isTheSameAs(new ListCollectionsIterableImpl<BsonDocument>(session, name, false, BsonDocument,
+                codecRegistry,
                 primary(), executor))
 
         when:
@@ -237,8 +238,8 @@ class MongoDatabaseSpecification extends Specification {
 
         then:
         // listCollectionNamesIterable is an instance of a MappingIterable, so have to get the mapped iterable inside it
-        expect listCollectionNamesIterable.getMapped(), isTheSameAs(new ListCollectionsIterableImpl<BsonDocument>(session, name,
-                BsonDocument, codecRegistry, primary(), executor))
+                expect listCollectionNamesIterable.getMapped(), isTheSameAs(new ListCollectionsIterableImpl<BsonDocument>(session, name,
+                        true, BsonDocument, codecRegistry, primary(), executor))
 
         where:
         session << [null, Stub(ClientSession)]

--- a/driver-core/src/main/com/mongodb/internal/operation/AsyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/AsyncOperations.java
@@ -206,8 +206,9 @@ public final class AsyncOperations<TDocument> {
 
     public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> listCollections(final String databaseName,
                                                                                    final Class<TResult> resultClass, final Bson filter,
+                                                                                   final boolean collectionNamesOnly,
                                                                                    final Integer batchSize, final long maxTimeMS) {
-        return operations.listCollections(databaseName, resultClass, filter, batchSize, maxTimeMS);
+        return operations.listCollections(databaseName, resultClass, filter, collectionNamesOnly, batchSize, maxTimeMS);
     }
 
     public <TResult> AsyncReadOperation<AsyncBatchCursor<TResult>> listDatabases(final Class<TResult> resultClass, final Bson filter,

--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -453,9 +453,11 @@ final class Operations<TDocument> {
     }
 
     <TResult> ListCollectionsOperation<TResult> listCollections(final String databaseName, final Class<TResult> resultClass,
-                                                                       final Bson filter, final Integer batchSize, final long maxTimeMS) {
+                                                                final Bson filter, final boolean collectionNamesOnly,
+                                                                final Integer batchSize, final long maxTimeMS) {
         return new ListCollectionsOperation<TResult>(databaseName, codecRegistry.get(resultClass))
                 .filter(toBsonDocumentOrNull(filter))
+                .nameOnly(collectionNamesOnly)
                 .batchSize(batchSize == null ? 0 : batchSize)
                 .maxTime(maxTimeMS, MILLISECONDS);
     }

--- a/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/SyncOperations.java
@@ -201,8 +201,9 @@ public final class SyncOperations<TDocument> {
     }
 
     public <TResult> ReadOperation<BatchCursor<TResult>> listCollections(final String databaseName, final Class<TResult> resultClass,
-                                                                         final Bson filter, final Integer batchSize, final long maxTimeMS) {
-        return operations.listCollections(databaseName, resultClass, filter, batchSize, maxTimeMS);
+                                                                         final Bson filter, final boolean collectionNamesOnly,
+                                                                         final Integer batchSize, final long maxTimeMS) {
+        return operations.listCollections(databaseName, resultClass, filter, collectionNamesOnly, batchSize, maxTimeMS);
     }
 
     public <TResult> ReadOperation<BatchCursor<TResult>> listDatabases(final Class<TResult> resultClass, final Bson filter,

--- a/driver-core/src/test/functional/com/mongodb/operation/ListCollectionsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ListCollectionsOperationSpecification.groovy
@@ -172,6 +172,7 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
         !names.contains(collectionName)
     }
 
+    @IgnoreIf({ !serverVersionAtLeast(3, 4) || serverVersionAtLeast(4, 0) })
     def 'should get all fields when nameOnly is not requested'() {
         given:
         def operation = new ListCollectionsOperation(databaseName, new DocumentCodec())
@@ -200,8 +201,8 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
         collection.size() == 2
     }
 
-    @IgnoreIf({ serverVersionAtLeast(4, 0) })
-    def 'should only all field names when nameOnly is requested on server versions that do not support nameOnly'() {
+    @IgnoreIf({ !serverVersionAtLeast(3, 4) || serverVersionAtLeast(4, 0) })
+    def 'should only get all field names when nameOnly is requested on server versions that do not support nameOnly'() {
         given:
         def operation = new ListCollectionsOperation(databaseName, new DocumentCodec())
                 .nameOnly(true)

--- a/driver-core/src/test/functional/com/mongodb/operation/ListCollectionsOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ListCollectionsOperationSpecification.groovy
@@ -172,6 +172,48 @@ class ListCollectionsOperationSpecification extends OperationFunctionalSpecifica
         !names.contains(collectionName)
     }
 
+    def 'should get all fields when nameOnly is not requested'() {
+        given:
+        def operation = new ListCollectionsOperation(databaseName, new DocumentCodec())
+        getCollectionHelper().create('collection4', new CreateCollectionOptions())
+
+        when:
+        def cursor = operation.execute(getBinding())
+        def collection = cursor.next()[0]
+
+        then:
+        collection.size() > 2
+    }
+
+    @IgnoreIf({ !serverVersionAtLeast(4, 0) })
+    def 'should only get collection names when nameOnly is requested'() {
+        given:
+        def operation = new ListCollectionsOperation(databaseName, new DocumentCodec())
+                .nameOnly(true)
+        getCollectionHelper().create('collection5', new CreateCollectionOptions())
+
+        when:
+        def cursor = operation.execute(getBinding())
+        def collection = cursor.next()[0]
+
+        then:
+        collection.size() == 2
+    }
+
+    @IgnoreIf({ serverVersionAtLeast(4, 0) })
+    def 'should only all field names when nameOnly is requested on server versions that do not support nameOnly'() {
+        given:
+        def operation = new ListCollectionsOperation(databaseName, new DocumentCodec())
+                .nameOnly(true)
+        getCollectionHelper().create('collection6', new CreateCollectionOptions())
+
+        when:
+        def cursor = operation.execute(getBinding())
+        def collection = cursor.next()[0]
+
+        then:
+        collection.size() > 2
+    }
 
     @Category(Async)
     def 'should return collection names if a collection exists asynchronously'() {

--- a/driver-legacy/src/main/com/mongodb/DB.java
+++ b/driver-legacy/src/main/com/mongodb/DB.java
@@ -260,7 +260,8 @@ public class DB {
                 new MongoIterableImpl<DBObject>(null, executor, ReadConcern.DEFAULT, primary()) {
                     @Override
                     public ReadOperation<BatchCursor<DBObject>> asReadOperation() {
-                        return new ListCollectionsOperation<DBObject>(name, commandCodec);
+                        return new ListCollectionsOperation<DBObject>(name, commandCodec)
+                                .nameOnly(true);
                     }
                 }.map(new Function<DBObject, String>() {
                             @Override

--- a/driver-sync/src/main/com/mongodb/client/internal/ListCollectionsIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/ListCollectionsIterableImpl.java
@@ -39,11 +39,14 @@ final class ListCollectionsIterableImpl<TResult> extends MongoIterableImpl<TResu
     private final Class<TResult> resultClass;
 
     private Bson filter;
+    private final boolean collectionNamesOnly;
     private long maxTimeMS;
 
-    ListCollectionsIterableImpl(@Nullable final ClientSession clientSession, final String databaseName, final Class<TResult> resultClass,
-                                final CodecRegistry codecRegistry, final ReadPreference readPreference, final OperationExecutor executor) {
+    ListCollectionsIterableImpl(@Nullable final ClientSession clientSession, final String databaseName, final boolean collectionNamesOnly,
+                                final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
+                                final OperationExecutor executor) {
         super(clientSession, executor, ReadConcern.DEFAULT, readPreference); // TODO: read concern?
+        this.collectionNamesOnly = collectionNamesOnly;
         this.operations = new SyncOperations<BsonDocument>(BsonDocument.class, readPreference, codecRegistry);
         this.databaseName = notNull("databaseName", databaseName);
         this.resultClass = notNull("resultClass", resultClass);
@@ -71,6 +74,6 @@ final class ListCollectionsIterableImpl<TResult> extends MongoIterableImpl<TResu
 
     @Override
     public ReadOperation<BatchCursor<TResult>> asReadOperation() {
-        return operations.listCollections(databaseName, resultClass, filter, getBatchSize(), maxTimeMS);
+        return operations.listCollections(databaseName, resultClass, filter, collectionNamesOnly, getBatchSize(), maxTimeMS);
     }
 }

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoDatabaseImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoDatabaseImpl.java
@@ -203,7 +203,7 @@ public class MongoDatabaseImpl implements MongoDatabase {
     }
 
     private MongoIterable<String> createListCollectionNamesIterable(@Nullable final ClientSession clientSession) {
-        return createListCollectionsIterable(clientSession, BsonDocument.class)
+        return createListCollectionsIterable(clientSession, BsonDocument.class, true)
                 .map(new Function<BsonDocument, String>() {
                     @Override
                     public String apply(final BsonDocument result) {
@@ -219,7 +219,7 @@ public class MongoDatabaseImpl implements MongoDatabase {
 
     @Override
     public <TResult> ListCollectionsIterable<TResult> listCollections(final Class<TResult> resultClass) {
-        return createListCollectionsIterable(null, resultClass);
+        return createListCollectionsIterable(null, resultClass, false);
     }
 
     @Override
@@ -230,13 +230,14 @@ public class MongoDatabaseImpl implements MongoDatabase {
     @Override
     public <TResult> ListCollectionsIterable<TResult> listCollections(final ClientSession clientSession, final Class<TResult> resultClass) {
         notNull("clientSession", clientSession);
-        return createListCollectionsIterable(clientSession, resultClass);
+        return createListCollectionsIterable(clientSession, resultClass, false);
     }
 
     private <TResult> ListCollectionsIterable<TResult> createListCollectionsIterable(@Nullable final ClientSession clientSession,
-                                                                                     final Class<TResult> resultClass) {
-        return new ListCollectionsIterableImpl<TResult>(clientSession, name, resultClass, codecRegistry, ReadPreference.primary(),
-                executor);
+                                                                                     final Class<TResult> resultClass,
+                                                                                     final boolean collectionNamesOnly) {
+        return new ListCollectionsIterableImpl<TResult>(clientSession, name, collectionNamesOnly, resultClass, codecRegistry,
+                ReadPreference.primary(), executor);
     }
 
     @Override

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoDatabaseSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoDatabaseSpecification.groovy
@@ -223,22 +223,22 @@ class MongoDatabaseSpecification extends Specification {
         def listCollectionIterable = TestHelper.execute(listCollectionsMethod, session)
 
         then:
-        expect listCollectionIterable, isTheSameAs(new ListCollectionsIterableImpl<Document>(session, name, Document, codecRegistry,
+        expect listCollectionIterable, isTheSameAs(new ListCollectionsIterableImpl<Document>(session, name, false, Document, codecRegistry,
                 primary(), executor))
 
         when:
         listCollectionIterable = TestHelper.execute(listCollectionsMethod, session, BsonDocument)
 
         then:
-        expect listCollectionIterable, isTheSameAs(new ListCollectionsIterableImpl<BsonDocument>(session, name, BsonDocument, codecRegistry,
-                primary(), executor))
+        expect listCollectionIterable, isTheSameAs(new ListCollectionsIterableImpl<BsonDocument>(session, name, false, BsonDocument,
+                codecRegistry, primary(), executor))
 
         when:
         def listCollectionNamesIterable = TestHelper.execute(listCollectionNamesMethod, session)
 
         then:
         // listCollectionNamesIterable is an instance of a MappingIterable, so have to get the mapped iterable inside it
-        expect listCollectionNamesIterable.getMapped(), isTheSameAs(new ListCollectionsIterableImpl<BsonDocument>(session, name,
+        expect listCollectionNamesIterable.getMapped(), isTheSameAs(new ListCollectionsIterableImpl<BsonDocument>(session, name, true,
                 BsonDocument, codecRegistry, primary(), executor))
 
         where:


### PR DESCRIPTION
MongoDB 4.0 adds support for the nameOnly field to the listCollections
command, which optimized for the case where the client only requires the
name and not all of the other metadata associated with collections.

This patch uses that optimization to implement the listCollectionNames
methods that already exist in the driver.