### PR TITLE
 JAVA-2892: Restrict when startAtOperationTime is included for change streams

### DIFF
--- a/driver-core/src/main/com/mongodb/operation/AsyncChangeStreamBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/AsyncChangeStreamBatchCursor.java
@@ -40,9 +40,7 @@ final class AsyncChangeStreamBatchCursor<T> implements AsyncBatchCursor<T> {
     AsyncChangeStreamBatchCursor(final ChangeStreamOperation<T> changeStreamOperation,
                                  final AsyncBatchCursor<RawBsonDocument> wrapped,
                                  final AsyncReadBinding binding) {
-        if (changeStreamOperation.getResumeToken() == null && changeStreamOperation.getStartAtOperationTime() == null) {
-            changeStreamOperation.startAtOperationTime(binding.getSessionContext().getOperationTime());
-        }
+        changeStreamOperation.setStartOperationTimeForResume(binding.getSessionContext().getOperationTime());
         this.changeStreamOperation = changeStreamOperation;
         this.resumeToken = changeStreamOperation.getResumeToken();
         this.wrapped = wrapped;
@@ -117,7 +115,8 @@ final class AsyncChangeStreamBatchCursor<T> implements AsyncBatchCursor<T> {
 
     private void retryOperation(final AsyncBlock asyncBlock, final SingleResultCallback<List<RawBsonDocument>> callback) {
         if (resumeToken != null) {
-            changeStreamOperation.startAtOperationTime(null).resumeAfter(resumeToken);
+            changeStreamOperation.setStartOperationTimeForResume(null);
+            changeStreamOperation.resumeAfter(resumeToken);
         }
         changeStreamOperation.executeAsync(binding, new SingleResultCallback<AsyncBatchCursor<T>>() {
             @Override

--- a/driver-core/src/main/com/mongodb/operation/ChangeStreamBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/ChangeStreamBatchCursor.java
@@ -40,9 +40,7 @@ final class ChangeStreamBatchCursor<T> implements BatchCursor<T> {
     ChangeStreamBatchCursor(final ChangeStreamOperation<T> changeStreamOperation,
                             final BatchCursor<RawBsonDocument> wrapped,
                             final ReadBinding binding) {
-        if (changeStreamOperation.getResumeToken() == null && changeStreamOperation.getStartAtOperationTime() == null) {
-            changeStreamOperation.startAtOperationTime(binding.getSessionContext().getOperationTime());
-        }
+        changeStreamOperation.setStartOperationTimeForResume(binding.getSessionContext().getOperationTime());
         this.changeStreamOperation = changeStreamOperation;
         this.resumeToken = changeStreamOperation.getResumeToken();
         this.wrapped = wrapped;
@@ -141,7 +139,8 @@ final class ChangeStreamBatchCursor<T> implements BatchCursor<T> {
             wrapped.close();
 
             if (resumeToken != null) {
-                changeStreamOperation.startAtOperationTime(null).resumeAfter(resumeToken);
+                changeStreamOperation.setStartOperationTimeForResume(null);
+                changeStreamOperation.resumeAfter(resumeToken);
             }
             wrapped = ((ChangeStreamBatchCursor<T>) changeStreamOperation.execute(binding)).getWrapped();
             binding.release(); // release the new change stream batch cursor's reference to the binding

--- a/driver-core/src/test/functional/com/mongodb/operation/ChangeStreamOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/ChangeStreamOperationSpecification.groovy
@@ -455,7 +455,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         def binding = Stub(ReadBinding) {
             getSessionContext() >> Stub(SessionContext) {
                 getReadConcern() >> ReadConcern.DEFAULT
-                getOperationTime() >> new BsonTimestamp()
+                getOperationTime() >> new BsonTimestamp(42, 1)
             }
             getReadConnectionSource() >> Stub(ConnectionSource) {
                 getConnection() >> Stub(Connection) {
@@ -479,7 +479,7 @@ class ChangeStreamOperationSpecification extends OperationFunctionalSpecificatio
         operation.execute(binding)
 
         then:
-        operation.getStartAtOperationTime() == new BsonTimestamp()
+        operation.getStartAtOperationTime() == new BsonTimestamp(42, 1)
 
         when: 'Set time'
         def startAtTime = new BsonTimestamp(42)


### PR DESCRIPTION
When resuming a change stream, the driver is required to save the
operationTime returned in the aggregate command response and send
it on subsequent aggregate commands when resuming the change stream,
until a resumeToken is available.

This commit ensures that it's only done when connected to a MongoDB 4.0
server, as per specification.

I'll try to find time to write better tests for this, but may have to leave it to @rozza to finish up.  I think it needs quite a bit of mocking.