### PR TITLE
JAVA-2876: Create SSLParameters if SSLSocket returns null reference

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/SocketStreamHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SocketStreamHelper.java
@@ -50,6 +50,9 @@ final class SocketStreamHelper {
             }
             SSLSocket sslSocket = (SSLSocket) socket;
             SSLParameters sslParameters = sslSocket.getSSLParameters();
+            if (sslParameters == null) {
+                sslParameters = new SSLParameters();
+            }
 
             enableSni(address, sslParameters);
 


### PR DESCRIPTION
On some JDKs the SSLSocket#getSSLParameters method can return null,
which triggers an NPE in the driver.  To work around this, construct a
new SSLParameters instance when null is returned, so that SNI and host
name validation properties can be set on it before calling
SSLSocket#setSSLParameters.

This was tested by the reporter of the issue and found to work as advertised.  Trying to automate a test for this is probably not worth the effort (would need to inject an SSLSocket implementation that returned null SSLParameters), but we can discuss.