### PR TITLE
Update to latest CRUD, transactions, and retryable writes spec tests

### DIFF
--- a/driver-async/src/test/functional/com/mongodb/async/client/CrudTest.java
+++ b/driver-async/src/test/functional/com/mongodb/async/client/CrudTest.java
@@ -63,16 +63,18 @@ public class CrudTest extends DatabaseTestCase {
         collection = Fixture.initializeCollection(new MongoNamespace(getDefaultDatabaseName(), getClass().getName()))
                 .withDocumentClass(BsonDocument.class);
         helper = new JsonPoweredCrudTestHelper(description, getDefaultDatabase(), collection);
-        new MongoOperation<Void>() {
-            @Override
-            public void execute() {
-                List<BsonDocument> documents = new ArrayList<BsonDocument>();
-                for (BsonValue document : data) {
-                    documents.add(document.asDocument());
+        if (!data.isEmpty()) {
+            new MongoOperation<Void>() {
+                @Override
+                public void execute() {
+                    List<BsonDocument> documents = new ArrayList<BsonDocument>();
+                    for (BsonValue document : data) {
+                        documents.add(document.asDocument());
+                    }
+                    collection.insertMany(documents, getCallback());
                 }
-                collection.insertMany(documents, getCallback());
-            }
-        }.get();
+            }.get();
+        }
     }
 
     @Test

--- a/driver-async/src/test/functional/com/mongodb/async/client/JsonPoweredCrudTestHelper.java
+++ b/driver-async/src/test/functional/com/mongodb/async/client/JsonPoweredCrudTestHelper.java
@@ -162,6 +162,7 @@ public class JsonPoweredCrudTestHelper {
                 }
             }
             resultDoc.append("insertedIds", insertedIds);
+            resultDoc.append("insertedCount", new BsonInt32(insertedIds.size()));
 
             resultDoc.append("matchedCount", new BsonInt32(bulkWriteResult.getMatchedCount()));
             if (bulkWriteResult.isModifiedCountAvailable()) {

--- a/driver-core/src/test/resources/crud/read/count-empty.json
+++ b/driver-core/src/test/resources/crud/read/count-empty.json
@@ -1,0 +1,39 @@
+{
+  "data": [],
+  "tests": [
+    {
+      "description": "Estimated document count with empty collection",
+      "operation": {
+        "name": "estimatedDocumentCount",
+        "arguments": {}
+      },
+      "outcome": {
+        "result": 0
+      }
+    },
+    {
+      "description": "Count documents with empty collection",
+      "operation": {
+        "name": "countDocuments",
+        "arguments": {
+          "filter": {}
+        }
+      },
+      "outcome": {
+        "result": 0
+      }
+    },
+    {
+      "description": "Deprecated count with empty collection",
+      "operation": {
+        "name": "count",
+        "arguments": {
+          "filter": {}
+        }
+      },
+      "outcome": {
+        "result": 0
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/crud/write/bulkWrite-arrayFilters.json
+++ b/driver-core/src/test/resources/crud/write/bulkWrite-arrayFilters.json
@@ -28,48 +28,57 @@
     {
       "description": "BulkWrite with arrayFilters",
       "operation": {
+        "name": "bulkWrite",
         "arguments": {
-          "options": {
-            "ordered": true
-          },
           "requests": [
             {
+              "name": "updateOne",
               "arguments": {
+                "filter": {},
+                "update": {
+                  "$set": {
+                    "y.$[i].b": 2
+                  }
+                },
                 "arrayFilters": [
                   {
                     "i.b": 3
                   }
-                ],
+                ]
+              }
+            },
+            {
+              "name": "updateMany",
+              "arguments": {
                 "filter": {},
                 "update": {
                   "$set": {
                     "y.$[i].b": 2
                   }
-                }
-              },
-              "name": "updateOne"
-            },
-            {
-              "arguments": {
+                },
                 "arrayFilters": [
                   {
                     "i.b": 1
                   }
-                ],
-                "filter": {},
-                "update": {
-                  "$set": {
-                    "y.$[i].b": 2
-                  }
-                }
-              },
-              "name": "updateMany"
+                ]
+              }
             }
-          ]
-        },
-        "name": "bulkWrite"
+          ],
+          "options": {
+            "ordered": true
+          }
+        }
       },
       "outcome": {
+        "result": {
+          "deletedCount": 0,
+          "insertedCount": 0,
+          "insertedIds": {},
+          "matchedCount": 3,
+          "modifiedCount": 3,
+          "upsertedCount": 0,
+          "upsertedIds": {}
+        },
         "collection": {
           "data": [
             {
@@ -95,14 +104,6 @@
               ]
             }
           ]
-        },
-        "result": {
-          "deletedCount": 0,
-          "insertedIds": {},
-          "matchedCount": 3,
-          "modifiedCount": 3,
-          "upsertedCount": 0,
-          "upsertedIds": {}
         }
       }
     }

