### PR TITLE
Deprecate the mongodb-driver-async module

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/AggregateIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/AggregateIterable.java
@@ -28,7 +28,9 @@ import java.util.concurrent.TimeUnit;
  *
  * @param <TResult> The type of the result.
  * @since 3.0
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public interface AggregateIterable<TResult> extends MongoIterable<TResult> {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/ChangeStreamIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/ChangeStreamIterable.java
@@ -34,7 +34,9 @@ import java.util.concurrent.TimeUnit;
  * @param <TResult> The type of the result.
  * @mongodb.server.release 3.6
  * @since 3.6
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public interface ChangeStreamIterable<TResult> extends MongoIterable<ChangeStreamDocument<TResult>> {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/ClientSession.java
+++ b/driver-async/src/main/com/mongodb/async/client/ClientSession.java
@@ -23,7 +23,9 @@ import com.mongodb.async.SingleResultCallback;
  * A client session that supports transactions.
  *
  * @since 3.8
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public interface ClientSession extends com.mongodb.session.ClientSession {
     /**
      * Returns true if there is an active transaction on this session, and false otherwise

--- a/driver-async/src/main/com/mongodb/async/client/DistinctIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/DistinctIterable.java
@@ -28,7 +28,9 @@ import java.util.concurrent.TimeUnit;
  *
  * @param <TResult> The type of the result.
  * @since 3.0
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public interface DistinctIterable<TResult> extends MongoIterable<TResult> {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/FindIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/FindIterable.java
@@ -28,7 +28,9 @@ import java.util.concurrent.TimeUnit;
  *
  * @param <T> The type of the result.
  * @since 3.0
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public interface FindIterable<T> extends MongoIterable<T> {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/ListCollectionsIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/ListCollectionsIterable.java
@@ -26,7 +26,9 @@ import java.util.concurrent.TimeUnit;
  *
  * @param <TResult> The type of the result.
  * @since 3.0
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public interface ListCollectionsIterable<TResult> extends MongoIterable<TResult> {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/ListDatabasesIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/ListDatabasesIterable.java
@@ -25,7 +25,9 @@ import java.util.concurrent.TimeUnit;
  * Iterable for ListDatabases.
  *
  * @param <T> The type of the result.
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public interface ListDatabasesIterable<T> extends MongoIterable<T> {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/ListIndexesIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/ListIndexesIterable.java
@@ -23,7 +23,9 @@ import java.util.concurrent.TimeUnit;
  *
  * @param <TResult> The type of the result.
  * @since 3.0
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public interface ListIndexesIterable<TResult> extends MongoIterable<TResult> {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/MapReduceIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/MapReduceIterable.java
@@ -30,7 +30,9 @@ import java.util.concurrent.TimeUnit;
  *
  * @param <TResult> The type of the result.
  * @since 3.0
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public interface MapReduceIterable<TResult> extends MongoIterable<TResult> {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/MongoClient.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoClient.java
@@ -33,8 +33,10 @@ import java.util.List;
  * Instance of this class serve as factories for {@code MongoDatabase} instances.
  * </p>
  * @since 3.0
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
 @Immutable
+@Deprecated
 public interface MongoClient extends Closeable {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/MongoClients.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoClients.java
@@ -36,8 +36,10 @@ import static com.mongodb.internal.event.EventListenerHelper.getCommandListener;
  * A factory for MongoClient instances.
  *
  * @since 3.0
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
 @SuppressWarnings("deprecation")
+@Deprecated
 public final class MongoClients {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/MongoCollection.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoCollection.java
@@ -60,8 +60,10 @@ import java.util.List;
  *
  * @param <TDocument> The type that this collection will encode documents from and decode documents to.
  * @since 3.0
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
 @ThreadSafe
+@Deprecated
 public interface MongoCollection<TDocument> {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/MongoDatabase.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoDatabase.java
@@ -35,8 +35,10 @@ import java.util.List;
  * Note: Additions to this interface will not be considered to break binary compatibility.</p>
  *
  * @since 3.0
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
 @ThreadSafe
+@Deprecated
 public interface MongoDatabase {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/MongoIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoIterable.java
@@ -29,7 +29,9 @@ import java.util.Collection;
  *
  * @param <TResult> the result type
  * @since 3.0
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public interface MongoIterable<TResult> {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/Observable.java
+++ b/driver-async/src/main/com/mongodb/async/client/Observable.java
@@ -26,7 +26,9 @@ package com.mongodb.async.client;
  *
  * @param <TResult> the type of element signaled.
  * @see Observables
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public interface Observable<TResult> {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/Observables.java
+++ b/driver-async/src/main/com/mongodb/async/client/Observables.java
@@ -28,7 +28,9 @@ import java.util.List;
  * <p>Allows async methods to be converted into event-based {@link Observable}s.</p>
  *
  * @since 3.1
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public final class Observables {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/Observer.java
+++ b/driver-async/src/main/com/mongodb/async/client/Observer.java
@@ -36,7 +36,9 @@ package com.mongodb.async.client;
  *
  * @param <TResult> The type of element signaled.
  * @since 3.1
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public interface Observer<TResult> {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/Subscription.java
+++ b/driver-async/src/main/com/mongodb/async/client/Subscription.java
@@ -26,7 +26,9 @@ package com.mongodb.async.client;
  * </p>
  *
  * @since 3.1
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public interface Subscription {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/gridfs/AsyncInputStream.java
+++ b/driver-async/src/main/com/mongodb/async/client/gridfs/AsyncInputStream.java
@@ -25,7 +25,9 @@ import java.nio.ByteBuffer;
  *
  * <p>See the {@link com.mongodb.async.client.gridfs.helpers} package for adapters that create an {@code AsyncInputStream}</p>
  * @since 3.3
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public interface AsyncInputStream {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/gridfs/AsyncOutputStream.java
+++ b/driver-async/src/main/com/mongodb/async/client/gridfs/AsyncOutputStream.java
@@ -26,7 +26,9 @@ import java.nio.ByteBuffer;
  *
  * <p>See the {@link com.mongodb.async.client.gridfs.helpers} package for adapters that create an {@code AsyncOutputStream}</p>
  * @since 3.3
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public interface AsyncOutputStream {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/gridfs/GridFSBucket.java
+++ b/driver-async/src/main/com/mongodb/async/client/gridfs/GridFSBucket.java
@@ -32,8 +32,10 @@ import org.bson.types.ObjectId;
  * Represents a GridFS Bucket
  *
  * @since 3.3
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
 @ThreadSafe
+@Deprecated
 public interface GridFSBucket {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/gridfs/GridFSBuckets.java
+++ b/driver-async/src/main/com/mongodb/async/client/gridfs/GridFSBuckets.java
@@ -22,7 +22,9 @@ import com.mongodb.async.client.MongoDatabase;
  * A factory for GridFSBucket instances.
  *
  * @since 3.3
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public final class GridFSBuckets {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/gridfs/GridFSDownloadStream.java
+++ b/driver-async/src/main/com/mongodb/async/client/gridfs/GridFSDownloadStream.java
@@ -25,7 +25,9 @@ import com.mongodb.client.gridfs.model.GridFSFile;
  * <p>Provides the {@code GridFSFile} for the file to being downloaded as well as the {@code read} methods of a {@link AsyncInputStream}</p>
  *
  * @since 3.3
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public interface GridFSDownloadStream extends AsyncInputStream {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/gridfs/GridFSFindIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/gridfs/GridFSFindIterable.java
@@ -28,7 +28,9 @@ import java.util.concurrent.TimeUnit;
  * Iterable for the GridFS Files Collection.
  *
  * @since 3.3
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public interface GridFSFindIterable extends MongoIterable<GridFSFile> {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/gridfs/GridFSUploadStream.java
+++ b/driver-async/src/main/com/mongodb/async/client/gridfs/GridFSUploadStream.java
@@ -26,7 +26,9 @@ import org.bson.types.ObjectId;
  * <p>Provides the {@code id} for the file to be uploaded as well as the {@code write} methods of a {@link AsyncOutputStream}</p>
  *
  * @since 3.3
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public interface GridFSUploadStream extends AsyncOutputStream {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/gridfs/helpers/AsyncStreamHelper.java
+++ b/driver-async/src/main/com/mongodb/async/client/gridfs/helpers/AsyncStreamHelper.java
@@ -40,7 +40,9 @@ import static com.mongodb.assertions.Assertions.notNull;
  * </ul>
  *
  * @since 3.3
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public final class AsyncStreamHelper {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/gridfs/helpers/AsynchronousChannelHelper.java
+++ b/driver-async/src/main/com/mongodb/async/client/gridfs/helpers/AsynchronousChannelHelper.java
@@ -34,7 +34,9 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * <p>Requires Java 7 or greater.</p>
  * @since 3.3
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public final class AsynchronousChannelHelper {
 
     /**

--- a/driver-async/src/main/com/mongodb/async/client/gridfs/helpers/package-info.java
+++ b/driver-async/src/main/com/mongodb/async/client/gridfs/helpers/package-info.java
@@ -18,4 +18,5 @@
  * Contains helper classes to create {@link com.mongodb.async.client.gridfs.AsyncInputStream} and
  * {@link com.mongodb.async.client.gridfs.AsyncOutputStream}'s from external sources.
  */
+@Deprecated
 package com.mongodb.async.client.gridfs.helpers;

--- a/driver-async/src/main/com/mongodb/async/client/gridfs/package-info.java
+++ b/driver-async/src/main/com/mongodb/async/client/gridfs/package-info.java
@@ -19,6 +19,7 @@
  * @mongodb.driver.manual core/gridfs/ GridFS
  */
 @NonNullApi
+@Deprecated
 package com.mongodb.async.client.gridfs;
 
 import com.mongodb.lang.NonNullApi;

--- a/driver-async/src/main/com/mongodb/async/client/package-info.java
+++ b/driver-async/src/main/com/mongodb/async/client/package-info.java
@@ -17,6 +17,7 @@
 /**
  * This packages contains classes for the new async client
  */
+@Deprecated
 @NonNullApi
 package com.mongodb.async.client;
 

--- a/driver-core/src/main/com/mongodb/async/AsyncBatchCursor.java
+++ b/driver-core/src/main/com/mongodb/async/AsyncBatchCursor.java
@@ -28,7 +28,9 @@ import java.util.List;
  *
  * @param <T> The type of documents the cursor contains
  * @mongodb.driver.manual ../meta-driver/latest/legacy/mongodb-wire-protocol/#wire-op-get-more OP_GET_MORE
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public interface AsyncBatchCursor<T> extends Closeable {
     /**
      * Returns the next batch of results.  A tailable cursor will block until another batch exists.  After the last batch, the next call

--- a/driver-core/src/main/com/mongodb/async/SingleResultCallback.java
+++ b/driver-core/src/main/com/mongodb/async/SingleResultCallback.java
@@ -21,7 +21,9 @@ package com.mongodb.async;
  *
  * @param <T> the result type
  * @since 3.0
+ * @deprecated Prefer the Reactive Streams-based asynchronous driver (mongodb-driver-reactivestreams artifactId)
  */
+@Deprecated
 public interface SingleResultCallback<T> {
     /**
      * Called when the operation completes.

--- a/driver-core/src/main/com/mongodb/async/package-info.java
+++ b/driver-core/src/main/com/mongodb/async/package-info.java
@@ -17,4 +17,5 @@
 /**
  * This package contains async interfaces
  */
+@Deprecated
 package com.mongodb.async;


### PR DESCRIPTION
The mongodb-driver-async module API is based on callbacks, which are
difficult and error-prone to program against.  Since this API was
introduced, the industry has standardize around
http://www.reactive-streams.org/ and, more recently,
java.util.concurrent.Flow (introduced in Java 9).  Given this trend, it
is no longer advantageous to maintain the callback-based public API; it
is now deprecated and the intention is to remove it in the next
major release of the driver.

JAVA-3008