### PR TITLE
3.9 deprecation

### DIFF
--- a/bson/src/main/org/bson/BSON.java
+++ b/bson/src/main/org/bson/BSON.java
@@ -16,8 +16,6 @@
 
 package org.bson;
 
-import org.bson.util.ClassMap;
-
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.regex.Pattern;
@@ -27,7 +25,10 @@ import java.util.regex.Pattern;
  * supports the registration of encoding and decoding hooks to transform BSON types during encoding or decoding.
  *
  * @see org.bson.Transformer
+ * @deprecated there is no replacement for this class
  */
+@Deprecated
+@SuppressWarnings("deprecation")
 public class BSON {
 
     public static final byte EOO = 0;
@@ -85,8 +86,8 @@ public class BSON {
 
     private static volatile boolean encodeHooks = false;
     private static volatile boolean decodeHooks = false;
-    private static final ClassMap<List<Transformer>> encodingHooks = new ClassMap<List<Transformer>>();
-    private static final ClassMap<List<Transformer>> decodingHooks = new ClassMap<List<Transformer>>();
+    private static final org.bson.util.ClassMap<List<Transformer>> encodingHooks = new org.bson.util.ClassMap<List<Transformer>>();
+    private static final org.bson.util.ClassMap<List<Transformer>> decodingHooks = new org.bson.util.ClassMap<List<Transformer>>();
 
     /**
      * Gets whether any encoding transformers have been registered for any classes.

--- a/bson/src/main/org/bson/BasicBSONCallback.java
+++ b/bson/src/main/org/bson/BasicBSONCallback.java
@@ -37,6 +37,7 @@ import java.util.regex.Pattern;
 /**
  * An implementation of {@code BsonCallback} that creates an instance of BSONObject.
  */
+@SuppressWarnings("deprecation")
 public class BasicBSONCallback implements BSONCallback {
 
     private Object root;

--- a/bson/src/main/org/bson/BasicBSONEncoder.java
+++ b/bson/src/main/org/bson/BasicBSONEncoder.java
@@ -37,11 +37,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 
-import static org.bson.BSON.regexFlags;
-
 /**
  * This is meant to be pooled or cached. There is some per instance memory for string conversion, etc...
  */
+@SuppressWarnings("deprecation")
 public class BasicBSONEncoder implements BSONEncoder {
 
     private BsonBinaryWriter bsonWriter;
@@ -386,7 +385,7 @@ public class BasicBSONEncoder implements BSONEncoder {
      */
     protected void putPattern(final String name, final Pattern value) {
         putName(name);
-        bsonWriter.writeRegularExpression(new BsonRegularExpression(value.pattern(), regexFlags(value.flags())));
+        bsonWriter.writeRegularExpression(new BsonRegularExpression(value.pattern(), org.bson.BSON.regexFlags(value.flags())));
     }
 
     /**

--- a/bson/src/main/org/bson/LazyBSONObject.java
+++ b/bson/src/main/org/bson/LazyBSONObject.java
@@ -54,6 +54,7 @@ import static org.bson.BsonBinarySubType.OLD_BINARY;
  * An immutable {@code BSONObject} backed by a byte buffer that lazily provides keys and values on request. This is useful for transferring
  * BSON documents between servers when you don't want to pay the performance penalty of encoding or decoding them fully.
  */
+@SuppressWarnings("deprecation")
 public class LazyBSONObject implements BSONObject {
     private final byte[] bytes;
     private final int offset;

--- a/bson/src/main/org/bson/util/ClassAncestry.java
+++ b/bson/src/main/org/bson/util/ClassAncestry.java
@@ -22,8 +22,8 @@ import java.util.List;
 import java.util.concurrent.ConcurrentMap;
 
 import static java.util.Collections.unmodifiableList;
-import static org.bson.util.CopyOnWriteMap.newHashMap;
 
+@SuppressWarnings("deprecation")
 class ClassAncestry {
 
     /**
@@ -81,6 +81,6 @@ class ClassAncestry {
         return (_ancestryCache);
     }
 
-    private static final ConcurrentMap<Class<?>, List<Class<?>>> _ancestryCache = newHashMap();
+    private static final ConcurrentMap<Class<?>, List<Class<?>>> _ancestryCache = CopyOnWriteMap.newHashMap();
 }
 

--- a/bson/src/main/org/bson/util/ClassMap.java
+++ b/bson/src/main/org/bson/util/ClassMap.java
@@ -38,7 +38,9 @@ import java.util.Map;
  * (assuming Dog.class &lt; Animal.class)
  *
  * @param <T> the type of the value in this map
+ * @deprecated there is no replacement for this class
  */
+@Deprecated
 public class ClassMap<T> {
     /**
      * Helper method that walks superclass and interface graph, superclasses first, then interfaces, to compute an ancestry list. Super

--- a/bson/src/main/org/bson/util/ComputingMap.java
+++ b/bson/src/main/org/bson/util/ComputingMap.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import static org.bson.assertions.Assertions.notNull;
 
+@SuppressWarnings("deprecation")
 final class ComputingMap<K, V> implements Map<K, V>, Function<K, V> {
 
     public static <K, V> Map<K, V> create(final Function<K, V> function) {

--- a/bson/src/test/unit/org/bson/BSONTest.java
+++ b/bson/src/test/unit/org/bson/BSONTest.java
@@ -39,6 +39,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("deprecation")
 public class BSONTest {
 
     @Before

--- a/bson/src/test/unit/org/bson/LazyBSONListTest.java
+++ b/bson/src/test/unit/org/bson/LazyBSONListTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@SuppressWarnings("rawtypes")
+@SuppressWarnings({"rawtypes", "deprecation"})
 public class LazyBSONListTest {
     private LazyBSONList encodeAndExtractList(final List<?> list) {
         BSONObject document = new BasicBSONObject("l", list);

--- a/driver-core/src/main/com/mongodb/DBObjectCodec.java
+++ b/driver-core/src/main/com/mongodb/DBObjectCodec.java
@@ -16,7 +16,6 @@
 
 package com.mongodb;
 
-import org.bson.BSON;
 import org.bson.BSONObject;
 import org.bson.BsonBinary;
 import org.bson.BsonBinarySubType;
@@ -62,7 +61,7 @@ import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
  *
  * @since 3.0
  */
-@SuppressWarnings("rawtypes")
+@SuppressWarnings({"rawtypes", "deprecation"})
 public class DBObjectCodec implements CollectibleCodec<DBObject> {
     private static final BsonTypeClassMap DEFAULT_BSON_TYPE_CLASS_MAP = createDefaultBsonTypeClassMap();
     private static final CodecRegistry DEFAULT_REGISTRY =
@@ -208,7 +207,7 @@ public class DBObjectCodec implements CollectibleCodec<DBObject> {
 
     @SuppressWarnings("unchecked")
     private void writeValue(final BsonWriter bsonWriter, final EncoderContext encoderContext, final Object initialValue) {
-        Object value = BSON.applyEncodingHooks(initialValue);
+        Object value = org.bson.BSON.applyEncodingHooks(initialValue);
         if (value == null) {
             bsonWriter.writeNull();
         } else if (value instanceof DBRef) {
@@ -334,7 +333,7 @@ public class DBObjectCodec implements CollectibleCodec<DBObject> {
             path.remove(fieldName);
         }
 
-        return BSON.applyDecodingHooks(initialRetVal);
+        return org.bson.BSON.applyDecodingHooks(initialRetVal);
     }
 
     private Object readBinary(final BsonReader reader, final DecoderContext decoderContext) {

--- a/driver-legacy/src/main/com/mongodb/Bytes.java
+++ b/driver-legacy/src/main/com/mongodb/Bytes.java
@@ -19,7 +19,6 @@
 package com.mongodb;
 
 import com.mongodb.lang.Nullable;
-import org.bson.BSON;
 import org.bson.types.BSONTimestamp;
 import org.bson.types.Code;
 import org.bson.types.CodeWScope;
@@ -31,8 +30,11 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Class that hold definitions of the wire protocol
+ * @deprecated there is no replacement for this class
  */
-public class Bytes extends BSON {
+@Deprecated
+@SuppressWarnings("deprecation")
+public class Bytes extends org.bson.BSON {
 
     /**
      * Little-endian

--- a/driver-legacy/src/main/com/mongodb/DB.java
+++ b/driver-legacy/src/main/com/mongodb/DB.java
@@ -70,6 +70,7 @@ import static java.util.Arrays.asList;
  * @see MongoClient
  */
 @ThreadSafe
+@SuppressWarnings("deprecation")
 public class DB {
     private final Mongo mongo;
     private final String name;

--- a/driver-legacy/src/main/com/mongodb/DB.java
+++ b/driver-legacy/src/main/com/mongodb/DB.java
@@ -105,7 +105,9 @@ public class DB {
      * Gets the Mongo instance
      *
      * @return the mongo instance that this database was created from.
+     * @deprecated
      */
+    @Deprecated
     public Mongo getMongo() {
         return mongo;
     }

--- a/driver-legacy/src/main/com/mongodb/DB.java
+++ b/driver-legacy/src/main/com/mongodb/DB.java
@@ -696,7 +696,9 @@ public class DB {
      *
      * @param option value to be added
      * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-query Query Flags
+     * @deprecated Replaced with {@link DBCursor#addOption(int)}
      */
+    @Deprecated
     public void addOption(final int option) {
         optionHolder.add(option);
     }
@@ -706,7 +708,9 @@ public class DB {
      *
      * @param options bit vector of query options
      * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-query Query Flags
+     * @deprecated Replaced with {@link DBCursor#setOptions(int)}
      */
+    @Deprecated
     public void setOptions(final int options) {
         optionHolder.set(options);
     }
@@ -714,7 +718,9 @@ public class DB {
     /**
      * Resets the query options.
      * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-query Query Flags
+     * @deprecated Replaced with {@link DBCursor#resetOptions()}
      */
+    @Deprecated
     public void resetOptions() {
         optionHolder.reset();
     }
@@ -724,7 +730,9 @@ public class DB {
      *
      * @return bit vector of query options
      * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#op-query Query Flags
+     * @deprecated Replaced with {@link DBCursor#getOptions()}
      */
+    @Deprecated
     public int getOptions() {
         return optionHolder.get();
     }

--- a/driver-legacy/src/main/com/mongodb/DB.java
+++ b/driver-legacy/src/main/com/mongodb/DB.java
@@ -105,12 +105,27 @@ public class DB {
     /**
      * Gets the Mongo instance
      *
-     * @return the mongo instance that this database was created from.
-     * @deprecated
+     * @return the mongo instance that this database was created from
+     * @deprecated Use {@link #getMongoClient()} instead
      */
     @Deprecated
     public Mongo getMongo() {
         return mongo;
+    }
+
+    /**
+     * Gets the MongoClient instance
+     *
+     * @return the MongoClient instance that this database was constructed from
+     * @throws IllegalStateException if this DB was not created from a MongoClient instance
+     * @since 3.9
+     */
+    public MongoClient getMongoClient() {
+        if (mongo instanceof MongoClient) {
+            return (MongoClient) mongo;
+        } else {
+            throw new IllegalStateException("This DB was not created from a MongoClient.  Use getMongo instead");
+        }
     }
 
     /**

--- a/driver-legacy/src/main/com/mongodb/DBCollection.java
+++ b/driver-legacy/src/main/com/mongodb/DBCollection.java
@@ -2088,7 +2088,9 @@ public class DBCollection {
      *
      * @param option value to be added
      * @mongodb.driver.manual reference/method/cursor.addOption/#flags Query Flags
+     * @deprecated Replaced with {@link DBCursor#addOption(int)}
      */
+    @Deprecated
     public void addOption(final int option) {
         optionHolder.add(option);
     }
@@ -2097,7 +2099,9 @@ public class DBCollection {
      * Resets the default query options
      *
      * @mongodb.driver.manual reference/method/cursor.addOption/#flags Query Flags
+     * @deprecated Replaced with {@link DBCursor#resetOptions()}
      */
+    @Deprecated
     public void resetOptions() {
         optionHolder.reset();
     }
@@ -2107,7 +2111,9 @@ public class DBCollection {
      *
      * @return bit vector of query options
      * @mongodb.driver.manual reference/method/cursor.addOption/#flags Query Flags
+     * @deprecated Replaced with {@link DBCursor#getOptions()}
      */
+    @Deprecated
     public int getOptions() {
         return optionHolder.get();
     }
@@ -2117,7 +2123,9 @@ public class DBCollection {
      *
      * @param options bit vector of query options
      * @mongodb.driver.manual reference/method/cursor.addOption/#flags Query Flags
+     * @deprecated Replaced with {@link DBCursor#setOptions(int)}
      */
+    @Deprecated
     public void setOptions(final int options) {
         optionHolder.set(options);
     }

--- a/driver-legacy/src/main/com/mongodb/DBCollectionObjectFactory.java
+++ b/driver-legacy/src/main/com/mongodb/DBCollectionObjectFactory.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 @Immutable
+@SuppressWarnings("deprecation")
 final class DBCollectionObjectFactory implements DBObjectFactory {
 
     private final Map<List<String>, Class<? extends DBObject>> pathToClassMap;

--- a/driver-legacy/src/main/com/mongodb/DBCursor.java
+++ b/driver-legacy/src/main/com/mongodb/DBCursor.java
@@ -65,6 +65,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * @mongodb.driver.manual core/read-operations Read Operations
  */
 @NotThreadSafe
+@SuppressWarnings("deprecation")
 public class DBCursor implements Cursor, Iterable<DBObject> {
     private final DBCollection collection;
     private final DBObject filter;

--- a/driver-legacy/src/main/com/mongodb/GroupCommand.java
+++ b/driver-legacy/src/main/com/mongodb/GroupCommand.java
@@ -28,7 +28,9 @@ import static com.mongodb.assertions.Assertions.notNull;
  * This class groups the argument for a group operation and can build the underlying command object
  *
  * @mongodb.driver.manual reference/command/group/ Group
+ * @deprecated the group command was deprecated in MongoDB 3.4
  */
+@Deprecated
 public class GroupCommand {
     private final String collectionName;
     private final DBObject keys;

--- a/driver-legacy/src/main/com/mongodb/Mongo.java
+++ b/driver-legacy/src/main/com/mongodb/Mongo.java
@@ -76,8 +76,11 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * @see MongoClient
  * @see ReadPreference
  * @see WriteConcern
+ * @deprecated Replaced by {@link MongoClient}.  Any non-deprecated methods will be moved to MongoClient. The rest will be removed along
+ * with this class.
  */
 @ThreadSafe
+@Deprecated
 public class Mongo {
     static final String ADMIN_DATABASE_NAME = "admin";
 
@@ -387,6 +390,7 @@ public class Mongo {
      * @return list of server addresses
      * @throws MongoException if there's a failure
      */
+    @Deprecated
     public List<ServerAddress> getAllAddress() {
         return delegate.getCluster().getSettings().getHosts();
     }
@@ -397,6 +401,7 @@ public class Mongo {
      * @return list of server addresses
      * @throws MongoException if there's a failure
      */
+    @Deprecated
     public List<ServerAddress> getServerAddressList() {
         return delegate.getServerAddressList();
     }
@@ -410,6 +415,7 @@ public class Mongo {
      *
      * @return the address
      */
+    @Deprecated
     @SuppressWarnings("deprecation")
     @Nullable
     public ServerAddress getAddress() {
@@ -439,6 +445,7 @@ public class Mongo {
      *
      * @return replica set status information
      */
+    @Deprecated
     @Nullable
     public ReplicaSetStatus getReplicaSetStatus() {
         ClusterDescription clusterDescription = getClusterDescription();
@@ -506,6 +513,7 @@ public class Mongo {
      *
      * @return a collection of database objects
      */
+    @Deprecated
     public Collection<DB> getUsedDatabases() {
         return dbCache.values();
     }
@@ -609,6 +617,7 @@ public class Mongo {
      * @throws MongoException if there's a failure
      * @mongodb.driver.manual reference/command/fsync/ fsync command
      */
+    @Deprecated
     public CommandResult fsync(final boolean async) {
         DBObject command = new BasicDBObject("fsync", 1);
         if (async) {
@@ -625,6 +634,7 @@ public class Mongo {
      * @throws MongoException if there's a failure
      * @mongodb.driver.manual reference/command/fsync/ fsync command
      */
+    @Deprecated
     public CommandResult fsyncAndLock() {
         DBObject command = new BasicDBObject("fsync", 1);
         command.put("lock", 1);
@@ -639,6 +649,7 @@ public class Mongo {
      * @throws MongoException if there's a failure
      * @mongodb.driver.manual reference/command/fsync/ fsync command
      */
+    @Deprecated
     public DBObject unlock() {
         return DBObjects.toDBObject(createOperationExecutor().execute(new FsyncUnlockOperation(), readPreference, readConcern));
     }
@@ -650,6 +661,7 @@ public class Mongo {
      * @throws MongoException if the operation fails
      * @mongodb.driver.manual reference/command/fsync/ fsync command
      */
+    @Deprecated
     public boolean isLocked() {
         return createOperationExecutor().execute(new CurrentOpOperation(), ReadPreference.primary(), readConcern)
                        .getBoolean("fsyncLock", BsonBoolean.FALSE).getValue();
@@ -669,6 +681,7 @@ public class Mongo {
      * @return the maximum size, or 0 if not obtained from servers yet.
      * @throws MongoException if there's a failure
      */
+    @Deprecated
     @SuppressWarnings("deprecation")
     public int getMaxBsonObjectSize() {
         List<ServerDescription> primaries = getClusterDescription().getPrimaries();
@@ -680,6 +693,7 @@ public class Mongo {
      *
      * @return server address in a host:port form
      */
+    @Deprecated
     @Nullable
     public String getConnectPoint() {
         ServerAddress master = getAddress();
@@ -850,6 +864,7 @@ public class Mongo {
      * Mongo.Holder can be used as a static place to hold several instances of Mongo. Security is not enforced at this level, and needs to
      * be done on the application side.
      */
+    @Deprecated
     public static class Holder {
 
         private static final Holder INSTANCE = new Holder();

--- a/driver-legacy/src/main/com/mongodb/MongoClient.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClient.java
@@ -83,7 +83,8 @@ import static java.util.Collections.singletonList;
  * @see MongoClientURI
  * @since 2.10.0
  */
-public class MongoClient extends Mongo implements Closeable {
+@SuppressWarnings("deprecation")
+public class MongoClient extends com.mongodb.Mongo implements Closeable {
 
     /**
      * Gets the default codec registry.  It includes the following providers:

--- a/driver-legacy/src/main/com/mongodb/MongoClient.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClient.java
@@ -84,7 +84,7 @@ import static java.util.Collections.singletonList;
  * @since 2.10.0
  */
 @SuppressWarnings("deprecation")
-public class MongoClient extends com.mongodb.Mongo implements Closeable {
+public class MongoClient extends Mongo implements Closeable {
 
     /**
      * Gets the default codec registry.  It includes the following providers:

--- a/driver-legacy/src/main/com/mongodb/ParallelScanOptions.java
+++ b/driver-legacy/src/main/com/mongodb/ParallelScanOptions.java
@@ -28,7 +28,9 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * @mongodb.driver.manual reference/command/parallelCollectionScan/ Parallel Collection Scan
  * @since 2.12
+ * @deprecated the parallelCollectionScan command will be removed in MongoDB 4.2
  */
+@Deprecated
 @Immutable
 public final class ParallelScanOptions {
     private final int numCursors;

--- a/driver-legacy/src/main/com/mongodb/ReflectionDBObject.java
+++ b/driver-legacy/src/main/com/mongodb/ReflectionDBObject.java
@@ -33,8 +33,10 @@ import static java.util.Collections.synchronizedMap;
 
 /**
  * This class enables to map simple Class fields to a BSON object fields
+ * @deprecated Replaced by {@link org.bson.codecs.pojo.PojoCodecProvider}
  */
 @SuppressWarnings({"unchecked", "rawtypes"})
+@Deprecated
 public abstract class ReflectionDBObject implements DBObject {
 
     @Override

--- a/driver-legacy/src/main/com/mongodb/ReplicaSetStatus.java
+++ b/driver-legacy/src/main/com/mongodb/ReplicaSetStatus.java
@@ -20,13 +20,17 @@ package com.mongodb;
 import com.mongodb.connection.Cluster;
 import com.mongodb.connection.ClusterDescription;
 import com.mongodb.connection.ServerDescription;
+import com.mongodb.event.ClusterListener;
 import com.mongodb.lang.Nullable;
 
 import java.util.List;
 
 /**
  * Keeps replica set status.
+ *
+ * @deprecated Prefer {@link MongoClientOptions.Builder#addClusterListener(ClusterListener)}
  */
+@Deprecated
 public class ReplicaSetStatus {
 
     private final Cluster cluster;

--- a/driver-legacy/src/main/com/mongodb/gridfs/CLI.java
+++ b/driver-legacy/src/main/com/mongodb/gridfs/CLI.java
@@ -18,7 +18,6 @@ package com.mongodb.gridfs;
 
 import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
-import com.mongodb.Mongo;
 import com.mongodb.MongoClient;
 import com.mongodb.util.Util;
 
@@ -34,7 +33,7 @@ public class CLI {
 
     private static String host = "127.0.0.1";
     private static String db = "test";
-    private static Mongo mongo = null;
+    private static com.mongodb.Mongo mongo = null;
     private static GridFS gridFS;
 
     /**
@@ -51,7 +50,7 @@ public class CLI {
     }
     // CHECKSTYLE:ON
 
-    private static Mongo getMongo() throws Exception {
+    private static com.mongodb.Mongo getMongo() throws Exception {
         if (mongo == null) {
             mongo = new MongoClient(host);
         }

--- a/driver-legacy/src/main/com/mongodb/gridfs/CLI.java
+++ b/driver-legacy/src/main/com/mongodb/gridfs/CLI.java
@@ -28,7 +28,10 @@ import java.security.MessageDigest;
 
 /**
  * A simple CLI for GridFS.
+ *
+ * @deprecated there is no replacement for this class
  */
+@Deprecated
 public class CLI {
 
     private static String host = "127.0.0.1";

--- a/driver-legacy/src/main/com/mongodb/util/ClassMapBasedObjectSerializer.java
+++ b/driver-legacy/src/main/com/mongodb/util/ClassMapBasedObjectSerializer.java
@@ -16,9 +16,6 @@
 
 package com.mongodb.util;
 
-import com.mongodb.Bytes;
-import org.bson.util.ClassMap;
-
 import java.util.List;
 
 /**
@@ -28,6 +25,7 @@ import java.util.List;
  *
  * @author breinero
  */
+@SuppressWarnings("deprecation")
 class ClassMapBasedObjectSerializer extends AbstractObjectSerializer {
 
     /**
@@ -52,7 +50,7 @@ class ClassMapBasedObjectSerializer extends AbstractObjectSerializer {
     public void serialize(final Object obj, final StringBuilder buf) {
         Object objectToSerialize = obj;
 
-        objectToSerialize = Bytes.applyEncodingHooks(objectToSerialize);
+        objectToSerialize = com.mongodb.Bytes.applyEncodingHooks(objectToSerialize);
 
         if (objectToSerialize == null) {
             buf.append(" null ");
@@ -62,7 +60,7 @@ class ClassMapBasedObjectSerializer extends AbstractObjectSerializer {
         ObjectSerializer serializer = null;
 
         List<Class<?>> ancestors;
-        ancestors = ClassMap.getAncestry(objectToSerialize.getClass());
+        ancestors = org.bson.util.ClassMap.getAncestry(objectToSerialize.getClass());
 
         for (final Class<?> ancestor : ancestors) {
             serializer = _serializers.get(ancestor);
@@ -82,5 +80,5 @@ class ClassMapBasedObjectSerializer extends AbstractObjectSerializer {
         serializer.serialize(objectToSerialize, buf);
     }
 
-    private final ClassMap<ObjectSerializer> _serializers = new ClassMap<ObjectSerializer>();
+    private final org.bson.util.ClassMap<ObjectSerializer> _serializers = new org.bson.util.ClassMap<ObjectSerializer>();
 }

--- a/driver-legacy/src/main/com/mongodb/util/JSONCallback.java
+++ b/driver-legacy/src/main/com/mongodb/util/JSONCallback.java
@@ -22,7 +22,6 @@ import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
 import com.mongodb.DBRef;
-import org.bson.BSON;
 import org.bson.BSONObject;
 import org.bson.BasicBSONCallback;
 import org.bson.BsonUndefined;
@@ -50,6 +49,7 @@ import java.util.regex.Pattern;
  * @deprecated This class has been superseded by to toJson and parse methods on BasicDBObject
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class JSONCallback extends BasicBSONCallback {
 
     @Override
@@ -103,7 +103,7 @@ public class JSONCallback extends BasicBSONCallback {
             }
         } else if (b.containsField("$regex")) {
             o = Pattern.compile((String) b.get("$regex"),
-                                BSON.regexFlags((String) b.get("$options")));
+                                org.bson.BSON.regexFlags((String) b.get("$options")));
         } else if (b.containsField("$ts")) { //Legacy timestamp format
             Integer ts = ((Number) b.get("$ts")).intValue();
             Integer inc = ((Number) b.get("$inc")).intValue();
@@ -142,7 +142,7 @@ public class JSONCallback extends BasicBSONCallback {
         if (!isStackEmpty()) {
             _put(name, o);
         } else {
-            o = !BSON.hasDecodeHooks() ? o : BSON.applyDecodingHooks(o);
+            o = !org.bson.BSON.hasDecodeHooks() ? o : org.bson.BSON.applyDecodingHooks(o);
             setRoot(o);
         }
         return o;

--- a/driver-legacy/src/main/com/mongodb/util/JSONSerializers.java
+++ b/driver-legacy/src/main/com/mongodb/util/JSONSerializers.java
@@ -17,7 +17,6 @@
 package com.mongodb.util;
 
 import com.mongodb.BasicDBObject;
-import com.mongodb.Bytes;
 import com.mongodb.DBObject;
 import com.mongodb.DBRef;
 import org.bson.BsonUndefined;
@@ -53,6 +52,7 @@ import java.util.regex.Pattern;
  * @deprecated This class has been superseded by to toJson and parse methods on BasicDBObject
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class JSONSerializers {
 
     private JSONSerializers() {
@@ -390,7 +390,7 @@ public class JSONSerializers {
             DBObject externalForm = new BasicDBObject();
             externalForm.put("$regex", obj.toString());
             if (((Pattern) obj).flags() != 0) {
-                externalForm.put("$options", Bytes.regexFlags(((Pattern) obj).flags()));
+                externalForm.put("$options", com.mongodb.Bytes.regexFlags(((Pattern) obj).flags()));
             }
             serializer.serialize(externalForm, buf);
         }

--- a/driver-legacy/src/test/functional/com/mongodb/DBCollectionSpecification.groovy
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCollectionSpecification.groovy
@@ -340,7 +340,7 @@ class DBCollectionSpecification extends Specification {
         def cannedResult = BasicDBObject.parse('{value: {}}')
         def executor = new TestOperationExecutor([cannedResult, cannedResult, cannedResult])
         def db = new DB(getMongoClient(), 'myDatabase', executor)
-        def retryWrites = db.getMongo().getMongoClientOptions().getRetryWrites()
+        def retryWrites = db.getMongoClient().getMongoClientOptions().getRetryWrites()
         def collection = db.getCollection('test')
 
         when:
@@ -360,7 +360,7 @@ class DBCollectionSpecification extends Specification {
         def cannedResult = BasicDBObject.parse('{value: {}}')
         def executor = new TestOperationExecutor([cannedResult, cannedResult, cannedResult])
         def db = new DB(getMongoClient(), 'myDatabase', executor)
-        def retryWrites = db.getMongo().getMongoClientOptions().getRetryWrites()
+        def retryWrites = db.getMongoClient().getMongoClientOptions().getRetryWrites()
         def collection = db.getCollection('test')
 
         when:
@@ -396,7 +396,7 @@ class DBCollectionSpecification extends Specification {
         def cannedResult = BasicDBObject.parse('{value: {}}')
         def executor = new TestOperationExecutor([cannedResult, cannedResult, cannedResult])
         def db = new DB(getMongoClient(), 'myDatabase', executor)
-        def retryWrites = db.getMongo().getMongoClientOptions().getRetryWrites()
+        def retryWrites = db.getMongoClient().getMongoClientOptions().getRetryWrites()
         def collection = db.getCollection('test')
 
         when:
@@ -751,7 +751,7 @@ class DBCollectionSpecification extends Specification {
         def result = Stub(WriteConcernResult)
         def executor = new TestOperationExecutor([result, result, result])
         def db = new DB(getMongoClient(), 'myDatabase', executor)
-        def retryWrites = db.getMongo().getMongoClientOptions().getRetryWrites()
+        def retryWrites = db.getMongoClient().getMongoClientOptions().getRetryWrites()
         def collection = db.getCollection('test')
         def query = '{a: 1}'
         def update = '{$set: {a: 2}}'
@@ -795,7 +795,7 @@ class DBCollectionSpecification extends Specification {
         def result = Stub(WriteConcernResult)
         def executor = new TestOperationExecutor([result, result, result])
         def db = new DB(getMongoClient(), 'myDatabase', executor)
-        def retryWrites = db.getMongo().getMongoClientOptions().getRetryWrites()
+        def retryWrites = db.getMongoClient().getMongoClientOptions().getRetryWrites()
         def collection = db.getCollection('test')
         def query = '{a: 1}'
 

--- a/driver-legacy/src/test/functional/com/mongodb/DBCollectionTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCollectionTest.java
@@ -69,6 +69,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
 
+@SuppressWarnings("deprecation")
 public class DBCollectionTest extends DatabaseTestCase {
 
     @Test

--- a/driver-legacy/src/test/functional/com/mongodb/DBCursorOldTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCursorOldTest.java
@@ -40,6 +40,7 @@ import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
 
+@SuppressWarnings("deprecation")
 public class DBCursorOldTest extends DatabaseTestCase {
 
     @Test

--- a/driver-legacy/src/test/functional/com/mongodb/DBCursorTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCursorTest.java
@@ -228,6 +228,7 @@ public class DBCursorTest extends DatabaseTestCase {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testGetServerAddress() {
         DBCursor cursor = collection.find().limit(2);

--- a/driver-legacy/src/test/functional/com/mongodb/DBCursorTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCursorTest.java
@@ -545,6 +545,7 @@ public class DBCursorTest extends DatabaseTestCase {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Test(expected = UnsupportedOperationException.class)
     public void exhaustOptionShouldThrowUnsupportedOperationException() {
         DBCursor cursor = new DBCursor(collection, new BasicDBObject("x", 1), new BasicDBObject(), ReadPreference.primary());

--- a/driver-legacy/src/test/functional/com/mongodb/DBObjectCodecReflectionTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBObjectCodecReflectionTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
+@SuppressWarnings("deprecation")
 public class DBObjectCodecReflectionTest extends DatabaseTestCase {
 
     @Test

--- a/driver-legacy/src/test/functional/com/mongodb/DBObjectCodecTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBObjectCodecTest.java
@@ -16,7 +16,6 @@
 
 package com.mongodb;
 
-import org.bson.BSON;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonDocumentWriter;
@@ -42,6 +41,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("deprecation")
 public class DBObjectCodecTest extends DatabaseTestCase {
 
     @Test
@@ -50,7 +50,7 @@ public class DBObjectCodecTest extends DatabaseTestCase {
             collection.save(new BasicDBObject("_id", 1).append("x", 1.1));
             assertEquals(Double.class, collection.findOne().get("x").getClass());
 
-            BSON.addEncodingHook(Double.class, new Transformer() {
+            org.bson.BSON.addEncodingHook(Double.class, new Transformer() {
                 public Object transform(final Object o) {
                     return o.toString();
                 }
@@ -59,20 +59,20 @@ public class DBObjectCodecTest extends DatabaseTestCase {
             collection.save(new BasicDBObject("_id", 1).append("x", 1.1));
             assertEquals(String.class, collection.findOne().get("x").getClass());
 
-            BSON.clearAllHooks();
+            org.bson.BSON.clearAllHooks();
             collection.save(new BasicDBObject("_id", 1).append("x", 1.1));
             assertEquals(Double.class, collection.findOne().get("x").getClass());
 
-            BSON.addDecodingHook(Double.class, new Transformer() {
+            org.bson.BSON.addDecodingHook(Double.class, new Transformer() {
                 public Object transform(final Object o) {
                     return o.toString();
                 }
             });
             assertEquals(String.class, collection.findOne().get("x").getClass());
-            BSON.clearAllHooks();
+            org.bson.BSON.clearAllHooks();
             assertEquals(Double.class, collection.findOne().get("x").getClass());
         } finally {
-            BSON.clearAllHooks();
+            org.bson.BSON.clearAllHooks();
         }
     }
 

--- a/driver-legacy/src/test/functional/com/mongodb/DBTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBTest.java
@@ -69,6 +69,21 @@ public class DBTest extends DatabaseTestCase {
     }
 
     @Test
+    public void shouldGetMongoClient() {
+        assertEquals(getMongoClient(), database.getMongoClient());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void shouldThrowGettingMongoClientIfFromMongo() {
+        Mongo mongo = new Mongo();
+        try {
+            mongo.getDB("test").getMongoClient();
+        } finally {
+            mongo.close();
+        }
+    }
+
+    @Test
     public void shouldReturnCachedCollectionObjectIfExists() {
         DBCollection collection1 = database.getCollection("test");
         DBCollection collection2 = database.getCollection("test");

--- a/driver-legacy/src/test/functional/com/mongodb/MapReduceTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/MapReduceTest.java
@@ -153,7 +153,7 @@ public class MapReduceTest extends DatabaseTestCase {
         MapReduceOutput output = collection.mapReduce(command);
 
 
-        DB db = database.getMongo().getDB(MR_DATABASE);
+        DB db = database.getMongoClient().getDB(MR_DATABASE);
         assertTrue(db.collectionExists(DEFAULT_COLLECTION));
         assertEquals(toList(output.results()), toList(db.getCollection(DEFAULT_COLLECTION).find()));
     }

--- a/driver-legacy/src/test/functional/com/mongodb/MongoMethodsTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/MongoMethodsTest.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
+@SuppressWarnings("deprecation")
 public class MongoMethodsTest extends DatabaseTestCase {
     @Test
     @SuppressWarnings("deprecation") // This is for testing the old API, so it will use deprecated methods

--- a/driver-legacy/src/test/unit/com/mongodb/DBCollectionObjectFactoryTest.java
+++ b/driver-legacy/src/test/unit/com/mongodb/DBCollectionObjectFactoryTest.java
@@ -27,6 +27,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
+@SuppressWarnings("deprecation")
 public class DBCollectionObjectFactoryTest {
 
     private DBCollectionObjectFactory factory;

--- a/driver-legacy/src/test/unit/com/mongodb/MongoConstructorsTest.java
+++ b/driver-legacy/src/test/unit/com/mongodb/MongoConstructorsTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
+@SuppressWarnings("deprecation")
 public class MongoConstructorsTest {
 
     @Test

--- a/driver-legacy/src/test/unit/com/mongodb/util/JSONCallbackTest.java
+++ b/driver-legacy/src/test/unit/com/mongodb/util/JSONCallbackTest.java
@@ -18,7 +18,6 @@ package com.mongodb.util;
 
 import com.mongodb.DBObject;
 import com.mongodb.DBRef;
-import org.bson.BSON;
 import org.bson.BsonUndefined;
 import org.bson.Transformer;
 import org.bson.types.BSONTimestamp;
@@ -67,7 +66,7 @@ public class JSONCallbackTest {
 
     @Test
     public void encodingHooks() {
-        BSON.addDecodingHook(Date.class, new Transformer() {
+        org.bson.BSON.addDecodingHook(Date.class, new Transformer() {
             @Override
             public Object transform(final Object o) {
                 return ((Date) o).getTime();
@@ -83,7 +82,7 @@ public class JSONCallbackTest {
             DBObject doc = (DBObject) JSON.parse("{ date : { \"$date\" : " + now.getTime() + "} }");
             assertEquals(Long.class, doc.get("date").getClass());
         } finally {
-            BSON.removeDecodingHooks(Date.class);
+            org.bson.BSON.removeDecodingHooks(Date.class);
         }
     }
 

--- a/driver-legacy/src/test/unit/com/mongodb/util/JSONTest.java
+++ b/driver-legacy/src/test/unit/com/mongodb/util/JSONTest.java
@@ -19,7 +19,6 @@ package com.mongodb.util;
 import com.mongodb.BasicDBObject;
 import com.mongodb.BasicDBObjectBuilder;
 import com.mongodb.DBObject;
-import org.bson.BSON;
 import org.bson.BasicBSONObject;
 import org.bson.types.BSONTimestamp;
 import org.bson.types.Code;
@@ -366,7 +365,7 @@ public class JSONTest {
         format.setCalendar(new GregorianCalendar(new SimpleTimeZone(0, "GMT")));
         assertEquals(format.parse("2011-05-18T18:56:00Z"), a.get("date"));
         Pattern pat = (Pattern) a.get("pat");
-        Pattern pat2 = Pattern.compile(".*", BSON.regexFlags(""));
+        Pattern pat2 = Pattern.compile(".*", org.bson.BSON.regexFlags(""));
         assertEquals(pat.pattern(), pat2.pattern());
         assertEquals(pat.flags(), pat2.flags());
         ObjectId oid = (ObjectId) a.get("oid");


### PR DESCRIPTION
Besides driver-async and driver-core, these are the remaining methods and classes that I identified for removal in 4.0 and so want to deprecate in 3.9.  Let me know if you disagree with any of these, and whether there are others that we should consider.