### PR TITLE
Use major JDK version number in Gradle error message

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -261,7 +261,7 @@ task wrapper(type: Wrapper) {
 if (!JavaVersion.current().isJava9Compatible()) {
     throw new GradleException("""
         | ERROR:
-        | JDK ${JavaVersion.VERSION_1_9} is required to build the driver: You are using JDK ${JavaVersion.current()}.
+        | JDK ${JavaVersion.VERSION_1_9.getMajorVersion()} is required to build the driver: You are using JDK ${JavaVersion.current().getMajorVersion()}.
         |""".stripMargin()
     )
 }


### PR DESCRIPTION
Now if you use JDK 8 to build the driver, it prints this error:

   ERROR:
   JDK 9 is required to build the driver: You are using JDK 8.

JAVA-2992