### PR TITLE
Dynamically override the Iterable.forEach(Consumer<TResult>) default method implementation

### DIFF
--- a/driver-sync/src/main/com/mongodb/client/internal/FallbackMongoIterableFactory.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/FallbackMongoIterableFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.internal;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.ReadConcern;
+import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.ClientSession;
+import com.mongodb.client.FindIterable;
+import com.mongodb.lang.Nullable;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
+
+import java.util.List;
+
+class FallbackMongoIterableFactory implements MongoIterableFactory {
+    @Override
+    public <TDocument, TResult>
+    FindIterable<TResult> findOf(final @Nullable ClientSession clientSession, final MongoNamespace namespace,
+                                 final Class<TDocument> documentClass, final Class<TResult> resultClass, final CodecRegistry codecRegistry,
+                                 final ReadPreference readPreference, final ReadConcern readConcern, final OperationExecutor executor,
+                                 final Bson filter) {
+        return new FindIterableImpl<TDocument, TResult>(clientSession, namespace, documentClass, resultClass, codecRegistry,
+                readPreference, readConcern, executor, filter);
+    }
+
+    @Override
+    public <TResult, TDocument>
+    AggregateIterable<TResult> aggregateOf(final @Nullable ClientSession clientSession, final MongoNamespace namespace,
+                                           final Class<TDocument> documentClass, final Class<TResult> resultClass,
+                                           final CodecRegistry codecRegistry, final ReadPreference readPreference,
+                                           final ReadConcern readConcern, final WriteConcern writeConcern, final OperationExecutor executor,
+                                           final List<? extends Bson> pipeline) {
+        return new AggregateIterableImpl<TDocument, TResult>(clientSession, namespace, documentClass, resultClass, codecRegistry,
+                readPreference, readConcern, writeConcern, executor, pipeline);
+    }
+}

--- a/driver-sync/src/main/com/mongodb/client/internal/FindIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/FindIterableImpl.java
@@ -20,6 +20,7 @@ import com.mongodb.CursorType;
 import com.mongodb.MongoNamespace;
 import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
+import com.mongodb.client.ClientSession;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.model.Collation;
 import com.mongodb.client.model.FindOptions;
@@ -27,7 +28,6 @@ import com.mongodb.internal.operation.SyncOperations;
 import com.mongodb.lang.Nullable;
 import com.mongodb.operation.BatchCursor;
 import com.mongodb.operation.ReadOperation;
-import com.mongodb.client.ClientSession;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
 
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 import static com.mongodb.assertions.Assertions.notNull;
 
 @SuppressWarnings("deprecation")
