### PR TITLE
Generate Javadoc in HTML 5 format

### DIFF
--- a/bson/src/main/org/bson/BSONObject.java
+++ b/bson/src/main/org/bson/BSONObject.java
@@ -30,8 +30,8 @@ public interface BSONObject {
      *
      * @param key Name to set
      * @param v   Corresponding value
-     * @return the previous value associated with <tt>key</tt>, or <tt>null</tt> if there was no mapping for <tt>key</tt>. (A <tt>null</tt>
-     * return can also indicate that the map previously associated <tt>null</tt> with <tt>key</tt>.)
+     * @return the previous value associated with {@code key}, or {@code null} if there was no mapping for {@code key}. (A
+     * {@code null} return can also indicate that the map previously associated {@code null} with {@code key}.)
      */
     Object put(String key, Object v);
 

--- a/bson/src/main/org/bson/ByteBuf.java
+++ b/bson/src/main/org/bson/ByteBuf.java
@@ -232,18 +232,18 @@ public interface ByteBuf  {
      * <p> This method transfers bytes from this buffer into the given
      * destination array.  If there are fewer bytes remaining in the
      * buffer than are required to satisfy the request, that is, if
-     * <tt>length</tt>&nbsp;<tt>&gt;</tt>&nbsp;<tt>remaining()</tt>, then no
+     * <code style="white-space:nowrap">length &gt; remaining()</code>, then no
      * bytes are transferred and a {@link java.nio.BufferUnderflowException} is
      * thrown.
      *
-     * <p> Otherwise, this method copies <tt>length</tt> bytes from this
+     * <p> Otherwise, this method copies {@code length} bytes from this
      * buffer into the given array, starting at the current position of this
      * buffer and at the given offset in the array.  The position of this
-     * buffer is then incremented by <tt>length</tt>.
+     * buffer is then incremented by {@code length}.
      *
      * <p> In other words, an invocation of this method of the form
-     * <tt>src.get(dst,&nbsp;off,&nbsp;len)</tt> has exactly the same effect as
-     * the loop
+     * <code style="white-space:nowrap">src.get(dst, off, len)</code>
+     * has exactly the same effect as the loop
      *
      * <pre>
      * {@code
@@ -261,21 +261,21 @@ public interface ByteBuf  {
      * @param  offset
      *         The offset within the array of the first byte to be
      *         written; must be non-negative and no larger than
-     *         <tt>dst.length</tt>
+     *         {@code dst.length}
      *
      * @param  length
      *         The maximum number of bytes to be written to the given
      *         array; must be non-negative and no larger than
-     *         <tt>dst.length - offset</tt>
+     *         {@code dst.length - offset}
      *
      * @return  This buffer
      *
      * @throws java.nio.BufferUnderflowException
-     *          If there are fewer than <tt>length</tt> bytes
+     *          If there are fewer than {@code length} bytes
      *          remaining in this buffer
      *
      * @throws  IndexOutOfBoundsException
-     *          If the preconditions on the <tt>offset</tt> and <tt>length</tt>
+     *          If the preconditions on the {@code offset} and {@code length}
      *          parameters do not hold
      */
     ByteBuf get(byte[] bytes, int offset, int length);

--- a/bson/src/main/org/bson/util/CopyOnWriteMap.java
+++ b/bson/src/main/org/bson/util/CopyOnWriteMap.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * mutations, and is useful when you cannot or don't want to synchronize traversals, yet need to preclude interference among concurrent
  * threads. The "snapshot" style iterators on the collections returned by {@link #entrySet()}, {@link #keySet()} and {@link #values()} use a
  * reference to the internal map at the point that the iterator was created. This map never changes during the lifetime of the iterator, so
- * interference is impossible and the iterator is guaranteed not to throw <tt>ConcurrentModificationException</tt>. The iterators will not
+ * interference is impossible and the iterator is guaranteed not to throw {@code ConcurrentModificationException}. The iterators will not
  * reflect additions, removals, or changes to the list since the iterator was created. Removing elements via these iterators is not
  * supported. The mutable operations on these collections (remove, retain etc.) are supported but as with the {@link java.util.Map}
  * interface, add and addAll are not and throw {@link UnsupportedOperationException}.</p> <p>The actual copy is performed by an abstract

--- a/driver-core/src/main/com/mongodb/TagSet.java
+++ b/driver-core/src/main/com/mongodb/TagSet.java
@@ -82,10 +82,10 @@ public final class TagSet implements Iterable<Tag> {
     }
 
     /**
-     * Returns <tt>true</tt> if this tag set contains all of the elements of the specified tag set.
+     * Returns {@code true} if this tag set contains all of the elements of the specified tag set.
      *
      * @param tagSet tag set to be checked for containment in this tag set
-     * @return <tt>true</tt> if this tag set contains all of the elements of the specified tag set
+     * @return {@code true} if this tag set contains all of the elements of the specified tag set
      */
     public boolean containsAll(final TagSet tagSet) {
         return wrapped.containsAll(tagSet.wrapped);

--- a/driver-core/src/main/com/mongodb/internal/connection/AsyncWritableByteChannel.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AsyncWritableByteChannel.java
@@ -20,56 +20,36 @@ import com.mongodb.connection.AsyncCompletionHandler;
 
 import java.nio.ByteBuffer;
 
-/**
- * An asynchronous channel that can write bytes.
- *
- * @since 3.0
- */
+// An asynchronous channel that can write bytes.
 interface AsyncWritableByteChannel {
-    /**
-     * Writes a sequence of bytes to this channel from the given buffer.
-     *
-     * <p> This method initiates an asynchronous write operation to write a
-     * sequence of bytes to this channel from the given buffer. The {@code
-     * handler} parameter is a completion handler that is invoked when the write
-     * operation completes (or fails). The result passed to the completion
-     * handler is the number of bytes written.
-     *
-     * <p> The write operation may write up to <i>r</i> bytes to the channel,
-     * where <i>r</i> is the number of bytes remaining in the buffer, that is,
-     * {@code src.remaining()} at the time that the write is attempted. Where
-     * <i>r</i> is 0, the write operation completes immediately with a result of
-     * {@code 0} without initiating an I/O operation.
-     *
-     * <p> Suppose that a byte sequence of length <i>n</i> is written, where
-     * <tt>0</tt>&nbsp;<tt>&lt;</tt>&nbsp;<i>n</i>&nbsp;<tt>&lt;=</tt>&nbsp;<i>r</i>.
-     * This byte sequence will be transferred from the buffer starting at index
-     * <i>p</i>, where <i>p</i> is the buffer's position at the moment the
-     * write is performed; the index of the last byte written will be
-     * <i>p</i>&nbsp;<tt>+</tt>&nbsp;<i>n</i>&nbsp;<tt>-</tt>&nbsp;<tt>1</tt>.
-     * Upon completion the buffer's position will be equal to
-     * <i>p</i>&nbsp;<tt>+</tt>&nbsp;<i>n</i>; its limit will not have changed.
-     *
-     * <p> Buffers are not safe for use by multiple concurrent threads so care
-     * should be taken to not access the buffer until the operation has
-     * completed.
-     *
-     * <p> This method may be invoked at any time. Some channel types may not
-     * allow more than one write to be outstanding at any given time. If a thread
-     * initiates a write operation before a previous write operation has
-     * completed then a {@link java.nio.channels.WritePendingException} will be thrown.
-     *
-     * @param   src
-     *          The buffer from which bytes are to be retrieved
-     * @param   handler
-     *          The completion handler object
-     *
-     * @throws java.nio.channels.WritePendingException
-     *          If the channel does not allow more than one write to be outstanding
-     *          and a previous write has not completed
-     * @throws java.nio.channels.ShutdownChannelGroupException
-     *          If the channel is associated with a {@link java.nio.channels.AsynchronousChannelGroup
-     *          group} that has terminated
-     */
+     // Writes a sequence of bytes to this channel from the given buffer.
+     //
+     // This method initiates an asynchronous write operation to write a
+     // sequence of bytes to this channel from the given buffer. The
+     // handler parameter is a completion handler that is invoked when the write
+     // operation completes (or fails). The result passed to the completion
+     // handler is the number of bytes written.
+     //
+     // The write operation may write up to r bytes to the channel,
+     // where r is the number of bytes remaining in the buffer, that is,
+     // src.remaining() at the time that the write is attempted. Where
+     // r is 0, the write operation completes immediately with a result of
+     // 0 without initiating an I/O operation.
+     //
+     // Suppose that a byte sequence of length n is written, where 0 < n <= r.
+     // This byte sequence will be transferred from the buffer starting at index
+     // p, where p is the buffer's position at the moment the write is performed;
+     // the index of the last byte written will be p + n - 1}.
+     // Upon completion the buffer's position will be equal to p + n;
+     // its limit will not have changed.
+     //
+     // Buffers are not safe for use by multiple concurrent threads so care
+     // should be taken to not access the buffer until the operation has
+     // completed.
+     //
+     // This method may be invoked at any time. Some channel types may not
+     // allow more than one write to be outstanding at any given time. If a thread
+     // initiates a write operation before a previous write operation has
+     // completed then a java.nio.channels.WritePendingException will be thrown.
     void write(ByteBuffer src, AsyncCompletionHandler<Void> handler);
 }

--- a/gradle/javadoc.gradle
+++ b/gradle/javadoc.gradle
@@ -50,7 +50,7 @@ allprojects {
                 encoding = 'UTF-8'
                 charSet 'UTF-8'
                 docEncoding 'UTF-8'
-                addBooleanOption("html4", true)
+                addBooleanOption("html5", true)
                 addBooleanOption("-allow-script-in-comments", true)
                 header = '''
             | <script type="text/javascript">


### PR DESCRIPTION
Replace all <tt> tags with either @code or <code> so that the Javadoc
parses as HTML 5.

JAVA-3059