### PR TITLE
JAVA-2882: Allow all non-escaped sub-delimiters ...

### DIFF
--- a/driver-core/src/main/com/mongodb/ConnectionString.java
+++ b/driver-core/src/main/com/mongodb/ConnectionString.java
@@ -302,7 +302,7 @@ public class ConnectionString {
         char[] password = null;
         idx = userAndHostInformation.lastIndexOf("@");
         if (idx > 0) {
-            userInfo = userAndHostInformation.substring(0, idx);
+            userInfo = userAndHostInformation.substring(0, idx).replace("+", "%2B");
             hostIdentifier = userAndHostInformation.substring(idx + 1);
             int colonCount = countOccurrences(userInfo, ":");
             if (userInfo.contains("@") || colonCount > 1) {

--- a/driver-core/src/test/resources/connection-string/valid-auth.json
+++ b/driver-core/src/test/resources/connection-string/valid-auth.json
@@ -241,6 +241,27 @@
       }
     },
     {
+      "description": "Subdelimiters in user/pass don't need escaping (MONGODB-CR)",
+      "uri": "mongodb://!$&'()*,;=:!$&'()*,;=@127.0.0.1/admin?authMechanism=MONGODB-CR",
+      "valid": true,
+      "warning": false,
+      "hosts": [
+        {
+          "type": "ipv4",
+          "host": "127.0.0.1",
+          "port": null
+        }
+      ],
+      "auth": {
+        "username": "!$&'()*,;=",
+        "password": "!$&'()*,;=",
+        "db": "admin"
+      },
+      "options": {
+        "authmechanism": "MONGODB-CR"
+      }
+    },
+    {
       "description": "Escaped username (MONGODB-X509)",
       "uri": "mongodb://CN%3DmyName%2COU%3DmyOrgUnit%2CO%3DmyOrg%2CL%3DmyLocality%2CST%3DmyState%2CC%3DmyCountry@localhost/?authMechanism=MONGODB-X509",
       "valid": true,

--- a/driver-core/src/test/unit/com/mongodb/ConnectionStringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/ConnectionStringTest.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-// See https://github.com/mongodb/specifications/tree/master/source/crud/tests
+// See https://github.com/mongodb/specifications/tree/master/source/connection-string/tests
 @RunWith(Parameterized.class)
 public class ConnectionStringTest extends TestCase {
     private final String filename;


### PR DESCRIPTION
  ... in connection string username and password

In order to continue using the built-in URLDecoder class, which replaces
all occurrences of the plus character with the space character, the plus
character is special-cased: before passing the user name or password to
the URLDecoder, all occurrences of the plus character are first replaced
with "%2B", the hex encoding of that character.