### PR TITLE
JAVA-3114: Deprecate streamType connection string query parameter

### DIFF
--- a/docs/reference/content/driver-async/tutorials/authentication.md
+++ b/docs/reference/content/driver-async/tutorials/authentication.md
@@ -192,8 +192,7 @@ MongoClient mongoClient = MongoClients.create(
                         builder.hosts(Arrays.asList(new ServerAddress("host1", 27017))))
                 .credential(credential)
                 .streamFactoryFactory(NettyStreamFactoryFactory.builder().eventLoopGroup(eventLoopGroup).build())
-                .applyToSslSettings(builder ->
-                        builder.enabled(true))
+                .applyToSslSettings(builder -> builder.enabled(true))
                 .build());
 ```
 
@@ -202,6 +201,10 @@ Or use a connection string that explicitly specifies the `authMechanism=MONGODB-
 ```java
 MongoClient mongoClient = MongoClients.create("mongodb://subjectName@host1/?authMechanism=MONGODB-X509&streamType=netty&ssl=true");
 ```
+
+{{% note %}}
+The streamType connection string query parameter is deprecated as of the 3.10 release and will be removed in the next major release.
+{{% /note %}}
 
 See the MongoDB server
 [x.509 tutorial](http://docs.mongodb.org/manual/tutorial/configure-x509-client-authentication/#add-x-509-certificate-subject-as-a-user) for

--- a/docs/reference/content/driver-async/tutorials/connect-to-mongodb.md
+++ b/docs/reference/content/driver-async/tutorials/connect-to-mongodb.md
@@ -240,7 +240,7 @@ in Java 7.  However, an application must use [Netty](http://netty.io/) instead i
 
 To configure the driver to use Netty,  
 
-- Include the `streamType` option set to `netty`  in the connection string
+- Include the `streamType` option set to `netty` in the connection string
 
     ```java
     MongoClient client = MongoClients.create("mongodb://localhost/?streamType=netty");
@@ -250,16 +250,17 @@ To configure the driver to use Netty,
 
     ```java
     MongoClient client = MongoClients.create(MongoClientSettings.builder()
-                              .clusterSettings(ClusterSettings.builder()
-                                                  .hosts(Arrays.asList(new ServerAddress()))
-                                                  .build())
-                              .streamFactoryFactory(NettyStreamFactoryFactory.builder()
-                                                  .build())
-                              .build());
+            .applyConnectionString(new ConnectionString("mongodb://localhost"))
+            .streamFactoryFactory(NettyStreamFactoryFactory.builder().build())
+            .build());
 
     ```
 
 {{% note %}}
+The streamType connection string query parameter is deprecated as of the 3.10 release and will be removed in the next major release.
+{{% /note %}}
+
+{{% note %}}
 Netty may also be configured by setting the `org.mongodb.async.type` system property to `netty`, but this should be considered as
-deprecated as of the 3.1 driver release.
+deprecated as of the 3.1 driver release, and will be removed in the next major release
 {{% /note %}}

--- a/driver-core/src/main/com/mongodb/ConnectionString.java
+++ b/driver-core/src/main/com/mongodb/ConnectionString.java
@@ -16,6 +16,7 @@
 
 package com.mongodb;
 
+import com.mongodb.connection.StreamFactoryFactory;
 import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
 import com.mongodb.lang.Nullable;
@@ -107,7 +108,9 @@ import static java.util.Collections.unmodifiableList;
  * <p>Connection Configuration:</p>
  * <p>Connection Configuration:</p>
  * <ul>
- * <li>{@code streamType=nio2|netty}: The stream type to use for connections. If unspecified, nio2 will be used.</li>
+ * <li>{@code streamType=nio2|netty}: The stream type to use for connections. If unspecified, nio2 will be used for asynchronous
+ * clients.  Note that this query parameter has been deprecated and applications should use
+ * {@link MongoClientSettings.Builder#streamFactoryFactory(StreamFactoryFactory)} instead.</li>
  * <li>{@code ssl=true|false}: Whether to connect using SSL.</li>
  * <li>{@code sslInvalidHostNameAllowed=true|false}: Whether to allow invalid host names for SSL connections.</li>
  * <li>{@code connectTimeoutMS=ms}: How long a connection can take to be opened before timing out.</li>
@@ -473,6 +476,8 @@ public class ConnectionString {
                 sslEnabled = parseBoolean(value, "ssl");
             } else if (key.equals("streamtype")) {
                 streamType = value;
+                LOGGER.warn("The streamType query parameter is deprecated and support for it will be removed"
+                        + " in the next major release.");
             } else if (key.equals("replicaset")) {
                 requiredReplicaSetName = value;
             } else if (key.equals("readconcernlevel")) {
@@ -1179,7 +1184,10 @@ public class ConnectionString {
      * Gets the stream type value specified in the connection string.
      * @return the stream type value
      * @since 3.3
+     * @deprecated Use {@link MongoClientSettings.Builder#streamFactoryFactory(StreamFactoryFactory)} to configure the stream type
+     * programmatically
      */
+    @Deprecated
     @Nullable
     public String getStreamType() {
         return streamType;


### PR DESCRIPTION
* Deprecate ConnectionString#getStreamType
* Update ConnectionString Javadoc
* And a warning to the logs if it's used
* Update async reference documentation

https://jira.mongodb.org/browse/JAVA-3114
http://jyemin.github.io/mongo-java-driver/3.9/driver-async/tutorials/