### PR TITLE
Deprecate MongoIterable#forEach(Block<? super TResult> block)

### DIFF
--- a/driver-sync/src/main/com/mongodb/client/MongoIterable.java
+++ b/driver-sync/src/main/com/mongodb/client/MongoIterable.java
@@ -21,6 +21,7 @@ import com.mongodb.Function;
 import com.mongodb.lang.Nullable;
 
 import java.util.Collection;
+import java.util.function.Consumer;
 
 /**
  *The MongoIterable is the results from an operation, such as a query.
@@ -56,7 +57,9 @@ public interface MongoIterable<TResult> extends Iterable<TResult> {
      * <p>Similar to {@code map} but the function is fully encapsulated with no returned result.</p>
      *
      * @param block the block to apply to each document of type T.
+     * @deprecated Prefer {@link Iterable#forEach(Consumer)}, which was added in Java 8
      */
+    @Deprecated
     void forEach(Block<? super TResult> block);
 
     /**


### PR DESCRIPTION
With the addition of the default method Iterable#forEach(Consumer)} in
Java 8, MongoIterable#forEach(Block<? super TResult> block) results in
an error at the point of call of forEach when using a lambda, which can
only be resolved by casting to either Block or Consumer. Rather than
keep that unfriendly API, we deprecate MongoIterable#forEach so that
it can be removed in the next major release of the driver (which will
required Java 8).

JAVA-3046