### PR TITLE
Apply hint, min, and max to explainable find operation

### DIFF
--- a/driver-core/src/main/com/mongodb/operation/FindOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/FindOperation.java
@@ -61,6 +61,7 @@ import static com.mongodb.assertions.Assertions.isTrueArgument;
 import static com.mongodb.assertions.Assertions.notNull;
 import static com.mongodb.connection.ServerType.SHARD_ROUTER;
 import static com.mongodb.internal.async.ErrorHandlingResultCallback.errorHandlingCallback;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
 import static com.mongodb.operation.CommandOperationHelper.CommandTransformer;
 import static com.mongodb.operation.CommandOperationHelper.executeWrappedCommandProtocol;
 import static com.mongodb.operation.CommandOperationHelper.executeWrappedCommandProtocolAsync;
@@ -69,7 +70,6 @@ import static com.mongodb.operation.OperationHelper.AsyncCallableWithConnectionA
 import static com.mongodb.operation.OperationHelper.LOGGER;
 import static com.mongodb.operation.OperationHelper.cursorDocumentToQueryResult;
 import static com.mongodb.operation.OperationHelper.releasingCallback;
-import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
 import static com.mongodb.operation.OperationHelper.validateReadConcernAndCollation;
 import static com.mongodb.operation.OperationHelper.withConnection;
 import static com.mongodb.operation.OperationReadConcernHelper.appendReadConcernToCommand;
@@ -911,6 +911,9 @@ public class FindOperation<T> implements AsyncReadOperation<AsyncBatchCursor<T>>
                .sort(sort)
                .skip(skip)
                .limit(Math.abs(limit) * -1)
+               .hint(hint)
+               .min(min)
+               .max(max)
                .modifiers(explainModifiers);
 
     }

--- a/driver-core/src/test/functional/com/mongodb/operation/FindOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/FindOperationSpecification.groovy
@@ -636,6 +636,9 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
                 .projection(new BsonDocument('x', new BsonInt32(1)))
                 .sort(new BsonDocument('y', new BsonInt32(-1)))
                 .filter(new BsonDocument('z', new BsonString('val')))
+                .hint(new BsonDocument('a', new BsonInt32(1)))
+                .min(new BsonDocument('min', new BsonInt32(1)))
+                .max(new BsonDocument('max', new BsonInt32(1)))
         def binding = Stub(ReadBinding)
         def source = Stub(ConnectionSource)
         def connection = Mock(Connection)
@@ -652,7 +655,10 @@ class FindOperationSpecification extends OperationFunctionalSpecification {
                 new ServerVersion(2, 6), STANDALONE, 1000, 100000, 100000, [])
 
         1 * connection.query(getNamespace(), new BsonDocument('$query', operation.filter)
-                .append('$explain', BsonBoolean.TRUE).append('$orderby', operation.sort),
+                .append('$explain', BsonBoolean.TRUE).append('$orderby', operation.sort)
+                .append('$hint', operation.hint)
+                .append('$min', operation.min)
+                .append('$max', operation.max),
                 operation.projection, 0, -20, 0, false, false, false, false, false, false, _) >>
                 new QueryResult(getNamespace(), [new BsonDocument('n', new BsonInt32(1))], 0, new ServerAddress())
 


### PR DESCRIPTION
Previously, FindOperation was incorrectly applying only modifiers before
executing a $explain query, but the changes in DBCursor meant that
hint, min, and max are now being set as individual properties on
FindOperation rather than through modifiers, so were not being applied
to the explain.

JAVA-3022

Patch build: https://evergreen.mongodb.com/version/5bbcbf0de3c3315c26d281db

