### PR TITLE
JAVA-2827: Re-enable maxAwaitTime test for AggregateOperation

### DIFF
--- a/driver-core/src/test/functional/com/mongodb/operation/AggregateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/AggregateOperationSpecification.groovy
@@ -49,7 +49,6 @@ import org.bson.BsonTimestamp
 import org.bson.Document
 import org.bson.codecs.BsonDocumentCodec
 import org.bson.codecs.DocumentCodec
-import spock.lang.Ignore
 import spock.lang.IgnoreIf
 
 import static com.mongodb.ClusterFixture.collectCursorResults
@@ -59,14 +58,15 @@ import static com.mongodb.ClusterFixture.executeAsync
 import static com.mongodb.ClusterFixture.getAsyncCluster
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.getCluster
+import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.isSharded
 import static com.mongodb.ClusterFixture.isStandalone
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
 import static com.mongodb.ExplainVerbosity.QUERY_PLANNER
-import static com.mongodb.internal.connection.ServerHelper.waitForLastRelease
 import static com.mongodb.connection.ServerType.STANDALONE
-import static com.mongodb.operation.QueryOperationHelper.getKeyPattern
+import static com.mongodb.internal.connection.ServerHelper.waitForLastRelease
 import static com.mongodb.operation.OperationReadConcernHelper.appendReadConcernToCommand
+import static com.mongodb.operation.QueryOperationHelper.getKeyPattern
 import static java.util.concurrent.TimeUnit.MILLISECONDS
 import static java.util.concurrent.TimeUnit.SECONDS
 
@@ -444,27 +444,29 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         async << [true, false]
     }
 
-//    @IgnoreIf({ isSharded() || !serverVersionAtLeast(3, 2) })
-    @Ignore
+    @IgnoreIf({ !isDiscoverableReplicaSet() || !serverVersionAtLeast(3, 6) })
     def 'should be able to respect maxAwaitTime with pipeline'() {
         given:
         enableMaxTimeFailPoint()
-        AggregateOperation operation = new AggregateOperation<Document>(getNamespace(), [], new DocumentCodec())
+        AggregateOperation operation = new AggregateOperation<Document>(getNamespace(), [
+                new BsonDocument('$changeStream', new BsonDocument())
+        ], new DocumentCodec())
                 .batchSize(2)
                 .maxAwaitTime(10, MILLISECONDS)
 
         when:
         def cursor = execute(operation, async)
+        collectionHelper.insertDocuments([new BsonDocument()], WriteConcern.MAJORITY)
         next(cursor, async)
 
         then:
-        notThrown(MongoExecutionTimeoutException)
+        noExceptionThrown()
 
         when:
-        next(cursor, async)
+        tryNext(cursor, async)
 
         then:
-        thrown(MongoExecutionTimeoutException)
+        noExceptionThrown()
 
         cleanup:
         cursor.close()


### PR DESCRIPTION
The server only supports maxTimeMS on getMore for tailable cursors,
so added a $changeStream stage to the pipeline.

Note that this is not a particularly good test, since it doesn't
check to see whether maxTimeMS has been added to the getMore command.
It just assumes it has been and is just checking that no exception
is thrown.

Patch build: https://evergreen.mongodb.com/version/5b2ac59fe3c3310a05f10d24