### PR TITLE
JAVA-2815: Support TransientTransactionError for MongoSocketException 

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/OperationExecutorImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/OperationExecutorImpl.java
@@ -17,7 +17,9 @@
 package com.mongodb.async.client;
 
 import com.mongodb.MongoClientException;
+import com.mongodb.MongoException;
 import com.mongodb.MongoInternalException;
+import com.mongodb.MongoSocketException;
 import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
 import com.mongodb.async.SingleResultCallback;
@@ -107,6 +109,9 @@ class OperationExecutorImpl implements OperationExecutor {
                         @Override
                         public void onResult(final T result, final Throwable t) {
                             try {
+                                if (t instanceof MongoSocketException && session != null && session.hasActiveTransaction()) {
+                                    ((MongoException) t).addLabel(MongoException.TRANSIENT_TRANSACTION_ERROR_LABEL);
+                                }
                                 errHandlingCallback.onResult(result, t);
                             } finally {
                                 binding.release();

--- a/driver-core/src/main/com/mongodb/MongoException.java
+++ b/driver-core/src/main/com/mongodb/MongoException.java
@@ -18,13 +18,29 @@ package com.mongodb;
 
 import com.mongodb.lang.Nullable;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.mongodb.assertions.Assertions.notNull;
+
 /**
  * Top level Exception for all Exceptions, server-side or client-side, that come from the driver.
  */
 public class MongoException extends RuntimeException {
+
+    /**
+     * An error label indicating that the exception can be treated as a transient transaction error.
+     *
+     * @see #hasErrorLabel(String)
+     * @since 3.8
+     */
+    public static final String TRANSIENT_TRANSACTION_ERROR_LABEL = "TransientTransactionError";
+
     private static final long serialVersionUID = -4415279469780082174L;
 
     private final int code;
+    private final Set<String> errorLabels = new HashSet<String>();
 
     /**
      * Static helper to create or cast a MongoException from a throwable
@@ -99,5 +115,39 @@ public class MongoException extends RuntimeException {
      */
     public int getCode() {
         return code;
+    }
+
+    /**
+     * Adds the given error label to the exception.
+     *
+     * @param errorLabel the non-null error label to add to the exception
+     *
+     * @since 3.8
+     */
+    public void addLabel(final String errorLabel) {
+        notNull("errorLabel", errorLabel);
+        errorLabels.add(errorLabel);
+    }
+
+    /**
+     * Gets the set of error labels associated with this exception.
+     *
+     * @return the error labels, which may not be null but may be empty
+     * @since 3.8
+     */
+    public Set<String> getErrorLabels() {
+        return Collections.unmodifiableSet(errorLabels);
+    }
+
+    /**
+     * Return true if the exception is labelled with the given error label, and false otherwise.
+     *
+     * @param errorLabel the non-null error label
+     * @return true if the exception is labelled with the given error label
+     * @since 3.8
+     */
+    public boolean hasErrorLabel(final String errorLabel) {
+        notNull("errorLabel", errorLabel);
+        return errorLabels.contains(errorLabel);
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
@@ -371,4 +371,8 @@ public final class CollectionHelper<T> {
         new CommandWriteOperation<BsonDocument>("admin", new BsonDocument("killAllSessions", new BsonArray()),
                 new BsonDocumentCodec());
     }
+
+    public void runAdminCommand(final BsonDocument command) {
+        new CommandWriteOperation<BsonDocument>("admin", command, new BsonDocumentCodec()).execute(getBinding());
+    }
 }

--- a/driver-core/src/test/resources/transactions/README.rst
+++ b/driver-core/src/test/resources/transactions/README.rst
@@ -17,6 +17,56 @@ tests and the Command Monitoring Spec tests.
 Several prose tests, which are not easily expressed in YAML, are also presented
 in this file. Those tests will need to be manually implemented by each driver.
 
+Server Fail Point
+=================
+
+Some tests depend on a server fail point, expressed in the ``failPoint`` field.
+For example the ``failCommand`` fail point allows the client to force the
+server to return an error. Keep in mind that the fail point only triggers for
+commands listed in the "failCommands" field. See `SERVER-35004`_ and
+`SERVER-35083`_ for more information.
+
+.. _SERVER-35004: https://jira.mongodb.org/browse/SERVER-35004
+.. _SERVER-35083: https://jira.mongodb.org/browse/SERVER-35083
+
+The ``failCommand`` fail point may be configured like so::
+
+    db.adminCommand({
+        configureFailPoint: "failCommand",
+        mode: <string|document>,
+        data: {
+          failCommands: ["commandName", "commandName2"],
+          closeConnection: <true|false>,
+          errorCode: <Number>,
+          writeConcernError: <document>
+        }
+    });
+
+``mode`` is a generic fail point option and may be assigned a string or document
+value. The string values ``"alwaysOn"`` and ``"off"`` may be used to enable or
+disable the fail point, respectively. A document may be used to specify either
+``times`` or ``skip``, which are mutually exclusive:
+
+- ``{ times: <integer> }`` may be used to limit the number of times the fail
+  point may trigger before transitioning to ``"off"``.
+- ``{ skip: <integer> }`` may be used to defer the first trigger of a fail
+  point, after which it will transition to ``"alwaysOn"``.
+
+The ``data`` option is a document that may be used to specify options that
+control the fail point's behavior. ``failCommand`` supports the following
+``data`` options, which may be combined if desired:
+
+- ``failCommands``: Required, the list of command names to fail.
+- ``closeConnection``: Boolean option, which defaults to ``false``. If
+  ``true``, the connection on which the command is executed will be closed
+  and the client will see a network error.
+- ``errorCode``: Integer option, which is unset by default. If set, the
+  specified command error code will be returned as a command error.
+- ``writeConcernError``: A document, which is unset by default. If set, the
+  server will return this document in the "writeConcernError" field. This
+  failure response only applies to commands that support write concern and
+  happens *after* the command finishes (regardless of success or failure).
+
 Test Format
 ===========
 
@@ -35,30 +85,43 @@ Each YAML file has the following keys:
 
   - ``clientOptions``: Optional, parameters to pass to MongoClient().
 
+  - ``failPoint``: Optional, a server failpoint to enable expressed as the
+    configureFailPoint command to run on the admin database.
+
   - ``sessionOptions``: Optional, parameters to pass to
     MongoClient.startSession().
 
   - ``operations``: Array of documents, each describing an operation to be
     executed. Each document has the following fields:
 
-      - ``name``: The name of the operation on ``object``.
+    - ``name``: The name of the operation on ``object``.
 
-      - ``object``: The name of the object to perform the operation on. Can be
-        "database", collection", "session0", or "session1".
+    - ``object``: The name of the object to perform the operation on. Can be
+      "database", "collection", "session0", or "session1".
 
-      - ``collectionOptions``: Optional, parameters to pass to the Collection()
-        used for this operation.
+    - ``collectionOptions``: Optional, parameters to pass to the Collection()
+      used for this operation.
 
-      - ``command_name``: Present only when ``name`` is "runCommand". The name
-        of the command to run. Required for languages that are unable preserve
-        the order keys in the "command" argument when parsing JSON/YAML.
+    - ``command_name``: Present only when ``name`` is "runCommand". The name
+      of the command to run. Required for languages that are unable preserve
+      the order keys in the "command" argument when parsing JSON/YAML.
 
-      - ``arguments``: Optional, the names and values of arguments.
+    - ``arguments``: Optional, the names and values of arguments.
 
-      - ``result``: The return value from the operation, if any. If the
-        operation is expected to return an error, the ``result`` has one field,
-        ``errorContains``, which is a substring of the expected error message
-        or ``errorCodeName``, which is the expected server error "codeName".
+    - ``result``: The return value from the operation, if any. If the
+      operation is expected to return an error, the ``result`` has one of
+      the following fields:
+
+      - ``errorContains``: A substring of the expected error message.
+
+      - ``errorCodeName``: The expected "codeName" field in the server
+        error response.
+
+      - ``errorLabelsContain``: A list of error label strings that the
+        error is expected to have.
+
+      - ``errorLabelsOmit``: A list of error label strings that the
+        error is expected not to have.
 
   - ``expectations``: Optional list of command-started events.
 
@@ -66,10 +129,10 @@ Each YAML file has the following keys:
     the collection after the operation is executed. Contains the following
     fields:
 
-      - ``collection``:
+    - ``collection``:
 
-        - ``data``: The data that should exist in the collection after the
-          operations have run.
+      - ``data``: The data that should exist in the collection after the
+        operations have run.
 
 Use as integration tests
 ========================
@@ -96,6 +159,8 @@ Then for each element in ``tests``:
    create it explicitly.)
 #. If the YAML file contains a ``data`` array, insert the documents in ``data``
    into the test collection, using writeConcern "majority".
+#. If ``failPoint`` is specified, its value is a configureFailPoint command.
+   Run the command on the admin database to enable the fail point.
 #. Create a **new** MongoClient ``client``, with Command Monitoring listeners
    enabled. (Using a new MongoClient for each test ensures a fresh session pool
    that hasn't executed any transactions previously, so the tests can assert
@@ -125,11 +190,22 @@ Then for each element in ``tests``:
      method threw an exception or returned an error, and that the value of the
      "errorContains" field matches the error string. "errorContains" is a
      substring (case-insensitive) of the actual error message.
+
      If the result document has an "errorCodeName" field, verify that the
      method threw a command failed exception or returned an error, and that
      the value of the "errorCodeName" field matches the "codeName" in the
      server error response.
-     If the operation returns a raw command response, eg from ``runCommand``,
+
+     If the result document has an "errorLabelsContain" field, verify that the
+     method threw an exception or returned an error. Verify that all of the
+     error labels in "errorLabelsContain" are present in the error or exception
+     using the ``hasErrorLabel`` method.
+
+     If the result document has an "errorLabelsOmit" field, verify that the
+     method threw an exception or returned an error. Verify that none of the
+     error labels in "errorLabelsOmit" are present in the error or exception
+     using the ``hasErrorLabel`` method.
+   - If the operation returns a raw command response, eg from ``runCommand``,
      then compare only the fields present in the expected result document.
      Otherwise, compare the method's return value to ``result`` using the same
      logic as the CRUD Spec Tests runner.
@@ -139,6 +215,14 @@ Then for each element in ``tests``:
    compare them to the actual command-started events using the
    same logic as the Command Monitoring Spec Tests runner, plus the rules in
    the Command-Started Events instructions below.
+#. If ``failPoint`` is specified, disable the fail point to avoid spurious
+   failures in subsequent tests. The fail point may be disabled like so::
+
+    db.adminCommand({
+        configureFailPoint: <fail point name>,
+        mode: "off"
+    });
+
 #. For each element in ``outcome``:
 
    - If ``name`` is "collection", verify that the test collection contains
@@ -148,7 +232,6 @@ Then for each element in ``tests``:
 
 TODO:
 
-- drivers MUST NOT retry writes in a transaction even when retryWrites=true, needs to use failpoint.
 - drivers MUST retry commit/abort, needs to use failpoint.
 - test writeConcernErrors
 

--- a/driver-core/src/test/resources/transactions/retryable-writes.json
+++ b/driver-core/src/test/resources/transactions/retryable-writes.json
@@ -235,6 +235,95 @@
           ]
         }
       }
+    },
+    {
+      "description": "writes are not retried",
+      "clientOptions": {
+        "retryWrites": true
+      },
+      "failPoint": {
+        "configureFailPoint": "failCommand",
+        "mode": {
+          "times": 1
+        },
+        "data": {
+          "failCommands": [
+            "insert"
+          ],
+          "closeConnection": true
+        }
+      },
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session0"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session0",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "errorLabelsContain": [
+              "TransientTransactionError"
+            ]
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session0"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session0",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": []
+        }
+      }
     }
   ]
 }

