### PR TITLE
Remove connection string from log message

### DIFF
--- a/driver-core/src/main/com/mongodb/ConnectionString.java
+++ b/driver-core/src/main/com/mongodb/ConnectionString.java
@@ -438,7 +438,7 @@ public class ConnectionString {
         for (final String key : optionsMap.keySet()) {
             if (!ALL_KEYS.contains(key)) {
                 if (LOGGER.isWarnEnabled()) {
-                    LOGGER.warn(format("Unsupported option '%s' in the connection string '%s'.", key, connectionString));
+                    LOGGER.warn(format("Connection string contains unsupported option '%s'.", key));
                 }
             }
         }


### PR DESCRIPTION
A connection string containing an unsupported option generates a log
message at warning level to the "org.mongodb.driver.uri" component. The
log message contains the full connection string.  As the connection
string may contain the credentials used to authenticate, it should not
be logged.  This commit removes the full connection string from the log
message, and instead just logs the name of the unsupported option.

JAVA-3093