### PR TITLE
 Improve lsid comparison is command event equality assertions

### DIFF
--- a/driver-async/src/test/functional/com/mongodb/async/client/ReadConcernTest.java
+++ b/driver-async/src/test/functional/com/mongodb/async/client/ReadConcernTest.java
@@ -86,8 +86,7 @@ public class ReadConcernTest {
             commandDocument.put("$readPreference", ReadPreference.primaryPreferred().toDocument());
         }
         assertEventsEquality(Arrays.<CommandEvent>asList(new CommandStartedEvent(1, null, getDefaultDatabaseName(),
-                        "count", commandDocument)), events,
-                commandListener.getSessions());
+                        "count", commandDocument)), events);
 
     }
 

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/TestCommandListener.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/TestCommandListener.java
@@ -43,8 +43,6 @@ import static org.junit.Assert.assertTrue;
 
 public class TestCommandListener implements CommandListener {
     private final List<CommandEvent> events = new ArrayList<CommandEvent>();
-    private final List<BsonDocument> sessions = new ArrayList<BsonDocument>();
-    private BsonDocument expectedSessionIdentifierForNextStartedEvent;
 
     private static final CodecRegistry CODEC_REGISTRY_HACK;
 
@@ -87,7 +85,6 @@ public class TestCommandListener implements CommandListener {
         events.add(new CommandStartedEvent(event.getRequestId(), event.getConnectionDescription(), event.getDatabaseName(),
                                            event.getCommandName(),
                                            event.getCommand() == null ? null : getWritableClone(event.getCommand())));
-        sessions.add(expectedSessionIdentifierForNextStartedEvent);
     }
 
     private BsonDocument getWritableClone(final BsonDocument original) {
@@ -180,13 +177,5 @@ public class TestCommandListener implements CommandListener {
     private void assertEquivalence(final CommandStartedEvent actual, final CommandStartedEvent expected) {
         assertEquals(expected.getDatabaseName(), actual.getDatabaseName());
         assertEquals(expected.getCommand(), actual.getCommand());
-    }
-
-    public void addExpectedSessionNextStartedEvent(final BsonDocument sessionIdentifier) {
-        expectedSessionIdentifierForNextStartedEvent = sessionIdentifier;
-    }
-
-    public List<BsonDocument> getSessions() {
-        return sessions;
     }
 }

--- a/driver-core/src/test/resources/transactions/insert.json
+++ b/driver-core/src/test/resources/transactions/insert.json
@@ -234,6 +234,196 @@
       }
     },
     {
+      "description": "insert with session1",
+      "operations": [
+        {
+          "name": "startTransaction",
+          "object": "session1"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session1",
+            "document": {
+              "_id": 1
+            }
+          },
+          "result": {
+            "insertedId": 1
+          }
+        },
+        {
+          "name": "insertMany",
+          "object": "collection",
+          "arguments": {
+            "documents": [
+              {
+                "_id": 2
+              },
+              {
+                "_id": 3
+              }
+            ],
+            "session": "session1"
+          },
+          "result": {
+            "insertedIds": {
+              "0": 2,
+              "1": 3
+            }
+          }
+        },
+        {
+          "name": "commitTransaction",
+          "object": "session1"
+        },
+        {
+          "name": "startTransaction",
+          "object": "session1"
+        },
+        {
+          "name": "insertOne",
+          "object": "collection",
+          "arguments": {
+            "session": "session1",
+            "document": {
+              "_id": 4
+            }
+          },
+          "result": {
+            "insertedId": 4
+          }
+        },
+        {
+          "name": "abortTransaction",
+          "object": "session1"
+        }
+      ],
+      "expectations": [
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 1
+                }
+              ],
+              "ordered": true,
+              "readConcern": null,
+              "lsid": "session1",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 2
+                },
+                {
+                  "_id": 3
+                }
+              ],
+              "ordered": true,
+              "lsid": "session1",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "commitTransaction": 1,
+              "lsid": "session1",
+              "txnNumber": {
+                "$numberLong": "1"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "commitTransaction",
+            "database_name": "admin"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "insert": "test",
+              "documents": [
+                {
+                  "_id": 4
+                }
+              ],
+              "ordered": true,
+              "readConcern": {
+                "afterClusterTime": 42
+              },
+              "lsid": "session1",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "startTransaction": true,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "insert",
+            "database_name": "transaction-tests"
+          }
+        },
+        {
+          "command_started_event": {
+            "command": {
+              "abortTransaction": 1,
+              "lsid": "session1",
+              "txnNumber": {
+                "$numberLong": "2"
+              },
+              "startTransaction": null,
+              "autocommit": false,
+              "writeConcern": null
+            },
+            "command_name": "abortTransaction",
+            "database_name": "admin"
+          }
+        }
+      ],
+      "outcome": {
+        "collection": {
+          "data": [
+            {
+              "_id": 1
+            },
+            {
+              "_id": 2
+            },
+            {
+              "_id": 3
+            }
+          ]
+        }
+      }
+    },
+    {
       "description": "collection writeConcern without transaction",
       "operations": [
         {

--- a/driver-sync/src/test/functional/com/mongodb/client/ReadConcernTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ReadConcernTest.java
@@ -85,8 +85,7 @@ public class ReadConcernTest {
             commandDocument.put("$readPreference", ReadPreference.primaryPreferred().toDocument());
         }
         assertEventsEquality(Arrays.<CommandEvent>asList(new CommandStartedEvent(1, null, getDefaultDatabaseName(),
-                        "count", commandDocument)), events,
-                commandListener.getSessions());
+                        "count", commandDocument)), events);
     }
 
     private boolean canRunTests() {

--- a/driver-sync/src/test/functional/com/mongodb/client/TransactionsTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/TransactionsTest.java
@@ -85,6 +85,7 @@ public class TransactionsTest {
     private MongoClient mongoClient;
     private CollectionHelper<Document> collectionHelper;
     private Map<String, ClientSession> sessionsMap;
+    private Map<String, BsonDocument> lsidMap;
 
     @BeforeClass
     public static void beforeClass() {
@@ -153,6 +154,9 @@ public class TransactionsTest {
         sessionsMap = new HashMap<String, ClientSession>();
         sessionsMap.put("session0", sessionZero);
         sessionsMap.put("session1", sessionOne);
+        lsidMap = new HashMap<String, BsonDocument>();
+        lsidMap.put("session0", sessionZero.getServerSession().getIdentifier());
+        lsidMap.put("session1", sessionOne.getServerSession().getIdentifier());
     }
 
     private ReadConcern getReadConcern(final BsonDocument clientOptions) {
@@ -242,8 +246,6 @@ public class TransactionsTest {
                     clientSession = operation.getDocument("arguments").containsKey("session")
                             ? sessionsMap.get(operation.getDocument("arguments").getString("session").getValue()) : null;
                 }
-                BsonDocument sessionIdentifier = (clientSession == null) ? null : clientSession.getServerSession().getIdentifier();
-                commandListener.addExpectedSessionNextStartedEvent(sessionIdentifier);
                 try {
                     if (operationName.equals("startTransaction")) {
                         BsonDocument arguments = operation.getDocument("arguments", new BsonDocument());
@@ -334,7 +336,7 @@ public class TransactionsTest {
             List<CommandEvent> expectedEvents = getExpectedEvents(definition.getArray("expectations"), databaseName, null);
             List<CommandEvent> events = commandListener.getCommandStartedEvents();
 
-            assertEventsEquality(expectedEvents, events, commandListener.getSessions());
+            assertEventsEquality(expectedEvents, events, lsidMap);
         }
 
         BsonDocument expectedOutcome = definition.getDocument("outcome", new BsonDocument());


### PR DESCRIPTION
Two commits:

* One to change how we compare lsid in command events
* Update insert.json transaction spec test, which exercises this new comparison method

JAVA-3115

Patch build: https://evergreen.mongodb.com/version/5c26486ce3c331572b4631eb

   Seems to be failing for reasons unrelated to this patch.