### PR TITLE
JAVA-2931: Support nesting RawBsonArray in BsonDocument

### DIFF
--- a/bson/src/main/org/bson/codecs/BsonValueCodecProvider.java
+++ b/bson/src/main/org/bson/codecs/BsonValueCodecProvider.java
@@ -91,10 +91,6 @@ public class BsonValueCodecProvider implements CodecProvider {
             return (Codec<T>) codecs.get(clazz);
         }
 
-        if (clazz == BsonArray.class) {
-            return (Codec<T>) new BsonArrayCodec(registry);
-        }
-
         if (clazz == BsonJavaScriptWithScope.class) {
             return (Codec<T>) new BsonJavaScriptWithScopeCodec(registry.get(BsonDocument.class));
         }
@@ -113,6 +109,10 @@ public class BsonValueCodecProvider implements CodecProvider {
 
         if (BsonDocument.class.isAssignableFrom(clazz)) {
             return (Codec<T>) new BsonDocumentCodec(registry);
+        }
+
+        if (BsonArray.class.isAssignableFrom(clazz)) {
+            return (Codec<T>) new BsonArrayCodec(registry);
         }
 
         return null;

--- a/bson/src/test/unit/org/bson/codecs/BsonValueCodecProviderSpecification.groovy
+++ b/bson/src/test/unit/org/bson/codecs/BsonValueCodecProviderSpecification.groovy
@@ -37,6 +37,7 @@ import org.bson.BsonString
 import org.bson.BsonSymbol
 import org.bson.BsonTimestamp
 import org.bson.BsonUndefined
+import org.bson.RawBsonArray
 import org.bson.RawBsonDocument
 import spock.lang.Specification
 
@@ -73,6 +74,7 @@ class BsonValueCodecProviderSpecification extends Specification {
         provider.get(BsonJavaScriptWithScope, codecRegistry).class == BsonJavaScriptWithScopeCodec
 
         provider.get(BsonArray, codecRegistry).class == BsonArrayCodec
+        provider.get(RawBsonArray, codecRegistry).class == BsonArrayCodec
 
         provider.get(BsonDocument, codecRegistry).class == BsonDocumentCodec
         provider.get(BsonDocumentWrapper, codecRegistry).class == BsonDocumentWrapperCodec


### PR DESCRIPTION
In BsonValueCodecProvider, use the BsonArrayCodec to encode RawBsonArray
as well as BsonArray. This allows the default BsonDocumentCodec to encode
a BsonDocument that nests a RawBsonArray.

