### PR TITLE
Add wildcard projection support to index creation

### DIFF
--- a/driver-async/src/test/unit/com/mongodb/async/client/MongoCollectionSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/MongoCollectionSpecification.groovy
@@ -1214,6 +1214,7 @@ class MongoCollectionSpecification extends Specification {
                          .storageEngine(BsonDocument.parse('{wiredTiger: {configString: "block_compressor=zlib"}}'))
                          .partialFilterExpression(BsonDocument.parse('{status: "active"}'))
                          .collation(collation)
+                         .wildcardProjection(new BsonDocument('a', new BsonInt32(1)))
                 ], ACKNOWLEDGED)
         indexName = execute(createIndexMethod, session, new Document('key', 1), new IndexOptions()
                 .background(true)
@@ -1233,7 +1234,8 @@ class MongoCollectionSpecification extends Specification {
                 .bucketSize(200.0)
                 .storageEngine(BsonDocument.parse('{wiredTiger: {configString: "block_compressor=zlib"}}'))
                 .partialFilterExpression(BsonDocument.parse('{status: "active"}'))
-                .collation(collation))
+                .collation(collation)
+                .wildcardProjection(new BsonDocument('a', new BsonInt32(1))))
         operation = executor.getWriteOperation() as CreateIndexesOperation
 
         then:

