### PR TITLE
JAVA-2815: Add transaction tests for runCommand

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/MongoDatabaseImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoDatabaseImpl.java
@@ -17,6 +17,7 @@
 package com.mongodb.async.client;
 
 import com.mongodb.Function;
+import com.mongodb.MongoClientException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
@@ -220,6 +221,9 @@ class MongoDatabaseImpl implements MongoDatabase {
                                           final SingleResultCallback<TResult> callback) {
         notNull("command", command);
         notNull("readPreference", readPreference);
+        if (clientSession != null && clientSession.hasActiveTransaction() && !readPreference.equals(ReadPreference.primary())) {
+            throw new MongoClientException("Read preference in a transaction must be primary");
+        }
         executor.execute(new CommandReadOperation<TResult>(getName(), toBsonDocument(command), codecRegistry.get(resultClass)),
                 readPreference, readConcern, clientSession, callback);
     }

--- a/driver-async/src/test/functional/com/mongodb/async/client/CrudTest.java
+++ b/driver-async/src/test/functional/com/mongodb/async/client/CrudTest.java
@@ -62,7 +62,7 @@ public class CrudTest extends DatabaseTestCase {
         super.setUp();
         collection = Fixture.initializeCollection(new MongoNamespace(getDefaultDatabaseName(), getClass().getName()))
                 .withDocumentClass(BsonDocument.class);
-        helper = new JsonPoweredCrudTestHelper(description, collection);
+        helper = new JsonPoweredCrudTestHelper(description, getDefaultDatabase(), collection);
         new MongoOperation<Void>() {
             @Override
             public void execute() {

--- a/driver-async/src/test/functional/com/mongodb/async/client/RetryableWritesTest.java
+++ b/driver-async/src/test/functional/com/mongodb/async/client/RetryableWritesTest.java
@@ -127,8 +127,9 @@ public class RetryableWritesTest extends DatabaseTestCase {
         collectionHelper.drop();
         collectionHelper.insertDocuments(documents);
 
-        collection = mongoClient.getDatabase(databaseName).getCollection(collectionName, BsonDocument.class);
-        helper = new JsonPoweredCrudTestHelper(description, collection);
+        MongoDatabase database = mongoClient.getDatabase(databaseName);
+        collection = database.getCollection(collectionName, BsonDocument.class);
+        helper = new JsonPoweredCrudTestHelper(description, database, collection);
         setFailPoint();
     }
 

--- a/driver-async/src/test/functional/com/mongodb/async/client/TransactionsTest.java
+++ b/driver-async/src/test/functional/com/mongodb/async/client/TransactionsTest.java
@@ -138,7 +138,7 @@ public class TransactionsTest {
                 .build());
 
         MongoDatabase database = mongoClient.getDatabase(databaseName);
-        helper = new JsonPoweredCrudTestHelper(description, database.getCollection(collectionName, BsonDocument.class));
+        helper = new JsonPoweredCrudTestHelper(description, database, database.getCollection(collectionName, BsonDocument.class));
 
         ClientSession sessionZero = createSession("session0");
         ClientSession sessionOne = createSession("session1");

--- a/driver-core/src/test/resources/transactions/README.rst
+++ b/driver-core/src/test/resources/transactions/README.rst
@@ -98,7 +98,14 @@ For each YAML file, for each element in ``tests``:
    - Enter a "try" block or your programming language's closest equivalent.
    - If ``name`` is "startTransaction", "commitTransaction", or
      "abortTransaction", call the named method on ``session0`` or
-     ``session1``, depending on the "session" argument.
+     ``session1``, depending on the "session" argument. 
+   - If ``name`` is "runCommand", call the runCommand method on the database
+     specified in the test. Pass the argument named "command" to the runCommand 
+     method. Pass ``session0`` or ``session1`` to the runCommand method, depending 
+     on which session's name is in the arguments list. If ``arguments`` 
+     contains no "session", pass no explicit session to the method. If ``arguments`` 
+     includes "readPreference", also pass the read preference to the runCommand 
+     method.    
    - Otherwise, ``name`` refers to a CRUD method, such as ``insertOne``.
      Execute the named method on the "transactions-tests" database on the "test"
      collection, passing the arguments listed. Pass ``session0`` or ``session1``

--- a/driver-core/src/test/resources/transactions/run-command.json
+++ b/driver-core/src/test/resources/transactions/run-command.json
@@ -1,0 +1,294 @@
+{
+  "database_name": "transaction-tests",
+  "collection_name": "test",
+  "data": [],
+  "tests": [
+    {
+      "description": "run command with default read preference",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "runCommand",
+          "arguments": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ]
+            },
+            "session": "session0"
+          },
+          "result": {
+            "n": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ]
+    },
+    {
+      "description": "run command with secondary read preference in client option and primary read preference in transaction options",
+      "clientOptions": {
+        "readPreference": "secondary"
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0",
+            "options": {
+              "readPreference": {
+                "mode": "Primary"
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "arguments": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ]
+            },
+            "session": "session0"
+          },
+          "result": {
+            "n": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ]
+    },
+    {
+      "description": "run command with explicit primary read preference",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "runCommand",
+          "arguments": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ]
+            },
+            "session": "session0",
+            "readPreference": {
+              "mode": "Primary"
+            }
+          },
+          "result": {
+            "n": 1
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        }
+      ]
+    },
+    {
+      "description": "run command fails with explicit secondary read preference",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0"
+          }
+        },
+        {
+          "name": "runCommand",
+          "arguments": {
+            "command": {
+              "count": "test"
+            },
+            "session": "session0",
+            "readPreference": {
+              "mode": "Secondary"
+            }
+          },
+          "result": {
+            "errorContains": "read preference in a transaction must be primary"
+          }
+        }
+      ]
+    },
+    {
+      "description": "run command fails with secondary read preference from transaction options",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "arguments": {
+            "session": "session0",
+            "options": {
+              "readPreference": {
+                "mode": "Secondary"
+              }
+            }
+          }
+        },
+        {
+          "name": "runCommand",
+          "arguments": {
+            "command": {
+              "count": "test"
+            },
+            "session": "session0"
+          },
+          "result": {
+            "errorContains": "read preference in a transaction must be primary"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/driver-legacy/src/test/functional/com/mongodb/client/LegacyCrudTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/client/LegacyCrudTest.java
@@ -62,7 +62,7 @@ public class LegacyCrudTest extends LegacyDatabaseTestCase {
         }
         getCollectionHelper().insertDocuments(documents);
         collection = database.getCollection(getClass().getName(), BsonDocument.class);
-        helper = new JsonPoweredCrudTestHelper(description, collection);
+        helper = new JsonPoweredCrudTestHelper(description, database, collection);
     }
 
     @Test

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoDatabaseImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoDatabaseImpl.java
@@ -17,6 +17,7 @@
 package com.mongodb.client.internal;
 
 import com.mongodb.Function;
+import com.mongodb.MongoClientException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
@@ -172,6 +173,9 @@ public class MongoDatabaseImpl implements MongoDatabase {
     private <TResult> TResult executeCommand(@Nullable final ClientSession clientSession, final Bson command,
                                              final ReadPreference readPreference, final Class<TResult> resultClass) {
         notNull("readPreference", readPreference);
+        if (clientSession != null && clientSession.hasActiveTransaction() && !readPreference.equals(ReadPreference.primary())) {
+            throw new MongoClientException("Read preference in a transaction must be primary");
+        }
         return executor.execute(new CommandReadOperation<TResult>(getName(), toBsonDocument(command), codecRegistry.get(resultClass)),
                 readPreference, readConcern, clientSession);
     }

--- a/driver-sync/src/test/functional/com/mongodb/client/CommandMonitoringTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/CommandMonitoringTest.java
@@ -124,13 +124,14 @@ public class CommandMonitoringTest {
         collectionHelper.insertDocuments(documents);
 
         commandListener.reset();
-        collection = mongoClient.getDatabase(databaseName).getCollection(collectionName, BsonDocument.class);
+        MongoDatabase database = mongoClient.getDatabase(databaseName);
+        collection = database.getCollection(collectionName, BsonDocument.class);
         if (definition.getDocument("operation").containsKey("read_preference")) {
             collection = collection.withReadPreference(ReadPreference.valueOf(definition.getDocument("operation")
                                                                                         .getDocument("read_preference")
                                                                                         .getString("mode").getValue()));
         }
-        helper = new JsonPoweredCrudTestHelper(description, collection);
+        helper = new JsonPoweredCrudTestHelper(description, database, collection);
     }
 
     private ServerVersion getServerVersion(final String fieldName) {

--- a/driver-sync/src/test/functional/com/mongodb/client/CrudTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/CrudTest.java
@@ -62,7 +62,7 @@ public class CrudTest extends DatabaseTestCase {
         }
         getCollectionHelper().insertDocuments(documents);
         collection = database.getCollection(getClass().getName(), BsonDocument.class);
-        helper = new JsonPoweredCrudTestHelper(description, collection);
+        helper = new JsonPoweredCrudTestHelper(description, database, collection);
     }
 
     @Test

--- a/driver-sync/src/test/functional/com/mongodb/client/RetryableWritesTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/RetryableWritesTest.java
@@ -123,8 +123,9 @@ public class RetryableWritesTest {
         collectionHelper.drop();
         collectionHelper.insertDocuments(documents);
 
-        collection = mongoClient.getDatabase(databaseName).getCollection(collectionName, BsonDocument.class);
-        helper = new JsonPoweredCrudTestHelper(description, collection);
+        MongoDatabase database = mongoClient.getDatabase(databaseName);
+        collection = database.getCollection(collectionName, BsonDocument.class);
+        helper = new JsonPoweredCrudTestHelper(description, database, collection);
         setFailPoint();
     }
 

--- a/driver-sync/src/test/functional/com/mongodb/client/TransactionsTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/TransactionsTest.java
@@ -140,7 +140,7 @@ public class TransactionsTest {
                 .build());
 
         MongoDatabase database = mongoClient.getDatabase(databaseName);
-        helper = new JsonPoweredCrudTestHelper(description, database.getCollection(collectionName, BsonDocument.class));
+        helper = new JsonPoweredCrudTestHelper(description, database, database.getCollection(collectionName, BsonDocument.class));
 
         ClientSession sessionZero = createSession("session0");
         ClientSession sessionOne = createSession("session1");


### PR DESCRIPTION
* Ensure that runCommand throws if an explicit, non-primary read preference is supplied
* Update spec tests