### PR TITLE
Deprecate API elements in driver-core module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ configure(subprojects.findAll { it.name != 'util' }) {
         options.encoding = 'ISO-8859-1'
         options.fork = true
         options.debug = true
-        options.compilerArgs = ['-Xlint:all', '-Xlint:-options']
+        options.compilerArgs = ['-Xlint:all', '-Xlint:-options', '-Xlint:-deprecation']
 
         onlyIf { JavaVersion.current().isJava7Compatible() }
     }

--- a/driver-core/src/main/com/mongodb/binding/AsyncClusterBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/AsyncClusterBinding.java
@@ -37,6 +37,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * @since 3.0
  */
+@Deprecated
 public class AsyncClusterBinding extends AbstractReferenceCounted implements AsyncReadWriteBinding {
     private final Cluster cluster;
     private final ReadPreference readPreference;

--- a/driver-core/src/main/com/mongodb/binding/AsyncConnectionSource.java
+++ b/driver-core/src/main/com/mongodb/binding/AsyncConnectionSource.java
@@ -26,6 +26,7 @@ import com.mongodb.session.SessionContext;
  *
  * @since 3.0
  */
+@Deprecated
 public interface AsyncConnectionSource extends ReferenceCounted {
 
     /**

--- a/driver-core/src/main/com/mongodb/binding/AsyncReadBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/AsyncReadBinding.java
@@ -25,6 +25,7 @@ import com.mongodb.session.SessionContext;
  *
  * @since 3.0
  */
+@Deprecated
 public interface AsyncReadBinding extends ReferenceCounted {
     /**
      * The read preference that all connection sources returned by this instance will satisfy.

--- a/driver-core/src/main/com/mongodb/binding/AsyncReadWriteBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/AsyncReadWriteBinding.java
@@ -22,6 +22,7 @@ package com.mongodb.binding;
  *
  * @since 3.0
  */
+@Deprecated
 public interface AsyncReadWriteBinding extends AsyncReadBinding, AsyncWriteBinding, ReferenceCounted {
     @Override
     AsyncReadWriteBinding retain();

--- a/driver-core/src/main/com/mongodb/binding/AsyncSingleConnectionReadBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/AsyncSingleConnectionReadBinding.java
@@ -30,6 +30,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * @since 3.2
  */
+@Deprecated
 public class AsyncSingleConnectionReadBinding extends AbstractReferenceCounted implements AsyncReadBinding {
     private final ReadPreference readPreference;
     private final ServerDescription serverDescription;

--- a/driver-core/src/main/com/mongodb/binding/AsyncWriteBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/AsyncWriteBinding.java
@@ -24,6 +24,7 @@ import com.mongodb.session.SessionContext;
  *
  * @since 3.0
  */
+@Deprecated
 public interface AsyncWriteBinding extends ReferenceCounted {
 
     /**

--- a/driver-core/src/main/com/mongodb/binding/ClusterBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/ClusterBinding.java
@@ -36,6 +36,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * @since 3.0
  */
+@Deprecated
 public class ClusterBinding extends AbstractReferenceCounted implements ReadWriteBinding {
     private final Cluster cluster;
     private final ReadPreference readPreference;

--- a/driver-core/src/main/com/mongodb/binding/ConnectionSource.java
+++ b/driver-core/src/main/com/mongodb/binding/ConnectionSource.java
@@ -25,6 +25,7 @@ import com.mongodb.session.SessionContext;
  *
  * @since 3.0
  */
+@Deprecated
 public interface ConnectionSource extends ReferenceCounted {
 
     /**

--- a/driver-core/src/main/com/mongodb/binding/ReadBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/ReadBinding.java
@@ -24,6 +24,7 @@ import com.mongodb.session.SessionContext;
  *
  * @since 3.0
  */
+@Deprecated
 public interface ReadBinding extends ReferenceCounted {
     /**
      * The read preference that all connection sources returned by this instance will satisfy.

--- a/driver-core/src/main/com/mongodb/binding/ReadWriteBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/ReadWriteBinding.java
@@ -22,6 +22,7 @@ package com.mongodb.binding;
  *
  * @since 3.0
  */
+@Deprecated
 public interface ReadWriteBinding extends ReadBinding, WriteBinding, ReferenceCounted {
     @Override
     ReadWriteBinding retain();

--- a/driver-core/src/main/com/mongodb/binding/ReferenceCounted.java
+++ b/driver-core/src/main/com/mongodb/binding/ReferenceCounted.java
@@ -21,6 +21,7 @@ package com.mongodb.binding;
  *
  * @since 3.0
  */
+@Deprecated
 public interface ReferenceCounted {
     /**
      * Gets the current reference count, which starts at 0.

--- a/driver-core/src/main/com/mongodb/binding/SingleConnectionReadBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/SingleConnectionReadBinding.java
@@ -29,6 +29,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * @since 3.2
  */
+@Deprecated
 public class SingleConnectionReadBinding extends AbstractReferenceCounted implements ReadBinding {
 
     private final ReadPreference readPreference;

--- a/driver-core/src/main/com/mongodb/binding/SingleServerBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/SingleServerBinding.java
@@ -33,6 +33,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * @since 3.0
  */
+@Deprecated
 public class SingleServerBinding extends AbstractReferenceCounted implements ReadWriteBinding {
     private final Cluster cluster;
     private final ServerAddress serverAddress;

--- a/driver-core/src/main/com/mongodb/binding/WriteBinding.java
+++ b/driver-core/src/main/com/mongodb/binding/WriteBinding.java
@@ -23,6 +23,7 @@ import com.mongodb.session.SessionContext;
  *
  * @since 3.0
  */
+@Deprecated
 public interface WriteBinding extends ReferenceCounted {
     /**
      * Supply a connection source to a server that can be written to

--- a/driver-core/src/main/com/mongodb/bulk/DeleteRequest.java
+++ b/driver-core/src/main/com/mongodb/bulk/DeleteRequest.java
@@ -26,6 +26,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * @since 3.0
  */
+@Deprecated
 public final class DeleteRequest extends WriteRequest {
     private final BsonDocument filter;
     private boolean isMulti = true;

--- a/driver-core/src/main/com/mongodb/bulk/IndexRequest.java
+++ b/driver-core/src/main/com/mongodb/bulk/IndexRequest.java
@@ -32,6 +32,7 @@ import static java.util.Arrays.asList;
  * @mongodb.driver.manual reference/method/db.collection.ensureIndex/#options Index options
  * @since 3.0
  */
+@Deprecated
 public class IndexRequest {
     private final BsonDocument keys;
     private static final List<Integer> VALID_TEXT_INDEX_VERSIONS = asList(1, 2, 3);

--- a/driver-core/src/main/com/mongodb/bulk/InsertRequest.java
+++ b/driver-core/src/main/com/mongodb/bulk/InsertRequest.java
@@ -25,6 +25,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * @since 3.0
  */
+@Deprecated
 public final class InsertRequest extends WriteRequest {
     private final BsonDocument document;
 

--- a/driver-core/src/main/com/mongodb/bulk/UpdateRequest.java
+++ b/driver-core/src/main/com/mongodb/bulk/UpdateRequest.java
@@ -28,6 +28,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * @since 3.0
  */
+@Deprecated
 public final class UpdateRequest extends WriteRequest {
     private final BsonDocument update;
     private final Type updateType;

--- a/driver-core/src/main/com/mongodb/bulk/WriteRequest.java
+++ b/driver-core/src/main/com/mongodb/bulk/WriteRequest.java
@@ -21,6 +21,7 @@ package com.mongodb.bulk;
  *
  * @since 3.0
  */
+@Deprecated
 public abstract class WriteRequest {
 
     /**

--- a/driver-core/src/main/com/mongodb/connection/AsyncConnection.java
+++ b/driver-core/src/main/com/mongodb/connection/AsyncConnection.java
@@ -42,6 +42,7 @@ import java.util.List;
  * @since 3.0
  */
 @ThreadSafe
+@Deprecated
 public interface AsyncConnection extends ReferenceCounted {
 
     @Override

--- a/driver-core/src/main/com/mongodb/connection/BulkWriteBatchCombiner.java
+++ b/driver-core/src/main/com/mongodb/connection/BulkWriteBatchCombiner.java
@@ -37,6 +37,7 @@ import static java.util.Arrays.asList;
 /**
  * This class is not part of the public API.  It may be changed or removed at any time.
  */
+@Deprecated
 public class BulkWriteBatchCombiner {
     private final ServerAddress serverAddress;
     private final boolean ordered;

--- a/driver-core/src/main/com/mongodb/connection/ByteBufferBsonOutput.java
+++ b/driver-core/src/main/com/mongodb/connection/ByteBufferBsonOutput.java
@@ -31,6 +31,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  * This class should not be considered as part of the public API, and it may change or be removed at any time.
  *
  */
+@Deprecated
 public class ByteBufferBsonOutput extends OutputBuffer {
 
     private static final int MAX_SHIFT = 31;

--- a/driver-core/src/main/com/mongodb/connection/Cluster.java
+++ b/driver-core/src/main/com/mongodb/connection/Cluster.java
@@ -29,6 +29,7 @@ import java.io.Closeable;
  *
  * @since 3.0
  */
+@Deprecated
 public interface Cluster extends Closeable {
 
     /**

--- a/driver-core/src/main/com/mongodb/connection/ClusterFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/ClusterFactory.java
@@ -27,6 +27,7 @@ import java.util.List;
  *
  * @since 3.0
  */
+@Deprecated
 public interface ClusterFactory {
 
     // CHECKSTYLE:OFF

--- a/driver-core/src/main/com/mongodb/connection/Connection.java
+++ b/driver-core/src/main/com/mongodb/connection/Connection.java
@@ -42,6 +42,7 @@ import java.util.List;
  * @since 3.0
  */
 @ThreadSafe
+@Deprecated
 public interface Connection extends ReferenceCounted {
 
     @Override

--- a/driver-core/src/main/com/mongodb/connection/DefaultClusterFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/DefaultClusterFactory.java
@@ -35,7 +35,7 @@ import java.util.List;
  *
  * @since 3.0
  */
-@SuppressWarnings("deprecation")
+@Deprecated
 public final class DefaultClusterFactory implements ClusterFactory {
 
     @Override

--- a/driver-core/src/main/com/mongodb/connection/QueryResult.java
+++ b/driver-core/src/main/com/mongodb/connection/QueryResult.java
@@ -28,6 +28,7 @@ import java.util.List;
  * @param <T> the type of document to decode query results to
  * @since 3.0
  */
+@Deprecated
 public class QueryResult<T> {
     private final MongoNamespace namespace;
     private final List<T> results;

--- a/driver-core/src/main/com/mongodb/connection/Server.java
+++ b/driver-core/src/main/com/mongodb/connection/Server.java
@@ -25,6 +25,7 @@ import com.mongodb.async.SingleResultCallback;
  * @since 3.0
  */
 @ThreadSafe
+@Deprecated
 public interface Server {
     /**
      * Gets the description of this server.  Implementations of this method should not block if the server has not yet been successfully

--- a/driver-core/src/main/com/mongodb/connection/SplittablePayload.java
+++ b/driver-core/src/main/com/mongodb/connection/SplittablePayload.java
@@ -40,6 +40,7 @@ import static com.mongodb.connection.SplittablePayload.Type.UPDATE;
  * com.mongodb.connection.SplittablePayload, org.bson.FieldNameValidator, com.mongodb.async.SingleResultCallback)
  * @since 3.6
  */
+@Deprecated
 public final class SplittablePayload {
     private final Type payloadType;
     private final List<BsonDocument> payload;

--- a/driver-core/src/main/com/mongodb/management/MBeanServer.java
+++ b/driver-core/src/main/com/mongodb/management/MBeanServer.java
@@ -19,6 +19,7 @@ package com.mongodb.management;
 /**
  * This class is NOT part of the public API.  It may change at any time without notification.
  */
+@Deprecated
 public interface MBeanServer {
     /**
      * Unregister the MBean with the given name.

--- a/driver-core/src/main/com/mongodb/management/MBeanServerFactory.java
+++ b/driver-core/src/main/com/mongodb/management/MBeanServerFactory.java
@@ -26,6 +26,7 @@ import com.mongodb.internal.management.jmx.JMXMBeanServer;
  *
  * @since 2.9
  */
+@Deprecated
 public final class MBeanServerFactory {
     private MBeanServerFactory() {
     }

--- a/driver-core/src/main/com/mongodb/management/NullMBeanServer.java
+++ b/driver-core/src/main/com/mongodb/management/NullMBeanServer.java
@@ -19,6 +19,7 @@ package com.mongodb.management;
 /**
  * This class is NOT part of the public API.  It may change at any time without notification.
  */
+@Deprecated
 public class NullMBeanServer implements MBeanServer {
     @Override
     public void unregisterMBean(final String mBeanName) {

--- a/driver-core/src/main/com/mongodb/operation/AbortTransactionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/AbortTransactionOperation.java
@@ -23,6 +23,7 @@ import com.mongodb.WriteConcern;
  *
  * @since 3.8
  */
+@Deprecated
 public class AbortTransactionOperation extends TransactionOperation {
 
     /**

--- a/driver-core/src/main/com/mongodb/operation/AggregateOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/AggregateOperation.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
  * @mongodb.server.release 2.2
  * @since 3.0
  */
+@Deprecated
 public class AggregateOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>, ReadOperation<BatchCursor<T>> {
     private final AggregateOperationImpl<T> wrapped;
     /**

--- a/driver-core/src/main/com/mongodb/operation/AggregateToCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/AggregateToCollectionOperation.java
@@ -59,6 +59,7 @@ import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTran
  * @mongodb.driver.manual reference/command/aggregate/ Aggregation
  * @since 3.0
  */
+@Deprecated
 public class AggregateToCollectionOperation implements AsyncWriteOperation<Void>, WriteOperation<Void> {
     private final MongoNamespace namespace;
     private final List<BsonDocument> pipeline;

--- a/driver-core/src/main/com/mongodb/operation/AsyncReadOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/AsyncReadOperation.java
@@ -26,6 +26,7 @@ import com.mongodb.binding.AsyncReadBinding;
  *
  * @since 3.0
  */
+@Deprecated
 public interface AsyncReadOperation<T> {
 
     /**

--- a/driver-core/src/main/com/mongodb/operation/AsyncWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/AsyncWriteOperation.java
@@ -26,6 +26,7 @@ import com.mongodb.binding.AsyncWriteBinding;
  *
  * @since 3.0
  */
+@Deprecated
 public interface AsyncWriteOperation<T> {
 
     /**

--- a/driver-core/src/main/com/mongodb/operation/BaseFindAndModifyOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/BaseFindAndModifyOperation.java
@@ -41,6 +41,7 @@ import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeast
  * @param <T> the document type
  * @since 3.8
  */
+@Deprecated
 public abstract class BaseFindAndModifyOperation<T> implements AsyncWriteOperation<T>, WriteOperation<T> {
 
     private final MongoNamespace namespace;

--- a/driver-core/src/main/com/mongodb/operation/BaseWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/BaseWriteOperation.java
@@ -49,6 +49,7 @@ import static com.mongodb.bulk.WriteRequest.Type.UPDATE;
  *
  * @since 3.0
  */
+@Deprecated
 public abstract class BaseWriteOperation implements AsyncWriteOperation<WriteConcernResult>, WriteOperation<WriteConcernResult> {
     private final WriteConcern writeConcern;
     private final MongoNamespace namespace;

--- a/driver-core/src/main/com/mongodb/operation/BatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/BatchCursor.java
@@ -36,6 +36,7 @@ import java.util.List;
  * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#wire-op-get-more OP_GET_MORE
  */
 @NotThreadSafe
+@Deprecated
 public interface BatchCursor<T> extends Iterator<List<T>>, Closeable {
     @Override
     void close();

--- a/driver-core/src/main/com/mongodb/operation/ChangeStreamOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ChangeStreamOperation.java
@@ -52,6 +52,7 @@ import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeast
  * @mongodb.server.release 2.6
  * @since 3.6
  */
+@Deprecated
 public class ChangeStreamOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>, ReadOperation<BatchCursor<T>> {
     private static final RawBsonDocumentCodec RAW_BSON_DOCUMENT_CODEC = new RawBsonDocumentCodec();
     private final AggregateOperationImpl<RawBsonDocument> wrapped;

--- a/driver-core/src/main/com/mongodb/operation/CommandReadOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CommandReadOperation.java
@@ -32,6 +32,7 @@ import static com.mongodb.operation.CommandOperationHelper.executeWrappedCommand
  * @param <T> the operations result type.
  * @since 3.0
  */
+@Deprecated
 public class CommandReadOperation<T> implements AsyncReadOperation<T>, ReadOperation<T> {
     private final String databaseName;
     private final BsonDocument command;

--- a/driver-core/src/main/com/mongodb/operation/CommandWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CommandWriteOperation.java
@@ -32,6 +32,7 @@ import static com.mongodb.operation.CommandOperationHelper.executeWrappedCommand
  * @param <T> the operations result type.
  * @since 3.0
  */
+@Deprecated
 public class CommandWriteOperation<T> implements AsyncWriteOperation<T>, WriteOperation<T> {
     private final String databaseName;
     private final BsonDocument command;

--- a/driver-core/src/main/com/mongodb/operation/CommitTransactionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CommitTransactionOperation.java
@@ -37,6 +37,7 @@ import static java.util.Arrays.asList;
  *
  * @since 3.8
  */
+@Deprecated
 public class CommitTransactionOperation extends TransactionOperation {
 
     /**

--- a/driver-core/src/main/com/mongodb/operation/CountOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CountOperation.java
@@ -63,6 +63,7 @@ import static com.mongodb.operation.OperationReadConcernHelper.appendReadConcern
  *
  * @since 3.0
  */
+@Deprecated
 public class CountOperation implements AsyncReadOperation<Long>, ReadOperation<Long> {
     private static final Decoder<BsonDocument> DECODER = new BsonDocumentCodec();
     private final MongoNamespace namespace;

--- a/driver-core/src/main/com/mongodb/operation/CreateCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateCollectionOperation.java
@@ -51,6 +51,7 @@ import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTran
  * @since 3.0
  * @mongodb.driver.manual reference/method/db.createCollection Create Collection
  */
+@Deprecated
 public class CreateCollectionOperation implements AsyncWriteOperation<Void>, WriteOperation<Void> {
     private final String databaseName;
     private final String collectionName;

--- a/driver-core/src/main/com/mongodb/operation/CreateIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateIndexesOperation.java
@@ -67,6 +67,7 @@ import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTran
  * @mongodb.driver.manual reference/command/createIndexes/ Create indexes
  * @since 3.0
  */
+@Deprecated
 public class CreateIndexesOperation implements AsyncWriteOperation<Void>, WriteOperation<Void> {
     private final MongoNamespace namespace;
     private final List<IndexRequest> requests;

--- a/driver-core/src/main/com/mongodb/operation/CreateViewOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateViewOperation.java
@@ -51,6 +51,7 @@ import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTran
  * @mongodb.server.release 3.4
  * @mongodb.driver.manual reference/command/create Create
  */
+@Deprecated
 public class CreateViewOperation implements AsyncWriteOperation<Void>, WriteOperation<Void> {
     private final String databaseName;
     private final String viewName;

--- a/driver-core/src/main/com/mongodb/operation/CurrentOpOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CurrentOpOperation.java
@@ -34,6 +34,7 @@ import static com.mongodb.operation.OperationHelper.withConnection;
  * @since 3.2
  * @mongodb.driver.manual reference/method/db.currentOp/ Current Op
  */
+@Deprecated
 public class CurrentOpOperation implements ReadOperation<BsonDocument> {
     @Override
     public BsonDocument execute(final ReadBinding binding) {

--- a/driver-core/src/main/com/mongodb/operation/DeleteOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DeleteOperation.java
@@ -31,6 +31,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * @since 3.0
  */
+@Deprecated
 public class DeleteOperation extends BaseWriteOperation {
     private final List<DeleteRequest> deleteRequests;
 

--- a/driver-core/src/main/com/mongodb/operation/DistinctOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DistinctOperation.java
@@ -61,6 +61,7 @@ import static com.mongodb.operation.OperationReadConcernHelper.appendReadConcern
  * @mongodb.driver.manual reference/command/distinct Distinct Command
  * @since 3.0
  */
+@Deprecated
 public class DistinctOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>, ReadOperation<BatchCursor<T>> {
     private static final String VALUES = "values";
 

--- a/driver-core/src/main/com/mongodb/operation/DropCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DropCollectionOperation.java
@@ -48,6 +48,7 @@ import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTran
  *
  * @since 3.0
  */
+@Deprecated
 public class DropCollectionOperation implements AsyncWriteOperation<Void>, WriteOperation<Void> {
     private final MongoNamespace namespace;
     private final WriteConcern writeConcern;

--- a/driver-core/src/main/com/mongodb/operation/DropDatabaseOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DropDatabaseOperation.java
@@ -42,6 +42,7 @@ import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTran
  *
  * @since 3.0
  */
+@Deprecated
 public class DropDatabaseOperation implements AsyncWriteOperation<Void>, WriteOperation<Void> {
     private static final BsonDocument DROP_DATABASE = new BsonDocument("dropDatabase", new BsonInt32(1));
     private final String databaseName;

--- a/driver-core/src/main/com/mongodb/operation/DropIndexOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/DropIndexOperation.java
@@ -51,6 +51,7 @@ import static com.mongodb.operation.OperationHelper.withConnection;
  * @mongodb.driver.manual reference/command/dropIndexes/ Drop indexes
  * @since 3.0
  */
+@Deprecated
 public class DropIndexOperation implements AsyncWriteOperation<Void>, WriteOperation<Void> {
     private final MongoNamespace namespace;
     private final String indexName;

--- a/driver-core/src/main/com/mongodb/operation/FindAndDeleteOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/FindAndDeleteOperation.java
@@ -45,6 +45,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * @mongodb.driver.manual reference/command/findAndModify/ findAndModify
  * @since 3.0
  */
+@Deprecated
 public class FindAndDeleteOperation<T> extends BaseFindAndModifyOperation<T> {
     private BsonDocument filter;
     private BsonDocument projection;

--- a/driver-core/src/main/com/mongodb/operation/FindAndReplaceOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/FindAndReplaceOperation.java
@@ -51,6 +51,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * @since 3.0
  * @mongodb.driver.manual reference/command/findAndModify/ findAndModify
  */
+@Deprecated
 public class FindAndReplaceOperation<T> extends BaseFindAndModifyOperation<T> {
     private final BsonDocument replacement;
     private BsonDocument filter;

--- a/driver-core/src/main/com/mongodb/operation/FindAndUpdateOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/FindAndUpdateOperation.java
@@ -53,6 +53,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * @since 3.0
  * @mongodb.driver.manual reference/command/findAndModify/ findAndModify
  */
+@Deprecated
 public class FindAndUpdateOperation<T> extends BaseFindAndModifyOperation<T> {
     private final BsonDocument update;
     private BsonDocument filter;

--- a/driver-core/src/main/com/mongodb/operation/FindOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/FindOperation.java
@@ -80,6 +80,7 @@ import static com.mongodb.operation.OperationReadConcernHelper.appendReadConcern
  * @param <T> the operations result type.
  * @since 3.0
  */
+@Deprecated
 public class FindOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>, ReadOperation<BatchCursor<T>> {
     private static final String FIRST_BATCH = "firstBatch";
 

--- a/driver-core/src/main/com/mongodb/operation/FsyncUnlockOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/FsyncUnlockOperation.java
@@ -36,6 +36,7 @@ import static com.mongodb.operation.OperationHelper.withConnection;
  * @mongodb.driver.manual reference/command/fsyncUnlock/ fsyncUnlock command
  * @since 3.2
  */
+@Deprecated
 public class FsyncUnlockOperation implements WriteOperation<BsonDocument>, ReadOperation<BsonDocument> {
     private static final BsonDocument FSYNC_UNLOCK_COMMAND = new BsonDocument("fsyncUnlock", new BsonInt32(1));
 

--- a/driver-core/src/main/com/mongodb/operation/GroupOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/GroupOperation.java
@@ -53,6 +53,7 @@ import static com.mongodb.operation.OperationHelper.withConnection;
  * @mongodb.driver.manual reference/command/group Group Command
  * @since 3.0
  */
+@Deprecated
 public class GroupOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>, ReadOperation<BatchCursor<T>> {
     private final MongoNamespace namespace;
     private final Decoder<T> decoder;

--- a/driver-core/src/main/com/mongodb/operation/InsertOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/InsertOperation.java
@@ -31,6 +31,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * @since 3.0
  */
+@Deprecated
 public class InsertOperation extends BaseWriteOperation {
     private final List<InsertRequest> insertRequests;
 

--- a/driver-core/src/main/com/mongodb/operation/ListCollectionsOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ListCollectionsOperation.java
@@ -79,6 +79,7 @@ import static java.util.Arrays.asList;
  * @param <T> the document type
  * @since 3.0
  */
+@Deprecated
 public class ListCollectionsOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>, ReadOperation<BatchCursor<T>> {
     private final String databaseName;
     private final Decoder<T> decoder;

--- a/driver-core/src/main/com/mongodb/operation/ListDatabasesOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ListDatabasesOperation.java
@@ -52,6 +52,7 @@ import static com.mongodb.operation.OperationHelper.withConnection;
  * @param <T> the document type
  * @since 3.0
  */
+@Deprecated
 public class ListDatabasesOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>, ReadOperation<BatchCursor<T>> {
     private final Decoder<T> decoder;
 

--- a/driver-core/src/main/com/mongodb/operation/ListIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ListIndexesOperation.java
@@ -66,6 +66,7 @@ import static com.mongodb.operation.OperationHelper.withConnection;
  * @since 3.0
  * @mongodb.driver.manual reference/command/listIndexes/ List indexes
  */
+@Deprecated
 public class ListIndexesOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>, ReadOperation<BatchCursor<T>> {
     private final MongoNamespace namespace;
     private final Decoder<T> decoder;

--- a/driver-core/src/main/com/mongodb/operation/MapReduceAsyncBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/MapReduceAsyncBatchCursor.java
@@ -25,6 +25,7 @@ import com.mongodb.async.AsyncBatchCursor;
  * @param <T> the type of each result, usually some sort of document.
  * @since 3.0
  */
+@Deprecated
 public interface MapReduceAsyncBatchCursor<T> extends AsyncBatchCursor<T> {
     /**
      * Get the statistics for this map-reduce operation

--- a/driver-core/src/main/com/mongodb/operation/MapReduceBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/operation/MapReduceBatchCursor.java
@@ -23,6 +23,7 @@ package com.mongodb.operation;
  * @param <T> the operations result type.
  * @since 3.0
  */
+@Deprecated
 public interface MapReduceBatchCursor<T> extends BatchCursor<T> {
     /**
      * Get the statistics for this map-reduce operation

--- a/driver-core/src/main/com/mongodb/operation/MapReduceStatistics.java
+++ b/driver-core/src/main/com/mongodb/operation/MapReduceStatistics.java
@@ -21,6 +21,7 @@ package com.mongodb.operation;
  *
  * @since 3.0
  */
+@Deprecated
 public class MapReduceStatistics {
 
     private final int inputCount;

--- a/driver-core/src/main/com/mongodb/operation/MapReduceToCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/MapReduceToCollectionOperation.java
@@ -67,6 +67,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * @mongodb.driver.manual core/map-reduce Map Reduce
  * @since 3.0
  */
+@Deprecated
 public class
 MapReduceToCollectionOperation implements AsyncWriteOperation<MapReduceStatistics>, WriteOperation<MapReduceStatistics> {
     private final MongoNamespace namespace;

--- a/driver-core/src/main/com/mongodb/operation/MapReduceWithInlineResultsOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/MapReduceWithInlineResultsOperation.java
@@ -70,6 +70,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * @mongodb.driver.manual core/map-reduce Map-Reduce
  * @since 3.0
  */
+@Deprecated
 public class MapReduceWithInlineResultsOperation<T> implements AsyncReadOperation<MapReduceAsyncBatchCursor<T>>,
                                                                ReadOperation<MapReduceBatchCursor<T>> {
     private final MongoNamespace namespace;

--- a/driver-core/src/main/com/mongodb/operation/MixedBulkWriteOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/MixedBulkWriteOperation.java
@@ -64,6 +64,7 @@ import static com.mongodb.operation.OperationHelper.withReleasableConnection;
  *
  * @since 3.0
  */
+@Deprecated
 public class MixedBulkWriteOperation implements AsyncWriteOperation<BulkWriteResult>, WriteOperation<BulkWriteResult> {
     private static final FieldNameValidator NO_OP_FIELD_NAME_VALIDATOR = new NoOpFieldNameValidator();
     private final MongoNamespace namespace;

--- a/driver-core/src/main/com/mongodb/operation/OrderBy.java
+++ b/driver-core/src/main/com/mongodb/operation/OrderBy.java
@@ -21,6 +21,7 @@ package com.mongodb.operation;
  *
  * @since 3.0
  */
+@Deprecated
 public enum OrderBy {
     /**
      * Ascending order

--- a/driver-core/src/main/com/mongodb/operation/ParallelCollectionScanOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ParallelCollectionScanOperation.java
@@ -63,6 +63,7 @@ import static com.mongodb.operation.OperationReadConcernHelper.appendReadConcern
  * @mongodb.server.release 2.6
  * @since 3.0
  */
+@Deprecated
 public class
 ParallelCollectionScanOperation<T> implements AsyncReadOperation<List<AsyncBatchCursor<T>>>,
                                                            ReadOperation<List<BatchCursor<T>>> {

--- a/driver-core/src/main/com/mongodb/operation/ReadOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/ReadOperation.java
@@ -24,6 +24,7 @@ import com.mongodb.binding.ReadBinding;
  * @param <T> the operations result type.
  * @since 3.0
  */
+@Deprecated
 public interface ReadOperation<T> {
     /**
      * General execute which can return anything of type T

--- a/driver-core/src/main/com/mongodb/operation/RenameCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/RenameCollectionOperation.java
@@ -47,6 +47,7 @@ import static com.mongodb.operation.CommandOperationHelper.writeConcernErrorTran
  * @mongodb.driver.manual reference/command/renameCollection renameCollection
  * @since 3.0
  */
+@Deprecated
 public class RenameCollectionOperation implements AsyncWriteOperation<Void>, WriteOperation<Void> {
     private final MongoNamespace originalNamespace;
     private final MongoNamespace newNamespace;

--- a/driver-core/src/main/com/mongodb/operation/TransactionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/TransactionOperation.java
@@ -40,6 +40,7 @@ import static com.mongodb.operation.OperationHelper.LOGGER;
  *
  * @since 3.8
  */
+@Deprecated
 public abstract class TransactionOperation implements WriteOperation<Void>, AsyncWriteOperation<Void> {
     private final WriteConcern writeConcern;
 

--- a/driver-core/src/main/com/mongodb/operation/UpdateOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/UpdateOperation.java
@@ -31,6 +31,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * @since 3.0
  */
+@Deprecated
 public class UpdateOperation extends BaseWriteOperation {
     private final List<UpdateRequest> updates;
 

--- a/driver-core/src/main/com/mongodb/operation/WriteOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/WriteOperation.java
@@ -25,6 +25,7 @@ import com.mongodb.binding.WriteBinding;
  *
  * @since 3.0
  */
+@Deprecated
 public interface WriteOperation<T> {
     /**
      * General execute which can return anything of type T

--- a/driver-core/src/main/com/mongodb/selector/LatencyMinimizingServerSelector.java
+++ b/driver-core/src/main/com/mongodb/selector/LatencyMinimizingServerSelector.java
@@ -32,6 +32,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
  *
  * @since 3.0
  */
+@Deprecated
 public class LatencyMinimizingServerSelector implements ServerSelector {
 
     private final long acceptableLatencyDifferenceNanos;

--- a/driver-core/src/main/com/mongodb/selector/ReadPreferenceServerSelector.java
+++ b/driver-core/src/main/com/mongodb/selector/ReadPreferenceServerSelector.java
@@ -30,6 +30,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * @since 3.0
  */
+@Deprecated
 public class ReadPreferenceServerSelector implements ServerSelector {
     private final ReadPreference readPreference;
 

--- a/driver-core/src/main/com/mongodb/selector/ServerAddressSelector.java
+++ b/driver-core/src/main/com/mongodb/selector/ServerAddressSelector.java
@@ -31,6 +31,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * @since 3.0
  */
+@Deprecated
 public class ServerAddressSelector implements ServerSelector {
     private final ServerAddress serverAddress;
 

--- a/driver-core/src/main/com/mongodb/selector/WritableServerSelector.java
+++ b/driver-core/src/main/com/mongodb/selector/WritableServerSelector.java
@@ -26,6 +26,7 @@ import java.util.List;
  *
  * @since 3.1
  */
+@Deprecated
 public final class WritableServerSelector implements ServerSelector {
 
     @Override


### PR DESCRIPTION
Deprecate API element in driver-core module that are not exposed via
the high-level driver APIS (driver-sync, driver-sync, driver-legacy).
The driver-core module is a useful abstraction on which to build these
high-level drivers, but as a public API it has not seen the sort of
adoption that we initially expected.  Formally deprecating it and using
it just as an internal abstraction will allow us to more rapidly evolve
its API without concern for backwards compatibility that doesn't
actually help external users.

JAVA-3007

The main feedback I'm looking for is whether there is anything deprecated that shouldn't be, and if there's anything not deprecated that should.

Patch build: https://evergreen.mongodb.com/version/5bb78f4ce3c3317b91a1096f

