### PR TITLE
Disable retryable writes when no session is available for any reason.

### DIFF
--- a/driver-core/src/main/com/mongodb/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/CommandOperationHelper.java
@@ -466,7 +466,7 @@ final class CommandOperationHelper {
                     @Override
                     public R call(final ConnectionSource source, final Connection connection) {
                         try {
-                            if (!canRetryWrite(source.getServerDescription(), connection.getDescription())) {
+                            if (!canRetryWrite(source.getServerDescription(), connection.getDescription(), binding.getSessionContext())) {
                                 throw originalException;
                             }
                             return transformer.apply(connection.command(database, originalCommand, fieldNameValidator,
@@ -559,7 +559,8 @@ final class CommandOperationHelper {
                     public void call(final AsyncConnectionSource source, final AsyncConnection connection, final Throwable t) {
                         if (t != null) {
                             callback.onResult(null, originalError);
-                        } else if (!canRetryWrite(source.getServerDescription(), connection.getDescription())) {
+                        } else if (!canRetryWrite(source.getServerDescription(), connection.getDescription(),
+                                binding.getSessionContext())) {
                             releasingCallback(callback, source, connection).onResult(null, originalError);
                         } else {
                             connection.commandAsync(database, command, fieldNameValidator, readPreference,

--- a/driver-core/src/main/com/mongodb/operation/OperationHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/OperationHelper.java
@@ -276,7 +276,8 @@ final class OperationHelper {
             LOGGER.debug("retryWrites set to true but the server is a standalone server.");
             return false;
         } else if (!sessionContext.hasSession()) {
-            LOGGER.debug("retryWrites set to true but there is no implicit session.");
+            LOGGER.debug("retryWrites set to true but there is no implicit session, likely because the MongoClient was created with " +
+                    "multiple MongoCredential instances and sessions can only be used with a single MongoCredential");
             return false;
         }
         return true;

--- a/driver-core/src/main/com/mongodb/operation/OperationHelper.java
+++ b/driver-core/src/main/com/mongodb/operation/OperationHelper.java
@@ -260,11 +260,12 @@ final class OperationHelper {
             LOGGER.debug("retryWrites set to true but in an active transaction.");
             return false;
         } else {
-            return canRetryWrite(serverDescription, connectionDescription);
+            return canRetryWrite(serverDescription, connectionDescription, sessionContext);
         }
     }
 
-    static boolean canRetryWrite(final ServerDescription serverDescription, final ConnectionDescription connectionDescription) {
+    static boolean canRetryWrite(final ServerDescription serverDescription, final ConnectionDescription connectionDescription,
+                                 final SessionContext sessionContext) {
         if (connectionDescription.getServerVersion().compareTo(new ServerVersion(3, 6)) < 0) {
             LOGGER.debug("retryWrites set to true but the server does not support retryable writes.");
             return false;
@@ -273,6 +274,9 @@ final class OperationHelper {
             return false;
         } else if (connectionDescription.getServerType().equals(ServerType.STANDALONE)) {
             LOGGER.debug("retryWrites set to true but the server is a standalone server.");
+            return false;
+        } else if (!sessionContext.hasSession()) {
+            LOGGER.debug("retryWrites set to true but there is no implicit session.");
             return false;
         }
         return true;

--- a/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/OperationFunctionalSpecification.groovy
@@ -264,12 +264,18 @@ class OperationFunctionalSpecification extends Specification {
             getReadConnectionSource() >> connectionSource
             getReadPreference() >> readPreference
             getSessionContext() >> Stub(SessionContext) {
+                hasSession() >> true
                 hasActiveTransaction() >> false
                 getReadConcern() >> readConcern
             }
         }
         def writeBinding = Stub(WriteBinding) {
             getWriteConnectionSource() >> connectionSource
+            getSessionContext() >> Stub(SessionContext) {
+                hasSession() >> true
+                hasActiveTransaction() >> false
+                getReadConcern() >> readConcern
+            }
         }
 
         if (retryable) {
@@ -334,12 +340,18 @@ class OperationFunctionalSpecification extends Specification {
             getReadConnectionSource(_) >> { it[0].onResult(connectionSource, null) }
             getReadPreference() >> readPreference
             getSessionContext() >> Stub(SessionContext) {
+                hasSession() >> true
                 hasActiveTransaction() >> false
                 getReadConcern() >> readConcern
             }
         }
         def writeBinding = Stub(AsyncWriteBinding) {
             getWriteConnectionSource(_) >> { it[0].onResult(connectionSource, null) }
+            getSessionContext() >> Stub(SessionContext) {
+                hasSession() >> true
+                hasActiveTransaction() >> false
+                getReadConcern() >> readConcern
+            }
         }
         def callback = new FutureResultCallback()
 
@@ -413,6 +425,11 @@ class OperationFunctionalSpecification extends Specification {
         }
         def writeBinding = Stub(WriteBinding) {
             getWriteConnectionSource() >> connectionSource
+            getSessionContext() >> Stub(SessionContext) {
+                hasSession() >> true
+                hasActiveTransaction() >> false
+                getReadConcern() >> ReadConcern.DEFAULT
+            }
         }
 
         1 * connection.command(*_) >> { throw exception }
@@ -452,6 +469,11 @@ class OperationFunctionalSpecification extends Specification {
 
         def writeBinding = Stub(AsyncWriteBinding) {
             getWriteConnectionSource(_) >> { it[0].onResult(connectionSource, null) }
+            getSessionContext() >> Stub(SessionContext) {
+                hasSession() >> true
+                hasActiveTransaction() >> false
+                getReadConcern() >> ReadConcern.DEFAULT
+            }
         }
         def callback = new FutureResultCallback()
 

--- a/driver-core/src/test/unit/com/mongodb/operation/CommandOperationHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/CommandOperationHelperSpecification.groovy
@@ -18,6 +18,7 @@ package com.mongodb.operation
 
 import com.mongodb.MongoCommandException
 import com.mongodb.MongoWriteConcernException
+import com.mongodb.ReadConcern
 import com.mongodb.ReadPreference
 import com.mongodb.ServerAddress
 import com.mongodb.async.SingleResultCallback
@@ -34,6 +35,7 @@ import com.mongodb.connection.ServerDescription
 import com.mongodb.connection.ServerType
 import com.mongodb.connection.ServerVersion
 import com.mongodb.internal.validator.NoOpFieldNameValidator
+import com.mongodb.session.SessionContext
 import org.bson.BsonBoolean
 import org.bson.BsonDocument
 import org.bson.BsonInt32
@@ -160,6 +162,11 @@ class CommandOperationHelperSpecification extends Specification {
         }
         def writeBinding = Stub(WriteBinding) {
             getWriteConnectionSource() >> connectionSource
+            getSessionContext() >> Stub(SessionContext) {
+                hasSession() >> true
+                hasActiveTransaction() >> false
+                getReadConcern() >> ReadConcern.DEFAULT
+            }
         }
 
         when:
@@ -208,6 +215,11 @@ class CommandOperationHelperSpecification extends Specification {
         }
         def asyncWriteBinding = Stub(AsyncWriteBinding) {
             getWriteConnectionSource(_) >> { it[0].onResult(connectionSource, null) }
+            getSessionContext() >> Stub(SessionContext) {
+                hasSession() >> true
+                hasActiveTransaction() >> false
+                getReadConcern() >> ReadConcern.DEFAULT
+            }
         }
 
         when:

--- a/driver-core/src/test/unit/com/mongodb/operation/OperationHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/OperationHelperSpecification.groovy
@@ -390,15 +390,22 @@ class OperationHelperSpecification extends Specification {
     def 'should check if a valid retryable write'() {
         given:
         def activeTransactionSessionContext = Stub(SessionContext) {
+            hasSession() >> true
             hasActiveTransaction() >> true
         }
         def noTransactionSessionContext = Stub(SessionContext) {
+            hasSession() >> true
+            hasActiveTransaction() >> false
+        }
+        def noOpSessionContext = Stub(SessionContext) {
+            hasSession() >> false
             hasActiveTransaction() >> false
         }
 
         expect:
         isRetryableWrite(retryWrites, writeConcern, serverDescription, connectionDescription, noTransactionSessionContext) == expected
         !isRetryableWrite(retryWrites, writeConcern, serverDescription, connectionDescription, activeTransactionSessionContext)
+        !isRetryableWrite(retryWrites, writeConcern, serverDescription, connectionDescription, noOpSessionContext)
 
         where:
         retryWrites | writeConcern   | serverDescription             | connectionDescription                 | expected


### PR DESCRIPTION
The only known reason that this covers is when the driver is configured
with multiple credentials (which is deprecated), in which case the
server supports retryable writes but sessions are still unsupported due
to the multiple credentials.

JAVA-2963