-final class FindIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult> implements FindIterable<TResult> {
+class FindIterableImpl<TDocument, TResult> extends MongoIterableImpl<TResult> implements FindIterable<TResult> {
 
     private final SyncOperations<TDocument> operations;
 

--- a/driver-sync/src/main/com/mongodb/client/internal/Java8AggregateIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Java8AggregateIterableImpl.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.internal;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.ReadConcern;
+import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
+import com.mongodb.client.ClientSession;
+import com.mongodb.lang.Nullable;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+class Java8AggregateIterableImpl<TDocument, TResult> extends AggregateIterableImpl<TDocument, TResult> {
+    Java8AggregateIterableImpl(@Nullable final ClientSession clientSession, final MongoNamespace namespace,
+                               final Class<TDocument> documentClass, final Class<TResult> resultClass, final CodecRegistry codecRegistry,
+                               final ReadPreference readPreference, final ReadConcern readConcern, final WriteConcern writeConcern,
+                               final OperationExecutor executor, final List<? extends Bson> pipeline) {
+        super(clientSession, namespace, documentClass, resultClass, codecRegistry, readPreference, readConcern, writeConcern, executor,
+                pipeline);
+    }
+
+    @Override
+    public void forEach(final Consumer<? super TResult> action) {
+        Java8ForEachHelper.forEach(this, action);
+    }
+}

--- a/driver-sync/src/main/com/mongodb/client/internal/Java8FindIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Java8FindIterableImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.internal;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.ReadConcern;
+import com.mongodb.ReadPreference;
+import com.mongodb.client.ClientSession;
+import com.mongodb.lang.Nullable;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
+
+import java.util.function.Consumer;
+
+class Java8FindIterableImpl<TDocument, TResult> extends FindIterableImpl<TDocument, TResult> {
+
+    Java8FindIterableImpl(@Nullable final ClientSession clientSession, final MongoNamespace namespace, final Class<TDocument> documentClass,
+                          final Class<TResult> resultClass, final CodecRegistry codecRegistry, final ReadPreference readPreference,
+                          final ReadConcern readConcern, final OperationExecutor executor, final Bson filter) {
+        super(clientSession, namespace, documentClass, resultClass, codecRegistry, readPreference, readConcern, executor, filter);
+    }
+
+    @Override
+    public void forEach(final Consumer<? super TResult> action) {
+        Java8ForEachHelper.forEach(this, action);
+    }
+}

--- a/driver-sync/src/main/com/mongodb/client/internal/Java8ForEachHelper.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Java8ForEachHelper.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.internal;
+
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.MongoIterable;
+
+import java.util.function.Consumer;
+
+final class Java8ForEachHelper {
+
+    static <TResult> void forEach(final MongoIterable<TResult> iterable, final Consumer<? super TResult> block) {
+        MongoCursor<TResult> cursor = iterable.iterator();
+        try {
+            while (cursor.hasNext()) {
+                block.accept(cursor.next());
+            }
+        } finally {
+            cursor.close();
+        }
+    }
+
+    private Java8ForEachHelper() {
+    }
+}

--- a/driver-sync/src/main/com/mongodb/client/internal/Java8MongoIterableFactory.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Java8MongoIterableFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.internal;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.ReadConcern;
+import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.ClientSession;
+import com.mongodb.client.FindIterable;
+import com.mongodb.lang.Nullable;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
+
+import java.util.List;
+
+class Java8MongoIterableFactory implements MongoIterableFactory {
+    @Override
+    public <TDocument, TResult> FindIterable<TResult> findOf(final @Nullable ClientSession clientSession, final MongoNamespace namespace,
+                                                             final Class<TDocument> documentClass, final Class<TResult> resultClass,
+                                                             final CodecRegistry codecRegistry, final ReadPreference readPreference,
+                                                             final ReadConcern readConcern, final OperationExecutor executor,
+                                                             final Bson filter) {
+        return new Java8FindIterableImpl<TDocument, TResult>(clientSession, namespace, documentClass, resultClass, codecRegistry,
+                readPreference, readConcern, executor, filter);
+    }
+
+    @Override
+    public <TResult, TDocument>
+    AggregateIterable<TResult> aggregateOf(final @Nullable ClientSession clientSession, final MongoNamespace namespace,
+                                           final Class<TDocument> documentClass, final Class<TResult> resultClass,
+                                           final CodecRegistry codecRegistry, final ReadPreference readPreference,
+                                           final ReadConcern readConcern, final WriteConcern writeConcern,
+                                           final OperationExecutor executor, final List<? extends Bson> pipeline) {
+        return new Java8AggregateIterableImpl<TDocument, TResult>(clientSession, namespace, documentClass, resultClass, codecRegistry,
+                readPreference, readConcern, writeConcern, executor, pipeline);
+    }
+}
+

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
@@ -38,7 +38,6 @@ import com.mongodb.client.MapReduceIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.BulkWriteOptions;
 import com.mongodb.client.model.CountOptions;
-import com.mongodb.internal.client.model.CountStrategy;
 import com.mongodb.client.model.CreateIndexOptions;
 import com.mongodb.client.model.DeleteOptions;
 import com.mongodb.client.model.DropIndexOptions;
@@ -57,6 +56,7 @@ import com.mongodb.client.model.WriteModel;
 import com.mongodb.client.model.changestream.ChangeStreamLevel;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
+import com.mongodb.internal.client.model.CountStrategy;
 import com.mongodb.internal.operation.IndexHelper;
 import com.mongodb.internal.operation.SyncOperations;
 import com.mongodb.lang.Nullable;
@@ -324,7 +324,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private <TResult> FindIterable<TResult> createFindIterable(@Nullable final ClientSession clientSession, final Bson filter,
                                                                final Class<TResult> resultClass) {
-        return new FindIterableImpl<TDocument, TResult>(clientSession, namespace, this.documentClass, resultClass, codecRegistry,
+        return MongoIterables.findOf(clientSession, namespace, this.documentClass, resultClass, codecRegistry,
                 readPreference, readConcern, executor, filter);
     }
 
@@ -353,7 +353,7 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
     private <TResult> AggregateIterable<TResult> createAggregateIterable(@Nullable final ClientSession clientSession,
                                                                          final List<? extends Bson> pipeline,
                                                                          final Class<TResult> resultClass) {
-        return new AggregateIterableImpl<TDocument, TResult>(clientSession, namespace, documentClass, resultClass, codecRegistry,
+        return MongoIterables.aggregateOf(clientSession, namespace, documentClass, resultClass, codecRegistry,
                 readPreference, readConcern, writeConcern, executor, pipeline);
     }
 

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoIterableFactory.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoIterableFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.internal;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.ReadConcern;
+import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.ClientSession;
+import com.mongodb.client.FindIterable;
+import com.mongodb.lang.Nullable;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
+
+import java.util.List;
+
+interface MongoIterableFactory {
+    <TDocument, TResult>
+    FindIterable<TResult> findOf(@Nullable ClientSession clientSession, MongoNamespace namespace, Class<TDocument> documentClass,
+                                 Class<TResult> resultClass, CodecRegistry codecRegistry, ReadPreference readPreference,
+                                 ReadConcern readConcern, OperationExecutor executor, Bson filter);
+
+    <TResult, TDocument>
+    AggregateIterable<TResult> aggregateOf(@Nullable ClientSession clientSession, MongoNamespace namespace, Class<TDocument> documentClass,
+                                           Class<TResult> resultClass, CodecRegistry codecRegistry, ReadPreference readPreference,
+                                           ReadConcern readConcern, WriteConcern writeConcern, OperationExecutor executor,
+                                           List<? extends Bson> pipeline);
+}

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoIterables.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoIterables.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.internal;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.ReadConcern;
+import com.mongodb.ReadPreference;
+import com.mongodb.WriteConcern;
+import com.mongodb.client.AggregateIterable;
+import com.mongodb.client.ClientSession;
+import com.mongodb.client.FindIterable;
+import com.mongodb.lang.Nullable;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.conversions.Bson;
+
+import java.util.List;
+
+// Helper class for instantiating the right implementation class for each MongoIterable.  In proper Java 8 environments, which includes
+// the java.util.function.Consumer interface, it instantiates an implementation which overrides the default forEach(Consumer<TResult)
+// method that in Java 8 is defined as a default method on java.lang.Iterable.  Otherwise it instantiates an implementation which does not
+// override this method.
+// It does this by delegating to an implementation of MongoIterableFactory that is determined based on a runtime check for the existence of
+// the java.util.function.Consumer class.
+final class MongoIterables {
+    private static MongoIterableFactory factory;
+
+    static {
+        try {
+            // Protect against running in an environment where Consumer is not available.  Either
+            // 1. Java version < 8
+            // 2. Android (which doesn't currently include Consumer even with its Java 8 support
+            Class.forName("java.util.function.Consumer");
+            factory = new Java8MongoIterableFactory();
+        } catch (ClassNotFoundException e) {
+            factory = new FallbackMongoIterableFactory();
+        }
+    }
+
+    static <TDocument, TResult>
+    FindIterable<TResult> findOf(final @Nullable ClientSession clientSession, final MongoNamespace namespace,
+                                 final Class<TDocument> documentClass, final Class<TResult> resultClass,
+                                 final CodecRegistry codecRegistry,
+                                 final ReadPreference readPreference, final ReadConcern readConcern,
+                                 final OperationExecutor executor, final Bson filter) {
+        return factory.findOf(clientSession, namespace, documentClass, resultClass, codecRegistry, readPreference, readConcern, executor,
+                filter);
+    }
+
+    static <TDocument, TResult>
+    AggregateIterable<TResult> aggregateOf(final @Nullable ClientSession clientSession, final MongoNamespace namespace,
+                                           final Class<TDocument> documentClass, final Class<TResult> resultClass,
+                                           final CodecRegistry codecRegistry, final ReadPreference readPreference,
+                                           final ReadConcern readConcern, final WriteConcern writeConcern, final OperationExecutor executor,
+                                           final List<? extends Bson> pipeline) {
+        return factory.aggregateOf(clientSession, namespace, documentClass, resultClass, codecRegistry,
+                readPreference, readConcern, writeConcern, executor, pipeline);
+    }
+
+
+    private MongoIterables() {
+    }
+}

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/Java8MongoIterablesSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/Java8MongoIterablesSpecification.groovy
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.internal
+
+
+import com.mongodb.MongoClientSettings
+import com.mongodb.MongoInternalException
+import com.mongodb.MongoNamespace
+import com.mongodb.ReadConcern
+import com.mongodb.WriteConcern
+import com.mongodb.operation.BatchCursor
+import org.bson.BsonBoolean
+import org.bson.BsonDocument
+import org.bson.Document
+import spock.lang.IgnoreIf
+import spock.lang.Specification
+
+import java.util.function.Consumer
+
+import static com.mongodb.ReadPreference.secondary
+
+class Java8MongoIterablesSpecification extends Specification {
+
+    static final boolean IS_CONSUMER_CLASS_AVAILABLE
+
+    static {
+        try {
+            Java8MongoIterablesSpecification.classLoader.loadClass('java.util.function.Consumer')
+            IS_CONSUMER_CLASS_AVAILABLE = true;
+        } catch (ClassNotFoundException ignored) {
+            IS_CONSUMER_CLASS_AVAILABLE = false;
+        }
+    }
+
+    static namespace = new MongoNamespace('databaseName', 'collectionName')
+    static codecRegistry = MongoClientSettings.getDefaultCodecRegistry()
+    static readPreference = secondary()
+    static readConcern = ReadConcern.MAJORITY
+    static writeConcern = WriteConcern.MAJORITY
+    static filter = new BsonDocument('x', BsonBoolean.TRUE)
+    static pipeline = Collections.emptyList()
+
+    @IgnoreIf({ !IS_CONSUMER_CLASS_AVAILABLE })
+    def 'should properly override Iterable forEach of Consumer'() {
+        given:
+        def cannedResults = [new Document('_id', 1), new Document('_id', 2), new Document('_id', 3)]
+        def isClosed = false
+        def count = 0
+        def accepted = 0
+
+        def cursor = {
+            Stub(BatchCursor) {
+                def results;
+                def getResult = {
+                    count++
+                    results = count == 1 ? cannedResults : null
+                    results
+                }
+                next() >> {
+                    getResult()
+                }
+                hasNext() >> {
+                    count == 0
+                }
+                close() >> {
+                    isClosed = true
+                }
+            }
+        }
+
+        when:
+        count = 0
+        accepted = 0
+        def mongoIterable = mongoIterableFactory(new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]))
+        mongoIterable.forEach(new Consumer<Document>() {
+            @Override
+            void accept(Document document) {
+                accepted++
+            }
+        })
+
+        then:
+        accepted == 3
+        isClosed
+
+        when:
+        count = 0
+        accepted = 0
+        mongoIterable = mongoIterableFactory(new TestOperationExecutor([cursor(), cursor(), cursor(), cursor()]))
+        mongoIterable.forEach(new Consumer<Document>() {
+            @Override
+            void accept(Document document) {
+                accepted++
+                throw new MongoInternalException("I don't accept this")
+            }
+        })
+
+        then:
+        thrown(MongoInternalException)
+        accepted == 1
+        isClosed
+
+        where:
+        mongoIterableFactory << [
+                { executor ->
+                    new Java8FindIterableImpl(null, namespace, Document, Document, codecRegistry,
+                            readPreference, readConcern, executor, filter)
+                },
+                { executor ->
+                    new Java8AggregateIterableImpl(null, namespace, Document, Document, codecRegistry,
+                            readPreference, readConcern, writeConcern, executor, pipeline)
+                }
+        ]
+    }
+}

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoCollectionSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoCollectionSpecification.groovy
@@ -348,28 +348,28 @@ class MongoCollectionSpecification extends Specification {
         def findIterable = execute(findMethod, session)
 
         then:
-        expect findIterable, isTheSameAs(new FindIterableImpl(session, namespace, Document, Document, codecRegistry,
+        expect findIterable, isTheSameAs(MongoIterables.findOf(session, namespace, Document, Document, codecRegistry,
                 readPreference, readConcern, executor, new BsonDocument()))
 
         when:
         findIterable = execute(findMethod, session, BsonDocument)
 
         then:
-        expect findIterable, isTheSameAs(new FindIterableImpl(session, namespace, Document, BsonDocument, codecRegistry,
+        expect findIterable, isTheSameAs(MongoIterables.findOf(session, namespace, Document, BsonDocument, codecRegistry,
                 readPreference, readConcern, executor, new BsonDocument()))
 
         when:
         findIterable = execute(findMethod, session, new Document())
 
         then:
-        expect findIterable, isTheSameAs(new FindIterableImpl(session, namespace, Document, Document, codecRegistry,
+        expect findIterable, isTheSameAs(MongoIterables.findOf(session, namespace, Document, Document, codecRegistry,
                 readPreference, readConcern, executor, new Document()))
 
         when:
         findIterable = execute(findMethod, session, new Document(), BsonDocument)
 
         then:
-        expect findIterable, isTheSameAs(new FindIterableImpl(session, namespace, Document, BsonDocument, codecRegistry,
+        expect findIterable, isTheSameAs(MongoIterables.findOf(session, namespace, Document, BsonDocument, codecRegistry,
                 readPreference, readConcern, executor, new Document()))
 
         where:
@@ -387,14 +387,14 @@ class MongoCollectionSpecification extends Specification {
         def aggregateIterable = execute(aggregateMethod, session, [new Document('$match', 1)])
 
         then:
-        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl(session, namespace, Document, Document, codecRegistry,
+        expect aggregateIterable, isTheSameAs(MongoIterables.aggregateOf(session, namespace, Document, Document, codecRegistry,
                 readPreference, readConcern,  ACKNOWLEDGED, executor, [new Document('$match', 1)]))
 
         when:
         aggregateIterable = execute(aggregateMethod, session, [new Document('$match', 1)], BsonDocument)
 
         then:
-        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl(session, namespace, Document, BsonDocument, codecRegistry,
+        expect aggregateIterable, isTheSameAs(MongoIterables.aggregateOf(session, namespace, Document, BsonDocument, codecRegistry,
                 readPreference, readConcern,  ACKNOWLEDGED, executor, [new Document('$match', 1)]))
 
         where:

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoIterablesSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoIterablesSpecification.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.internal
+
+import com.mongodb.MongoClientSettings
+import com.mongodb.MongoNamespace
+import com.mongodb.ReadConcern
+import com.mongodb.WriteConcern
+import com.mongodb.client.ClientSession
+import org.bson.BsonBoolean
+import org.bson.BsonDocument
+import org.bson.Document
+import spock.lang.IgnoreIf
+import spock.lang.Specification
+
+import static com.mongodb.CustomMatchers.isTheSameAs
+import static com.mongodb.ReadPreference.secondary
+import static spock.util.matcher.HamcrestSupport.expect
+
+class MongoIterablesSpecification extends Specification {
+
+    def executor = new TestOperationExecutor([])
+    def clientSession = Stub(ClientSession)
+    def namespace = new MongoNamespace('databaseName', 'collectionName')
+    def codecRegistry = MongoClientSettings.getDefaultCodecRegistry()
+    def readPreference = secondary()
+    def readConcern = ReadConcern.MAJORITY
+    def writeConcern = WriteConcern.MAJORITY
+    def filter = new BsonDocument('x', BsonBoolean.TRUE)
+    def pipeline = Collections.emptyList()
+
+    @IgnoreIf({ !Java8MongoIterablesSpecification.IS_CONSUMER_CLASS_AVAILABLE })
+    def 'should create Java 8 iterables when java.util.function.Consumer is available'() {
+        when:
+        def findIterable = MongoIterables.findOf(clientSession, namespace, Document, BsonDocument, codecRegistry, readPreference,
+                readConcern, executor, filter)
+
+        then:
+        expect findIterable, isTheSameAs(new Java8FindIterableImpl<Document, BsonDocument>(clientSession, namespace, Document,
+                BsonDocument, codecRegistry, readPreference, readConcern, executor, filter))
+
+        when:
+        def aggregateIterable = MongoIterables.aggregateOf(clientSession, namespace, Document, BsonDocument, codecRegistry, readPreference,
+                readConcern, writeConcern, executor, pipeline)
+
+        then:
+        expect aggregateIterable, isTheSameAs(new Java8AggregateIterableImpl<Document, BsonDocument>(clientSession, namespace, Document,
+                BsonDocument, codecRegistry, readPreference, readConcern, writeConcern, executor, pipeline))
+    }
+
+    @IgnoreIf({ Java8MongoIterablesSpecification.IS_CONSUMER_CLASS_AVAILABLE })
+    def 'should create non-Java 8 iterables when java.util.function.Consumer is unavailable'() {
+        when:
+        def findIterable = MongoIterables.findOf(clientSession, namespace, Document, BsonDocument, codecRegistry, readPreference,
+                readConcern, executor, filter)
+
+        then:
+        expect findIterable, isTheSameAs(new FindIterableImpl<Document, BsonDocument>(clientSession, namespace, Document,
+                BsonDocument, codecRegistry, readPreference, readConcern, executor, filter))
+
+        when:
+        def aggregateIterable = MongoIterables.aggregateOf(clientSession, namespace, Document, BsonDocument, codecRegistry, readPreference,
+                readConcern, writeConcern, executor, pipeline)
+
+        then:
+        expect aggregateIterable, isTheSameAs(new AggregateIterableImpl<Document, BsonDocument>(clientSession, namespace, Document,
+                BsonDocument, codecRegistry, readPreference, readConcern, writeConcern, executor, pipeline))
+    }
+}


### PR DESCRIPTION
... so that it properly closes the MongoCursor in the face of exceptions that interrupt the loop.

This is a WIP just to get feedback.  I proved it out with AggregateIterable and FindIterable, so if it looks good I can do the rest.  Once this is done we can deprecate MongoIterable.forEach(Block<TResult>).

JAVA-2010

Evergreen patch: https://evergreen.mongodb.com/version/5bbe16fae3c3313fb77676d7