### PR TITLE
Conform to ObjectId(byte[] bytes) contract

### DIFF
--- a/bson/src/main/org/bson/assertions/Assertions.java
+++ b/bson/src/main/org/bson/assertions/Assertions.java
@@ -64,6 +64,25 @@ public final class Assertions {
     }
 
     /**
+     * Throw IllegalArgumentException if the condition if false, otherwise return the value.  This is useful when arguments must be checked
+     * within an expression, as when using {@code this} to call another constructor, which must be the first line of the calling
+     * constructor.
+     *
+     * @param <T>       the value type
+     * @param name      the name of the state that is being checked
+     * @param value     the value of the argument
+     * @param condition the condition about the parameter to check
+     * @return          the value
+     * @throws java.lang.IllegalArgumentException if the condition is false
+     */
+    public static <T> T isTrueArgument(final String name, final T value, final boolean condition) {
+        if (!condition) {
+            throw new IllegalArgumentException("state should be: " + name);
+        }
+        return value;
+    }
+
+    /**
      * Cast an object to the given class and return it, or throw IllegalArgumentException if it's not assignable to that class.
      *
      * @param clazz        the class to cast to

--- a/bson/src/main/org/bson/types/ObjectId.java
+++ b/bson/src/main/org/bson/types/ObjectId.java
@@ -212,7 +212,7 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
      * @throws IllegalArgumentException if array is null or not of length 12
      */
     public ObjectId(final byte[] bytes) {
-        this(ByteBuffer.wrap(notNull("bytes", bytes)));
+        this(ByteBuffer.wrap(isTrueArgument("bytes has length of 12", bytes, notNull("bytes", bytes).length == 12)));
     }
 
     /**

--- a/bson/src/test/unit/org/bson/types/ObjectIdTest.java
+++ b/bson/src/test/unit/org/bson/types/ObjectIdTest.java
@@ -26,7 +26,9 @@ import java.nio.ByteBuffer;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+@SuppressWarnings("deprecation")
 public class ObjectIdTest {
     @Test
     public void testToBytes() {
@@ -42,6 +44,28 @@ public class ObjectIdTest {
 
     @Test
     public void testFromBytes() {
+
+        try {
+            new ObjectId((byte[]) null);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("bytes can not be null", e.getMessage());
+        }
+
+        try {
+            new ObjectId(new byte[11]);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("state should be: bytes has length of 12", e.getMessage());
+        }
+
+        try {
+            new ObjectId(new byte[13]);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("state should be: bytes has length of 12", e.getMessage());
+        }
+
         byte[] bytes = new byte[]{81, 6, -4, -102, -68, -126, 55, 85, -127, 54, -46, -119};
 
         ObjectId objectId1 = new ObjectId(bytes);


### PR DESCRIPTION
The Javadoc states that it throws IllegalArgumentException if array is
null or not of length 12. The implementation now conforms to that
contract and throws the specified exception the byte array is not of
length 12.

JAVA-2961