--- a/driver-sync/src/test/functional/com/mongodb/client/TransactionsTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/TransactionsTest.java
@@ -19,6 +19,7 @@ package com.mongodb.client;
 import com.mongodb.Block;
 import com.mongodb.ClientSessionOptions;
 import com.mongodb.MongoCommandException;
+import com.mongodb.MongoException;
 import com.mongodb.MongoNamespace;
 import com.mongodb.MongoWriteConcernException;
 import com.mongodb.ReadConcern;
@@ -123,6 +124,10 @@ public class TransactionsTest {
             collectionHelper.insertDocuments(documents, WriteConcern.MAJORITY);
         }
 
+        if (definition.containsKey("failPoint")) {
+            collectionHelper.runAdminCommand(definition.getDocument("failPoint"));
+        }
+
         BsonDocument clientOptions = definition.getDocument("clientOptions", new BsonDocument());
 
         mongoClient = MongoClients.create(getMongoClientSettingsBuilder()
@@ -210,6 +215,12 @@ public class TransactionsTest {
         if (mongoClient != null) {
             mongoClient.close();
         }
+
+        if (definition.containsKey("failPoint")) {
+            collectionHelper.runAdminCommand(new BsonDocument("configureFailPoint",
+                    definition.getDocument("failPoint").getString("configureFailPoint"))
+                    .append("mode", new BsonString("off")));
+        }
     }
 
     private void closeAllSessions() {
@@ -267,21 +278,35 @@ public class TransactionsTest {
                     assertFalse(String.format("Expected error code '%s' but none thrown", getErrorCodeNameField(expectedResult)),
                             hasErrorCodeNameField(expectedResult));
                 } catch (RuntimeException e) {
+                    boolean passedAssertion = false;
+                    if (hasErrorLabelContainsField(expectedResult)) {
+                        if (e instanceof MongoException) {
+                            MongoException mongoException = (MongoException) e;
+                            for (String curErrorLabel : getErrorLabelContainsField(expectedResult)) {
+                                assertTrue(String.format("Expected error label '%s but found labels '%s'", curErrorLabel,
+                                        mongoException.getErrorLabels()),
+                                        mongoException.hasErrorLabel(curErrorLabel));
+                            }
+                            passedAssertion = true;
+                        }
+                    }
                     if (hasErrorContainsField(expectedResult)) {
                         String expectedError = getErrorContainsField(expectedResult);
                         assertTrue(String.format("Expected '%s' but got '%s'", expectedError, e.getMessage()),
                                 e.getMessage().toLowerCase().contains(expectedError.toLowerCase()));
-                    } else if (hasErrorCodeNameField(expectedResult) || (e instanceof MongoCommandException)
-                            || (e instanceof MongoWriteConcernException)) {
+                        passedAssertion = true;
+                    }
+                    if (hasErrorCodeNameField(expectedResult)) {
                         String expectedErrorCodeName = getErrorCodeNameField(expectedResult);
                         if (e instanceof MongoCommandException) {
                             assertEquals(expectedErrorCodeName, ((MongoCommandException) e).getErrorCodeName());
+                            passedAssertion = true;
                         } else if (e instanceof MongoWriteConcernException) {
                             assertEquals(expectedErrorCodeName, ((MongoWriteConcernException) e).getWriteConcernError().getCodeName());
-                        } else {
-                            throw e;
+                            passedAssertion = true;
                         }
-                    } else {
+                    }
+                    if (!passedAssertion) {
                         throw e;
                     }
                 }
@@ -320,6 +345,18 @@ public class TransactionsTest {
         } else {
             return "";
         }
+    }
+
+    private boolean hasErrorLabelContainsField(final BsonValue expectedResult) {
+        return hasErrorField(expectedResult, "errorLabelsContain");
+    }
+
+    private List<String> getErrorLabelContainsField(final BsonValue expectedResult) {
+        List<String> errorLabelContainsList = new ArrayList<String>();
+        for (BsonValue cur : expectedResult.asDocument().getArray("errorLabelsContain")) {
+            errorLabelContainsList.add(cur.asString().getValue());
+        }
+        return errorLabelContainsList;
     }
 
     private boolean hasErrorContainsField(final BsonValue expectedResult) {


### PR DESCRIPTION
First commit adds support for error labels to MongoException.

Second commit adds the TransientTransactionError error label to any
MongoSocketException thrown while a transaction is active.

In a short comedy of errors, I screwed up and already pushed this to master, but still want to get it reviewed.