--- a/driver-core/src/main/com/mongodb/bulk/IndexRequest.java
+++ b/driver-core/src/main/com/mongodb/bulk/IndexRequest.java
@@ -519,7 +519,6 @@ public class IndexRequest {
      *
      * @return the wildcard projection
      * @mongodb.server.release 4.2
-     * @mongodb.driver.manual TODO
      * @since 3.10
      */
     public BsonDocument getWildcardProjection() {
@@ -532,7 +531,6 @@ public class IndexRequest {
      * @param wildcardProjection the wildcard projection
      * @return this
      * @mongodb.server.release 4.2
-     * @mongodb.driver.manual TODO
      * @since 3.10
      */
     public IndexRequest wildcardProjection(final BsonDocument wildcardProjection) {

--- a/driver-core/src/main/com/mongodb/bulk/IndexRequest.java
+++ b/driver-core/src/main/com/mongodb/bulk/IndexRequest.java
@@ -56,6 +56,7 @@ public class IndexRequest {
     private BsonDocument storageEngine;
     private BsonDocument partialFilterExpression;
     private Collation collation;
+    private BsonDocument wildcardProjection;
 
     /**
      * Construct a new instance with the given keys
@@ -510,6 +511,32 @@ public class IndexRequest {
      */
     public IndexRequest collation(final Collation collation) {
         this.collation = collation;
+        return this;
+    }
+
+    /**
+     * Gets the wildcard projection of a wildcard index
+     *
+     * @return the wildcard projection
+     * @mongodb.server.release 4.2
+     * @mongodb.driver.manual TODO
+     * @since 3.10
+     */
+    public BsonDocument getWildcardProjection() {
+        return wildcardProjection;
+    }
+
+    /**
+     * Sets the wildcard projection of a wildcard index
+     *
+     * @param wildcardProjection the wildcard projection
+     * @return this
+     * @mongodb.server.release 4.2
+     * @mongodb.driver.manual TODO
+     * @since 3.10
+     */
+    public IndexRequest wildcardProjection(final BsonDocument wildcardProjection) {
+        this.wildcardProjection = wildcardProjection;
         return this;
     }
 }

--- a/driver-core/src/main/com/mongodb/client/model/IndexOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/IndexOptions.java
@@ -472,7 +472,6 @@ public class IndexOptions {
      *
      * @return the wildcard projection
      * @mongodb.server.release 4.2
-     * @mongodb.driver.manual TODO
      * @since 3.10
      */
     public Bson getWildcardProjection() {
@@ -485,7 +484,6 @@ public class IndexOptions {
      * @param wildcardProjection the wildcard projection
      * @return this
      * @mongodb.server.release 4.2
-     * @mongodb.driver.manual TODO
      * @since 3.10
      */
     public IndexOptions wildcardProjection(final Bson wildcardProjection) {

--- a/driver-core/src/main/com/mongodb/client/model/IndexOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/IndexOptions.java
@@ -46,6 +46,7 @@ public class IndexOptions {
     private Bson storageEngine;
     private Bson partialFilterExpression;
     private Collation collation;
+    private Bson wildcardProjection;
 
     /**
      * Create the index in the background
@@ -466,6 +467,32 @@ public class IndexOptions {
         return this;
     }
 
+    /**
+     * Gets the wildcard projection of a wildcard index
+     *
+     * @return the wildcard projection
+     * @mongodb.server.release 4.2
+     * @mongodb.driver.manual TODO
+     * @since 3.10
+     */
+    public Bson getWildcardProjection() {
+        return wildcardProjection;
+    }
+
+    /**
+     * Sets the wildcard projection of a wildcard index
+     *
+     * @param wildcardProjection the wildcard projection
+     * @return this
+     * @mongodb.server.release 4.2
+     * @mongodb.driver.manual TODO
+     * @since 3.10
+     */
+    public IndexOptions wildcardProjection(final Bson wildcardProjection) {
+        this.wildcardProjection = wildcardProjection;
+        return this;
+    }
+
     @Override
     public String toString() {
         return "IndexOptions{"
@@ -487,6 +514,7 @@ public class IndexOptions {
                 + ", storageEngine=" + storageEngine
                 + ", partialFilterExpression=" + partialFilterExpression
                 + ", collation=" + collation
+                + ", wildcardProjection=" + wildcardProjection
                 + '}';
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/operation/Operations.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/Operations.java
@@ -437,6 +437,7 @@ final class Operations<TDocument> {
                     .storageEngine(toBsonDocument(model.getOptions().getStorageEngine()))
                     .partialFilterExpression(toBsonDocument(model.getOptions().getPartialFilterExpression()))
                     .collation(model.getOptions().getCollation())
+                    .wildcardProjection(toBsonDocument(model.getOptions().getWildcardProjection()))
             );
         }
         return new CreateIndexesOperation(namespace, indexRequests, writeConcern)

--- a/driver-core/src/main/com/mongodb/operation/CreateIndexesOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/CreateIndexesOperation.java
@@ -273,6 +273,9 @@ public class CreateIndexesOperation implements AsyncWriteOperation<Void>, WriteO
         if (request.getCollation() != null) {
             index.append("collation", request.getCollation().asDocument());
         }
+        if (request.getWildcardProjection() != null) {
+            index.append("wildcardProjection", request.getWildcardProjection());
+        }
         return index;
     }
 

--- a/driver-core/src/test/unit/com/mongodb/IndexRequestSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/IndexRequestSpecification.groovy
@@ -55,6 +55,7 @@ class IndexRequestSpecification extends Specification {
         request.getStorageEngine() == null
         request.getPartialFilterExpression() == null
         request.getCollation() == null
+        request.getWildcardProjection() == null
 
         when:
         def keys = BsonDocument.parse('{ a: 1 }')
@@ -71,6 +72,7 @@ class IndexRequestSpecification extends Specification {
                 .collationMaxVariable(CollationMaxVariable.SPACE)
                 .backwards(true)
                 .build()
+        def wildcardProjection = BsonDocument.parse('{a  : 1}')
         def request2 = new IndexRequest(keys)
                 .background(true)
                 .unique(true)
@@ -91,6 +93,7 @@ class IndexRequestSpecification extends Specification {
                 .storageEngine(storageEngine)
                 .partialFilterExpression(partialFilterExpression)
                 .collation(collation)
+                .wildcardProjection(wildcardProjection)
 
         then:
         request2.getKeys() == keys
@@ -113,6 +116,7 @@ class IndexRequestSpecification extends Specification {
         request2.getStorageEngine() == storageEngine
         request2.getPartialFilterExpression() == partialFilterExpression
         request2.getCollation() == collation
+        request2.getWildcardProjection() == wildcardProjection
     }
 
 

--- a/driver-core/src/test/unit/com/mongodb/client/model/IndexOptionsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/IndexOptionsSpecification.groovy
@@ -46,6 +46,8 @@ class IndexOptionsSpecification extends Specification {
         options.getStorageEngine() == null
         options.getPartialFilterExpression() == null
         options.getCollation() == null
+        options.getWildcardProjection() == null
+        def wildcardProjection = BsonDocument.parse('{a  : 1}')
 
         when:
         def weights = BsonDocument.parse('{ a: 1000 }')
@@ -70,6 +72,7 @@ class IndexOptionsSpecification extends Specification {
                 .storageEngine(storageEngine)
                 .partialFilterExpression(partialFilterExpression)
                 .collation(collation)
+                .wildcardProjection(wildcardProjection)
 
         then:
         options.isBackground()
@@ -90,6 +93,7 @@ class IndexOptionsSpecification extends Specification {
         options.getStorageEngine() == storageEngine
         options.getPartialFilterExpression() == partialFilterExpression
         options.getCollation() == collation
+        options.getWildcardProjection() == wildcardProjection
     }
 
     def 'should convert expireAfter'() {

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoCollectionSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoCollectionSpecification.groovy
@@ -1215,6 +1215,7 @@ class MongoCollectionSpecification extends Specification {
                          .storageEngine(BsonDocument.parse('{wiredTiger: {configString: "block_compressor=zlib"}}'))
                          .partialFilterExpression(BsonDocument.parse('{status: "active"}'))
                          .collation(collation)
+                         .wildcardProjection(new BsonDocument('a', new BsonInt32(1)))
                 ], ACKNOWLEDGED)
         indexName = execute(createIndexMethod, session, new Document('key', 1), new IndexOptions()
                 .background(true)
@@ -1234,7 +1235,8 @@ class MongoCollectionSpecification extends Specification {
                 .bucketSize(200.0)
                 .storageEngine(BsonDocument.parse('{wiredTiger: {configString: "block_compressor=zlib"}}'))
                 .partialFilterExpression(BsonDocument.parse('{status: "active"}'))
-                .collation(collation))
+                .collation(collation)
+                .wildcardProjection(new BsonDocument('a', new BsonInt32(1))))
         operation = executor.getWriteOperation() as CreateIndexesOperation
 
         then:


### PR DESCRIPTION
https://jira.mongodb.org/browse/JAVA-3014

Patch build: https://evergreen.mongodb.com/version/5bf2b2b6e3c3316df140591c

Nearly positive that no further changes are required for reactive streams or scala drivers, but please confirm that.