--- a/driver-core/src/test/resources/crud/write/updateMany-arrayFilters.json
+++ b/driver-core/src/test/resources/crud/write/updateMany-arrayFilters.json
@@ -46,7 +46,8 @@
       "outcome": {
         "result": {
           "matchedCount": 2,
-          "modifiedCount": 0
+          "modifiedCount": 0,
+          "upsertedCount": 0
         },
         "collection": {
           "data": [
@@ -97,7 +98,8 @@
       "outcome": {
         "result": {
           "matchedCount": 2,
-          "modifiedCount": 1
+          "modifiedCount": 1,
+          "upsertedCount": 0
         },
         "collection": {
           "data": [
@@ -148,7 +150,8 @@
       "outcome": {
         "result": {
           "matchedCount": 2,
-          "modifiedCount": 2
+          "modifiedCount": 2,
+          "upsertedCount": 0
         },
         "collection": {
           "data": [

--- a/driver-core/src/test/resources/crud/write/updateOne-arrayFilters.json
+++ b/driver-core/src/test/resources/crud/write/updateOne-arrayFilters.json
@@ -62,7 +62,8 @@
       "outcome": {
         "result": {
           "matchedCount": 1,
-          "modifiedCount": 0
+          "modifiedCount": 0,
+          "upsertedCount": 0
         },
         "collection": {
           "data": [
@@ -129,7 +130,8 @@
       "outcome": {
         "result": {
           "matchedCount": 1,
-          "modifiedCount": 1
+          "modifiedCount": 1,
+          "upsertedCount": 0
         },
         "collection": {
           "data": [
@@ -196,7 +198,8 @@
       "outcome": {
         "result": {
           "matchedCount": 1,
-          "modifiedCount": 1
+          "modifiedCount": 1,
+          "upsertedCount": 0
         },
         "collection": {
           "data": [
@@ -268,7 +271,8 @@
       "outcome": {
         "result": {
           "matchedCount": 1,
-          "modifiedCount": 0
+          "modifiedCount": 0,
+          "upsertedCount": 0
         },
         "collection": {
           "data": [
@@ -340,7 +344,8 @@
       "outcome": {
         "result": {
           "matchedCount": 1,
-          "modifiedCount": 1
+          "modifiedCount": 1,
+          "upsertedCount": 0
         },
         "collection": {
           "data": [

--- a/driver-core/src/test/resources/retryable-writes/bulkWrite-serverErrors.json
+++ b/driver-core/src/test/resources/retryable-writes/bulkWrite-serverErrors.json
@@ -71,6 +71,7 @@
       "outcome": {
         "result": {
           "deletedCount": 1,
+          "insertedCount": 1,
           "insertedIds": {
             "1": 3
           },
@@ -156,6 +157,7 @@
       "outcome": {
         "result": {
           "deletedCount": 1,
+          "insertedCount": 1,
           "insertedIds": {
             "1": 3
           },

--- a/driver-core/src/test/resources/retryable-writes/bulkWrite.json
+++ b/driver-core/src/test/resources/retryable-writes/bulkWrite.json
@@ -61,6 +61,7 @@
       "outcome": {
         "result": {
           "deletedCount": 1,
+          "insertedCount": 1,
           "insertedIds": {
             "0": 2
           },
@@ -178,6 +179,7 @@
       "outcome": {
         "result": {
           "deletedCount": 1,
+          "insertedCount": 3,
           "insertedIds": {
             "0": 2,
             "2": 3,
@@ -271,6 +273,7 @@
       "outcome": {
         "result": {
           "deletedCount": 0,
+          "insertedCount": 1,
           "insertedIds": {
             "0": 2
           },
@@ -352,6 +355,7 @@
       "outcome": {
         "result": {
           "deletedCount": 0,
+          "insertedCount": 1,
           "insertedIds": {
             "0": 2
           },
@@ -416,6 +420,7 @@
       "outcome": {
         "result": {
           "deletedCount": 0,
+          "insertedCount": 2,
           "insertedIds": {
             "0": 2,
             "1": 3
@@ -501,6 +506,7 @@
         "error": true,
         "result": {
           "deletedCount": 0,
+          "insertedCount": 0,
           "insertedIds": {},
           "matchedCount": 0,
           "modifiedCount": 0,
@@ -575,6 +581,7 @@
         "error": true,
         "result": {
           "deletedCount": 0,
+          "insertedCount": 1,
           "insertedIds": {
             "0": 2
           },
@@ -660,6 +667,7 @@
         "error": true,
         "result": {
           "deletedCount": 0,
+          "insertedCount": 1,
           "insertedIds": {
             "1": 2
           },
@@ -726,6 +734,7 @@
       "outcome": {
         "result": {
           "deletedCount": 1,
+          "insertedCount": 1,
           "insertedIds": {
             "1": 2
           },
@@ -793,6 +802,7 @@
       "outcome": {
         "result": {
           "deletedCount": 0,
+          "insertedCount": 1,
           "insertedIds": {
             "1": 2
           },

--- a/driver-core/src/test/resources/transactions/bulk.json
+++ b/driver-core/src/test/resources/transactions/bulk.json
@@ -184,6 +184,7 @@
           },
           "result": {
             "deletedCount": 4,
+            "insertedCount": 6,
             "insertedIds": {
               "0": 1,
               "3": 3,

--- a/driver-core/src/test/resources/transactions/transaction-options.json
+++ b/driver-core/src/test/resources/transactions/transaction-options.json
@@ -1159,6 +1159,7 @@
           },
           "result": {
             "deletedCount": 0,
+            "insertedCount": 1,
             "insertedIds": {
               "0": 1
             },

--- a/driver-legacy/src/test/functional/com/mongodb/client/LegacyCrudTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/client/LegacyCrudTest.java
@@ -56,11 +56,13 @@ public class LegacyCrudTest extends LegacyDatabaseTestCase {
     @Before
     public void setUp() {
         super.setUp();
-        List<BsonDocument> documents = new ArrayList<BsonDocument>();
-        for (BsonValue document: data) {
-            documents.add(document.asDocument());
+        if (!data.isEmpty()) {
+            List<BsonDocument> documents = new ArrayList<BsonDocument>();
+            for (BsonValue document : data) {
+                documents.add(document.asDocument());
+            }
+            getCollectionHelper().insertDocuments(documents);
         }
-        getCollectionHelper().insertDocuments(documents);
         collection = database.getCollection(getClass().getName(), BsonDocument.class);
         helper = new JsonPoweredCrudTestHelper(description, database, collection);
     }
@@ -78,11 +80,6 @@ public class LegacyCrudTest extends LegacyDatabaseTestCase {
                     && actualResult.asDocument().getNumber("upsertedCount").intValue() == 0
                     && !expectedResult.asDocument().containsKey("upsertedCount")) {
             expectedResult.asDocument().append("upsertedCount", actualResult.asDocument().get("upsertedCount"));
-        }
-
-        // Remove insertCount
-        if (actualResult.isDocument() && actualResult.asDocument().containsKey("insertedCount")) {
-            actualResult.asDocument().remove("insertedCount");
         }
 
         assertEquals(description, expectedResult, actualResult);

--- a/driver-sync/src/test/functional/com/mongodb/client/CrudTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/CrudTest.java
@@ -57,10 +57,12 @@ public class CrudTest extends DatabaseTestCase {
     public void setUp() {
         super.setUp();
         List<BsonDocument> documents = new ArrayList<BsonDocument>();
-        for (BsonValue document: data) {
-            documents.add(document.asDocument());
+        if (!data.isEmpty()) {
+            for (BsonValue document : data) {
+                documents.add(document.asDocument());
+            }
+            getCollectionHelper().insertDocuments(documents);
         }
-        getCollectionHelper().insertDocuments(documents);
         collection = database.getCollection(getClass().getName(), BsonDocument.class);
         helper = new JsonPoweredCrudTestHelper(description, database, collection);
     }
@@ -79,7 +81,6 @@ public class CrudTest extends DatabaseTestCase {
                     && !expectedResult.asDocument().containsKey("upsertedCount")) {
             expectedResult.asDocument().append("upsertedCount", actualResult.asDocument().get("upsertedCount"));
         }
-
         assertEquals(description, expectedResult, actualResult);
 
         if (expectedOutcome.containsKey("collection")) {

--- a/driver-sync/src/test/functional/com/mongodb/client/JsonPoweredCrudTestHelper.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/JsonPoweredCrudTestHelper.java
@@ -144,6 +144,7 @@ public class JsonPoweredCrudTestHelper {
                 }
             }
             resultDoc.append("insertedIds", insertedIds);
+            resultDoc.append("insertedCount", new BsonInt32(insertedIds.size()));
 
             resultDoc.append("matchedCount", new BsonInt32(bulkWriteResult.getMatchedCount()));
             if (bulkWriteResult.isModifiedCountAvailable()) {


### PR DESCRIPTION
Two changes required to test runners:

1. Handle insertedCount, which is redundant with insertedIds.  Has to be done twice, once for sync and once for async.
2. Handle an empty list of documents to insert in the test setup.  Has to be thrice, once for sync, once for async, and once for legacy sync.