### PR TITLE
Deprecate all use of the ServerVersion class

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/ConnectionDescription.java
+++ b/driver-core/src/main/com/mongodb/connection/ConnectionDescription.java
@@ -106,7 +106,9 @@ public class ConnectionDescription {
      * @param maxMessageSize  the max message size in bytes
      * @param compressors     the available compressors on the connection
      * @since 3.10
+     * @deprecated
      */
+    @Deprecated
     public ConnectionDescription(final ConnectionId connectionId, final ServerVersion serverVersion, final int maxWireVersion,
                                  final ServerType serverType, final int maxBatchCount, final int maxDocumentSize,
                                  final int maxMessageSize, final List<String> compressors) {
@@ -120,6 +122,23 @@ public class ConnectionDescription {
         this.compressors = notNull("compressors", Collections.unmodifiableList(new ArrayList<String>(compressors)));
     }
 
+    /**
+     * Construct an instance.
+     *
+     * @param connectionId    the connection id
+     * @param maxWireVersion  the max wire version
+     * @param serverType      the server type
+     * @param maxBatchCount   the max batch count
+     * @param maxDocumentSize the max document size in bytes
+     * @param maxMessageSize  the max message size in bytes
+     * @param compressors     the available compressors on the connection
+     * @since 3.10
+     */
+    public ConnectionDescription(final ConnectionId connectionId, final int maxWireVersion,
+                                 final ServerType serverType, final int maxBatchCount, final int maxDocumentSize,
+                                 final int maxMessageSize, final List<String> compressors) {
+        this(connectionId, new ServerVersion(), maxWireVersion, serverType, maxBatchCount, maxDocumentSize, maxMessageSize, compressors);
+    }
 
     /**
      * Creates a new connection description with the set connection id
@@ -156,7 +175,9 @@ public class ConnectionDescription {
      * Gets the version of the server.
      *
      * @return the server version
+     * @deprecated Use {@link #getMaxWireVersion()} instead
      */
+    @Deprecated
     public ServerVersion getServerVersion() {
         return serverVersion;
     }

--- a/driver-core/src/main/com/mongodb/connection/ServerDescription.java
+++ b/driver-core/src/main/com/mongodb/connection/ServerDescription.java
@@ -306,7 +306,9 @@ public class ServerDescription {
          *
          * @param version a ServerVersion representing which version of MongoDB is running on this server
          * @return this
+         * @deprecated Use {@link #maxWireVersion} instead
          */
+        @Deprecated
         public Builder version(final ServerVersion version) {
             notNull("version", version);
             this.version = version;
@@ -728,7 +730,9 @@ public class ServerDescription {
      * Gets the server version
      *
      * @return a ServerVersion representing which version of MongoDB is running on this server
+     * @deprecated Use {@link #getMaxWireVersion()} instead
      */
+    @Deprecated
     public ServerVersion getVersion() {
         return version;
     }


### PR DESCRIPTION
Deprecate use of ServerVersion in ConnectionDescription and
ServerDescription. This will allow the driver to stop calling the
buildInfo command in the next major release, after removal of these
deprecated methods.

JAVA-3107