### PR TITLE
Clean up deprecations in preparation for next major release

### DIFF
--- a/bson/src/main/org/bson/BSONCallback.java
+++ b/bson/src/main/org/bson/BSONCallback.java
@@ -228,7 +228,7 @@ public interface BSONCallback {
      *
      * @param name the name of the field
      * @param data the field's value
-     * @deprecated
+     * @deprecated this method is no longer called by the decoder
      */
     @Deprecated
     void gotBinaryArray(String name, byte[] data);

--- a/bson/src/main/org/bson/json/JsonMode.java
+++ b/bson/src/main/org/bson/json/JsonMode.java
@@ -27,9 +27,10 @@ public enum JsonMode {
     /**
      * Strict mode representations of BSON types conform to the <a href="http://www.json.org">JSON RFC spec</a>.
      *
-     * @deprecated  The format generated with this mode is no longer considered standard for MongoDB tools.
+     * @deprecated  The format generated with this mode is no longer considered standard for MongoDB tools. This value is not currently
+     * scheduled for removal.
      */
-    @Deprecated
+    @Deprecated // NOT CURRENTLY INTENDED FOR REMOVAL
     STRICT,
 
     /**

--- a/bson/src/main/org/bson/types/ObjectId.java
+++ b/bson/src/main/org/bson/types/ObjectId.java
@@ -455,8 +455,8 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
     /**
      * Gets the time of this ID, in seconds.
      *
-     * @deprecated Use #getTimestamp instead
      * @return the time component of this ID in seconds
+     * @deprecated Use #getTimestamp instead
      */
     @Deprecated
     public int getTimeSecond() {
@@ -466,8 +466,8 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
     /**
      * Gets the time of this instance, in milliseconds.
      *
-     * @deprecated Use #getDate instead
      * @return the time component of this ID in milliseconds
+     * @deprecated Use #getDate instead
      */
     @Deprecated
     public long getTime() {

--- a/bson/src/main/org/bson/util/CopyOnWriteMap.java
+++ b/bson/src/main/org/bson/util/CopyOnWriteMap.java
@@ -166,19 +166,14 @@ abstract class CopyOnWriteMap<K, V> extends AbstractCopyOnWriteMap<K, V, Map<K, 
      * Create a new {@link CopyOnWriteMap} with the supplied {@link Map} to initialize the values.
      *
      * @param map the initial map to initialize with
-     * @deprecated since 0.0.12 use the versions that explicitly specify View.Type
      */
-    @Deprecated
     protected CopyOnWriteMap(final Map<? extends K, ? extends V> map) {
         this(map, View.Type.LIVE);
     }
 
     /**
      * Create a new empty {@link CopyOnWriteMap}.
-     *
-     * @deprecated since 0.0.12 use the versions that explicitly specify View.Type
      */
-    @Deprecated
     protected CopyOnWriteMap() {
         this(Collections.<K, V>emptyMap(), View.Type.LIVE);
     }

--- a/driver-async/src/main/com/mongodb/async/client/AggregateIterableImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/AggregateIterableImpl.java
@@ -100,7 +100,7 @@ class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public AggregateIterable<TResult> useCursor(@Nullable final Boolean useCursor) {
         this.useCursor = useCursor;
         return this;

--- a/driver-async/src/main/com/mongodb/async/client/ClientSessionHelper.java
+++ b/driver-async/src/main/com/mongodb/async/client/ClientSessionHelper.java
@@ -87,6 +87,7 @@ class ClientSessionHelper {
         }
     }
 
+    @SuppressWarnings("deprecation")
     private ClientSession createClientSession(final ClientSessionOptions options, final OperationExecutor executor) {
         ClientSessionOptions mergedOptions = ClientSessionOptions.builder(options)
                 .defaultTransactionOptions(

--- a/driver-async/src/main/com/mongodb/async/client/FindIterableImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/FindIterableImpl.java
@@ -100,6 +100,7 @@ class FindIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult> im
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public FindIterable<TResult> modifiers(@Nullable final Bson modifiers) {
         findOptions.modifiers(modifiers);
         return this;
@@ -166,7 +167,7 @@ class FindIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult> im
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public FindIterable<TResult> maxScan(final long maxScan) {
         findOptions.maxScan(maxScan);
         return this;
@@ -185,7 +186,7 @@ class FindIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult> im
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public FindIterable<TResult> snapshot(final boolean snapshot) {
         findOptions.snapshot(snapshot);
         return this;

--- a/driver-async/src/main/com/mongodb/async/client/MongoClients.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoClients.java
@@ -37,6 +37,7 @@ import static com.mongodb.internal.event.EventListenerHelper.getCommandListener;
  *
  * @since 3.0
  */
+@SuppressWarnings("deprecation")
 public final class MongoClients {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/MongoCollectionImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoCollectionImpl.java
@@ -160,37 +160,37 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public void count(final SingleResultCallback<Long> callback) {
         count(new BsonDocument(), callback);
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public void count(final Bson filter, final SingleResultCallback<Long> callback) {
         count(filter, new CountOptions(), callback);
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public void count(final Bson filter, final CountOptions options, final SingleResultCallback<Long> callback) {
         executeCount(null, filter, options, CountStrategy.COMMAND, callback);
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public void count(final ClientSession clientSession, final SingleResultCallback<Long> callback) {
         count(clientSession, new BsonDocument(), callback);
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public void count(final ClientSession clientSession, final Bson filter, final SingleResultCallback<Long> callback) {
         count(clientSession, filter, new CountOptions(), callback);
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public void count(final ClientSession clientSession, final Bson filter, final CountOptions options,
                       final SingleResultCallback<Long> callback) {
         notNull("clientSession", clientSession);
@@ -601,7 +601,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public void replaceOne(final Bson filter, final TDocument replacement, final UpdateOptions options,
                            final SingleResultCallback<UpdateResult> callback) {
         replaceOne(filter, replacement, createReplaceOptions(options), callback);
@@ -620,7 +620,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public void replaceOne(final ClientSession clientSession, final Bson filter, final TDocument replacement, final UpdateOptions options,
                            final SingleResultCallback<UpdateResult> callback) {
         replaceOne(clientSession, filter, replacement, createReplaceOptions(options), callback);

--- a/driver-core/src/main/com/mongodb/MongoCredential.java
+++ b/driver-core/src/main/com/mongodb/MongoCredential.java
@@ -52,6 +52,7 @@ public final class MongoCredential {
      * @mongodb.driver.manual core/authentication/#mongodb-cr-authentication MONGODB-CR
      * @deprecated This mechanism was replaced by {@link #SCRAM_SHA_1_MECHANISM} in MongoDB 3.0, and is now deprecated
      */
+    @SuppressWarnings("deprecation")
     @Deprecated
     public static final String MONGODB_CR_MECHANISM = AuthenticationMechanism.MONGODB_CR.getMechanismName();
 
@@ -221,6 +222,7 @@ public final class MongoCredential {
      * @deprecated MONGODB-CR was replaced by SCRAM-SHA-1 in MongoDB 3.0, and is now deprecated. Use
      * the {@link #createCredential(String, String, char[])} factory method instead.
      */
+    @SuppressWarnings("deprecation")
     @Deprecated
     public static MongoCredential createMongoCRCredential(final String userName, final String database, final char[] password) {
         return new MongoCredential(MONGODB_CR, userName, database, password);

--- a/driver-core/src/main/com/mongodb/event/CommandListenerMulticaster.java
+++ b/driver-core/src/main/com/mongodb/event/CommandListenerMulticaster.java
@@ -29,6 +29,7 @@ import java.util.List;
  */
 @Immutable
 @Deprecated
+@SuppressWarnings("deprecation")
 public class CommandListenerMulticaster implements CommandListener {
 
     private final CommandEventMulticaster wrapped;

--- a/driver-core/src/main/com/mongodb/event/ConnectionListener.java
+++ b/driver-core/src/main/com/mongodb/event/ConnectionListener.java
@@ -27,6 +27,7 @@ import java.util.EventListener;
  */
 @Beta
 @Deprecated
+@SuppressWarnings("deprecation")
 public interface ConnectionListener extends EventListener {
 
     /**

--- a/driver-legacy/src/main/com/mongodb/Mongo.java
+++ b/driver-legacy/src/main/com/mongodb/Mongo.java
@@ -93,6 +93,7 @@ public class Mongo {
     private final MongoClientOptions options;
     private final List<MongoCredential> credentialsList;
 
+    @SuppressWarnings("deprecation")
     private final Bytes.OptionHolder optionHolder;
 
     private final BufferProvider bufferProvider = new PowerOfTwoBufferPool();
@@ -312,6 +313,7 @@ public class Mongo {
                 mongoURI.getCredentials() != null ? asList(mongoURI.getCredentials()) : Collections.<MongoCredential>emptyList());
     }
 
+    @SuppressWarnings("deprecation")
     Mongo(final Cluster cluster, final MongoClientOptions options, final List<MongoCredential> credentialsList) {
         this.options = options;
         this.readPreference = options.getReadPreference();
@@ -435,6 +437,7 @@ public class Mongo {
      * @deprecated Please use {@link MongoClient} class to connect to server and corresponding {@link
      * com.mongodb.MongoClient#getMongoClientOptions()}
      */
+    @SuppressWarnings("deprecation")
     @Deprecated
     public MongoOptions getMongoOptions() {
         return new MongoOptions(getMongoClientOptions());
@@ -445,6 +448,7 @@ public class Mongo {
      *
      * @return replica set status information
      */
+    @SuppressWarnings("deprecation")
     @Deprecated
     @Nullable
     public ReplicaSetStatus getReplicaSetStatus() {
@@ -490,9 +494,11 @@ public class Mongo {
      * @return a DB representing the specified database
      * @throws IllegalArgumentException if the name is invalid
      * @see MongoNamespace#checkDatabaseNameValidity(String)
-     * @deprecated use {@link com.mongodb.MongoClient#getDatabase(String)}
+     * @deprecated This method is not currently scheduled for removal, but prefer {@link com.mongodb.MongoClient#getDatabase(String)} for
+     * new code.  Note that {@link DB} and {@link com.mongodb.client.MongoDatabase} can be used together in the same application, whith the
+     * same {@link MongoClient} instance.
      */
-    @Deprecated
+    @Deprecated // NOT CURRENTLY INTENDED FOR REMOVAL
     public DB getDB(final String dbName) {
         DB db = dbCache.get(dbName);
         if (db != null) {
@@ -546,6 +552,7 @@ public class Mongo {
      * @see ReadPreference#secondaryPreferred()
      * @deprecated Replaced with {@code ReadPreference.secondaryPreferred()}
      */
+    @SuppressWarnings("deprecation")
     @Deprecated
     public void slaveOk() {
         addOption(Bytes.QUERYOPTION_SLAVEOK);
@@ -780,6 +787,7 @@ public class Mongo {
         return delegate.getServerSessionPool();
     }
 
+    @SuppressWarnings("deprecation")
     Bytes.OptionHolder getOptionHolder() {
         return optionHolder;
     }
@@ -888,6 +896,7 @@ public class Mongo {
          * @throws MongoException if there's a failure
          * @deprecated Please use {@link #connect(MongoClientURI)} instead.
          */
+        @SuppressWarnings("deprecation")
         @Deprecated
         public Mongo connect(final MongoURI uri) {
             return connect(uri.toClientURI());

--- a/driver-legacy/src/main/com/mongodb/MongoOptions.java
+++ b/driver-legacy/src/main/com/mongodb/MongoOptions.java
@@ -171,6 +171,7 @@ public class MongoOptions {
      * @param options the MongoClientOptions to copy values from into the new MongoOptions.
      * @deprecated use {@link com.mongodb.MongoClientOptions}
      */
+    @SuppressWarnings("deprecation")
     @Deprecated
     public MongoOptions(final MongoClientOptions options) {
         connectionsPerHost = options.getConnectionsPerHost();
@@ -245,6 +246,7 @@ public class MongoOptions {
         return m;
     }
 
+    @SuppressWarnings("deprecation")
     MongoClientOptions toClientOptions() {
         Builder builder = MongoClientOptions.builder()
                                             .requiredReplicaSetName(requiredReplicaSetName)
@@ -274,6 +276,7 @@ public class MongoOptions {
      *
      * @return a WriteConcern for the current MongoOptions.
      */
+    @SuppressWarnings("deprecation")
     public WriteConcern getWriteConcern() {
         WriteConcern retVal;
 

--- a/driver-legacy/src/main/com/mongodb/MongoURI.java
+++ b/driver-legacy/src/main/com/mongodb/MongoURI.java
@@ -39,6 +39,7 @@ public class MongoURI {
     public static final String MONGODB_PREFIX = "mongodb://";
     private final MongoClientURI proxied;
 
+    @SuppressWarnings("deprecation")
     private final MongoOptions options;
 
     /**
@@ -48,6 +49,7 @@ public class MongoURI {
      * @mongodb.driver.manual reference/connection-string Connection String URI Format
      * @deprecated Replaced by {@link MongoClientURI#MongoClientURI(String)}
      */
+    @SuppressWarnings("deprecation")
     @Deprecated
     public MongoURI(final String uri) {
         this.proxied = new MongoClientURI(uri, MongoClientOptions.builder()
@@ -62,6 +64,7 @@ public class MongoURI {
      *
      * @param proxied the MongoClientURI to wrap with this deprecated class. * @deprecated Replaced by {@link MongoClientURI})
      */
+    @SuppressWarnings("deprecation")
     @Deprecated
     public MongoURI(final MongoClientURI proxied) {
         this.proxied = proxied;
@@ -169,6 +172,7 @@ public class MongoURI {
      * @param mongo the Mongo instance to get the database from.
      * @return the database specified in this URI
      */
+    @SuppressWarnings("deprecation")
     public DB connectDB(final Mongo mongo) {
         return mongo.getDB(getDatabaseNonNull());
     }
@@ -189,6 +193,7 @@ public class MongoURI {
      * @param mongo the mongo instance to get the collection from
      * @return the collection specified in this URI
      */
+    @SuppressWarnings("deprecation")
     public DBCollection connectCollection(final Mongo mongo) {
         return connectDB(mongo).getCollection(getCollectionNonNull());
     }

--- a/driver-legacy/src/main/com/mongodb/ReflectionDBObject.java
+++ b/driver-legacy/src/main/com/mongodb/ReflectionDBObject.java
@@ -50,7 +50,7 @@ public abstract class ReflectionDBObject implements DBObject {
         return getWrapper().keySet();
     }
 
-    @Deprecated
+    @SuppressWarnings("deprecation")
     @Override
     public boolean containsKey(final String key) {
         return containsField(key);

--- a/driver-legacy/src/main/com/mongodb/gridfs/CLI.java
+++ b/driver-legacy/src/main/com/mongodb/gridfs/CLI.java
@@ -31,6 +31,7 @@ import java.security.MessageDigest;
  *
  * @deprecated there is no replacement for this class
  */
+@SuppressWarnings("deprecation")
 @Deprecated
 public class CLI {
 

--- a/driver-legacy/src/main/com/mongodb/util/JSON.java
+++ b/driver-legacy/src/main/com/mongodb/util/JSON.java
@@ -29,6 +29,7 @@ import org.bson.BSONCallback;
  * @deprecated This class has been superseded by to toJson and parse methods on BasicDBObject
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 public class JSON {
 
     /**

--- a/driver-legacy/src/test/unit/com/mongodb/MongoOptionsTest.java
+++ b/driver-legacy/src/test/unit/com/mongodb/MongoOptionsTest.java
@@ -29,10 +29,10 @@ import static org.junit.Assert.assertTrue;
 /**
  * The mongo options test.
  */
+@SuppressWarnings("deprecation")
 public class MongoOptionsTest {
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testCopy() throws Exception {
 
         MongoOptions options = new MongoOptions();
@@ -79,7 +79,6 @@ public class MongoOptionsTest {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testGetterSetters() throws Exception {
 
         MongoOptions options = new MongoOptions();
@@ -126,7 +125,6 @@ public class MongoOptionsTest {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testGetWriteConcern() {
         MongoOptions options = new MongoOptions();
         assertEquals(WriteConcern.NORMAL, options.getWriteConcern());
@@ -153,7 +151,6 @@ public class MongoOptionsTest {
     }
 
     @Test
-    @SuppressWarnings("deprecation")
     public void testToClientOptions() throws UnknownHostException {
         MongoOptions options = new MongoOptions();
         options.description = "my client";

--- a/driver-legacy/src/test/unit/com/mongodb/util/JSONSerializersTest.java
+++ b/driver-legacy/src/test/unit/com/mongodb/util/JSONSerializersTest.java
@@ -79,7 +79,7 @@ public class JSONSerializersTest {
         assertEquals("{ \"binary\" : <Binary Data>}", buf.toString());
 
         // test  BOOLEAN
-        testObj = new BasicDBObject("boolean", new Boolean(true));
+        testObj = new BasicDBObject("boolean", Boolean.TRUE);
         buf = new StringBuilder();
         serializer.serialize(testObj, buf);
         assertEquals(buf.toString(), "{ \"boolean\" : true}");
@@ -164,7 +164,7 @@ public class JSONSerializersTest {
         // test  NUMBER
         Random rand = new Random();
         long val = rand.nextLong();
-        Long longVal = new Long(val);
+        Long longVal = val;
         buf = new StringBuilder();
         serializer.serialize(longVal, buf);
         assertEquals(String.valueOf(val), buf.toString());

--- a/driver-sync/src/main/com/mongodb/client/gridfs/GridFSBucketImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/gridfs/GridFSBucketImpl.java
@@ -465,14 +465,12 @@ final class GridFSBucketImpl implements GridFSBucket {
     }
 
     @Override
-    @Deprecated
     @SuppressWarnings("deprecation")
     public GridFSDownloadStream openDownloadStreamByName(final String filename) {
         return openDownloadStreamByName(filename, new com.mongodb.client.gridfs.model.GridFSDownloadByNameOptions());
     }
 
     @Override
-    @Deprecated
     @SuppressWarnings("deprecation")
     public GridFSDownloadStream openDownloadStreamByName(final String filename,
                                                          final com.mongodb.client.gridfs.model.GridFSDownloadByNameOptions options) {
@@ -480,14 +478,12 @@ final class GridFSBucketImpl implements GridFSBucket {
     }
 
     @Override
-    @Deprecated
     @SuppressWarnings("deprecation")
     public void downloadToStreamByName(final String filename, final OutputStream destination) {
         downloadToStreamByName(filename, destination, new com.mongodb.client.gridfs.model.GridFSDownloadByNameOptions());
     }
 
     @Override
-    @Deprecated
     @SuppressWarnings("deprecation")
     public void downloadToStreamByName(final String filename, final OutputStream destination,
                                        final com.mongodb.client.gridfs.model.GridFSDownloadByNameOptions options) {

--- a/driver-sync/src/main/com/mongodb/client/gridfs/GridFSUploadStreamImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/gridfs/GridFSUploadStreamImpl.java
@@ -67,7 +67,7 @@ final class GridFSUploadStreamImpl extends GridFSUploadStream {
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public ObjectId getFileId() {
         return getObjectId();
     }

--- a/driver-sync/src/main/com/mongodb/client/internal/AggregateIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/AggregateIterableImpl.java
@@ -99,7 +99,7 @@ class AggregateIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResul
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public AggregateIterable<TResult> useCursor(@Nullable final Boolean useCursor) {
         this.useCursor = useCursor;
         return this;

--- a/driver-sync/src/main/com/mongodb/client/internal/FindIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/FindIterableImpl.java
@@ -101,6 +101,7 @@ final class FindIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResu
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public FindIterable<TResult> modifiers(@Nullable final Bson modifiers) {
         findOptions.modifiers(modifiers);
         return this;
@@ -167,7 +168,7 @@ final class FindIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResu
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public FindIterable<TResult> maxScan(final long maxScan) {
         findOptions.maxScan(maxScan);
         return this;
@@ -186,7 +187,7 @@ final class FindIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResu
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public FindIterable<TResult> snapshot(final boolean snapshot) {
         findOptions.snapshot(snapshot);
         return this;

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
@@ -166,37 +166,37 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public long count() {
         return count(new BsonDocument(), new CountOptions());
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public long count(final Bson filter) {
         return count(filter, new CountOptions());
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public long count(final Bson filter, final CountOptions options) {
         return executeCount(null, filter, options, CountStrategy.COMMAND);
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public long count(final ClientSession clientSession) {
         return count(clientSession, new BsonDocument());
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public long count(final ClientSession clientSession, final Bson filter) {
         return count(clientSession, filter, new CountOptions());
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public long count(final ClientSession clientSession, final Bson filter, final CountOptions options) {
         notNull("clientSession", clientSession);
         return executeCount(clientSession, filter, options, CountStrategy.COMMAND);
@@ -568,7 +568,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public UpdateResult replaceOne(final Bson filter, final TDocument replacement, final UpdateOptions updateOptions) {
         return replaceOne(filter, replacement, createReplaceOptions(updateOptions));
     }
@@ -584,7 +584,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     }
 
     @Override
-    @Deprecated
+    @SuppressWarnings("deprecation")
     public UpdateResult replaceOne(final ClientSession clientSession, final Bson filter, final TDocument replacement,
                                    final UpdateOptions updateOptions) {
         return replaceOne(clientSession, filter, replacement, createReplaceOptions(updateOptions));


### PR DESCRIPTION
* Replace unnecessary Deprecation annotations with SuppressWarnings annotations
* Clearly mark the two Deprecated API elements that will _not_ be removed in 4.0
* Add missing SuppressWarnings annotations