### PR TITLE
J3085

### DIFF
--- a/bson/src/main/org/bson/json/StrictCharacterStreamJsonWriter.java
+++ b/bson/src/main/org/bson/json/StrictCharacterStreamJsonWriter.java
@@ -144,11 +144,11 @@ public final class StrictCharacterStreamJsonWriter implements StrictJsonWriter {
         if (settings.isIndent()) {
             write(settings.getNewLineCharacters());
             write(context.indentation);
-        } else {
+        } else if (context.hasElements){
             write(" ");
         }
         writeStringHelper(name);
-        write(" : ");
+        write(": ");
 
         state = State.VALUE;
     }
@@ -220,8 +220,6 @@ public final class StrictCharacterStreamJsonWriter implements StrictJsonWriter {
         if (settings.isIndent() && context.hasElements) {
             write(settings.getNewLineCharacters());
             write(context.parentContext.indentation);
-        } else {
-            write(" ");
         }
         write("}");
         context = context.parentContext;
@@ -240,6 +238,10 @@ public final class StrictCharacterStreamJsonWriter implements StrictJsonWriter {
             throw new BsonInvalidOperationException("Can't end an array if not in an array");
         }
 
+        if (settings.isIndent() && context.hasElements) {
+            write(settings.getNewLineCharacters());
+            write(context.parentContext.indentation);
+        }
         write("]");
         context = context.parentContext;
         if (context.contextType == JsonContextType.TOP_LEVEL) {
@@ -276,7 +278,13 @@ public final class StrictCharacterStreamJsonWriter implements StrictJsonWriter {
     private void preWriteValue() {
         if (context.contextType == JsonContextType.ARRAY) {
             if (context.hasElements) {
-                write(", ");
+                write(",");
+            }
+            if (settings.isIndent()) {
+                write(settings.getNewLineCharacters());
+                write(context.indentation);
+            } else if (context.hasElements) {
+                write(" ");
             }
         }
         context.hasElements = true;

--- a/bson/src/test/unit/org/bson/DocumentTest.java
+++ b/bson/src/test/unit/org/bson/DocumentTest.java
@@ -118,7 +118,7 @@ public class DocumentTest {
             // noop
         }
 
-        assertEquals("{ \"database\" : { \"name\" : \"MongoDB\" } }", customDocument.toJson(customDocumentCodec));
+        assertEquals("{\"database\": {\"name\": \"MongoDB\"}}", customDocument.toJson(customDocumentCodec));
     }
 
     public class Name {

--- a/bson/src/test/unit/org/bson/json/JsonWriterTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonWriterTest.java
@@ -177,7 +177,7 @@ public class JsonWriterTest {
     public void testEmptyDocument() {
         writer.writeStartDocument();
         writer.writeEndDocument();
-        String expected = "{ }";
+        String expected = "{}";
         assertEquals(expected, stringWriter.toString());
     }
 
@@ -187,7 +187,7 @@ public class JsonWriterTest {
         writer.writeName("s");
         writer.writeString("str");
         writer.writeEndDocument();
-        String expected = "{ \"s\" : \"str\" }";
+        String expected = "{\"s\": \"str\"}";
         assertEquals(expected, stringWriter.toString());
     }
 
@@ -199,7 +199,7 @@ public class JsonWriterTest {
         writer.writeName("d");
         writer.writeString("str2");
         writer.writeEndDocument();
-        String expected = "{ \"s\" : \"str\", \"d\" : \"str2\" }";
+        String expected = "{\"s\": \"str\", \"d\": \"str2\"}";
         assertEquals(expected, stringWriter.toString());
     }
 
@@ -215,7 +215,7 @@ public class JsonWriterTest {
         writer.writeEndDocument();
         writer.writeEndDocument();
         writer.writeEndDocument();
-        String expected = "{ \"doc\" : { \"doc\" : { \"s\" : \"str\" } } }";
+        String expected = "{\"doc\": {\"doc\": {\"s\": \"str\"}}}";
         assertEquals(expected, stringWriter.toString());
     }
 
@@ -224,7 +224,7 @@ public class JsonWriterTest {
         writer.writeStartDocument();
         writer.writeString("abc", "xyz");
         writer.writeEndDocument();
-        String expected = "{ \"abc\" : \"xyz\" }";
+        String expected = "{\"abc\": \"xyz\"}";
         assertEquals(expected, stringWriter.toString());
     }
 
@@ -234,7 +234,7 @@ public class JsonWriterTest {
         writer.writeStartDocument();
         writer.writeBoolean("abc", true);
         writer.writeEndDocument();
-        String expected = "{ \"abc\" : true }";
+        String expected = "{\"abc\": true}";
         assertEquals(expected, stringWriter.toString());
     }
 
@@ -265,7 +265,7 @@ public class JsonWriterTest {
             writer.writeStartDocument();
             writer.writeDouble("d", cur.value);
             writer.writeEndDocument();
-            String expected = "{ \"d\" : { \"$numberDouble\" : \"" + cur.expected + "\" } }";
+            String expected = "{\"d\": {\"$numberDouble\": \"" + cur.expected + "\"}}";
             assertEquals(expected, stringWriter.toString());
         }
     }
@@ -285,7 +285,7 @@ public class JsonWriterTest {
             writer.writeStartDocument();
             writer.writeInt64("l", cur.value);
             writer.writeEndDocument();
-            String expected = "{ \"l\" : " + cur.expected + " }";
+            String expected = "{\"l\": " + cur.expected + "}";
             assertEquals(expected, stringWriter.toString());
         }
     }
@@ -307,7 +307,7 @@ public class JsonWriterTest {
             writer.writeStartDocument();
             writer.writeInt64("l", cur.value);
             writer.writeEndDocument();
-            String expected = "{ \"l\" : { \"$numberLong\" : \"" + cur.expected + "\" } }";
+            String expected = "{\"l\": {\"$numberLong\": \"" + cur.expected + "\"}}";
             assertEquals(expected, stringWriter.toString());
         }
     }
@@ -325,7 +325,7 @@ public class JsonWriterTest {
             writer.writeStartDocument();
             writer.writeDecimal128("d", cur.value);
             writer.writeEndDocument();
-            String expected = "{ \"d\" : NumberDecimal(\"" + cur.expected + "\") }";
+            String expected = "{\"d\": NumberDecimal(\"" + cur.expected + "\")}";
             assertEquals(expected, stringWriter.toString());
         }
     }
@@ -344,7 +344,7 @@ public class JsonWriterTest {
             writer.writeStartDocument();
             writer.writeDecimal128("d", cur.value);
             writer.writeEndDocument();
-            String expected = "{ \"d\" : { \"$numberDecimal\" : \"" + cur.expected + "\" } }";
+            String expected = "{\"d\": {\"$numberDecimal\": \"" + cur.expected + "\"}}";
             assertEquals(expected, stringWriter.toString());
         }
     }
@@ -358,7 +358,7 @@ public class JsonWriterTest {
         writer.writeInt32(3);
         writer.writeEndArray();
         writer.writeEndDocument();
-        String expected = "{ \"array\" : [1, 2, 3] }";
+        String expected = "{\"array\": [1, 2, 3]}";
         assertEquals(expected, stringWriter.toString());
     }
 
@@ -366,27 +366,27 @@ public class JsonWriterTest {
     @SuppressWarnings("deprecation")
     public void testBinaryStrict() {
         List<TestData<BsonBinary>> tests = asList(new TestData<BsonBinary>(new BsonBinary(new byte[0]),
-                                                                   "{ \"$binary\" : \"\", "
-                                                                   + "\"$type\" : \"00\" }"),
-                                              new TestData<BsonBinary>(new BsonBinary(new byte[]{1}),
-                                                                   "{ \"$binary\" : \"AQ==\", "
-                                                                   + "\"$type\" : \"00\" }"),
-                                              new TestData<BsonBinary>(new BsonBinary(new byte[]{1, 2}),
-                                                                   "{ \"$binary\" : \"AQI=\", "
-                                                                   + "\"$type\" : \"00\" }"),
-                                              new TestData<BsonBinary>(new BsonBinary(new byte[]{1, 2, 3}),
-                                                                   "{ \"$binary\" : \"AQID\", "
-                                                                   + "\"$type\" : \"00\" }"),
-                                              new TestData<BsonBinary>(new BsonBinary((byte) 0x80, new byte[]{1, 2, 3}),
-                                                                   "{ \"$binary\" : \"AQID\", "
-                                                                   + "\"$type\" : \"80\" }"));
+                        "{\"$binary\": \"\", "
+                                + "\"$type\": \"00\"}"),
+                new TestData<BsonBinary>(new BsonBinary(new byte[]{1}),
+                        "{\"$binary\": \"AQ==\", "
+                                + "\"$type\": \"00\"}"),
+                new TestData<BsonBinary>(new BsonBinary(new byte[]{1, 2}),
+                        "{\"$binary\": \"AQI=\", "
+                                + "\"$type\": \"00\"}"),
+                new TestData<BsonBinary>(new BsonBinary(new byte[]{1, 2, 3}),
+                        "{\"$binary\": \"AQID\", "
+                                + "\"$type\": \"00\"}"),
+                new TestData<BsonBinary>(new BsonBinary((byte) 0x80, new byte[]{1, 2, 3}),
+                        "{\"$binary\": \"AQID\", "
+                                + "\"$type\": \"80\"}"));
         for (final TestData<BsonBinary> cur : tests) {
             stringWriter = new StringWriter();
             writer = new JsonWriter(stringWriter, JsonWriterSettings.builder().outputMode(JsonMode.STRICT).build());
             writer.writeStartDocument();
             writer.writeBinaryData("binary", cur.value);
             writer.writeEndDocument();
-            String expected = "{ \"binary\" : " + cur.expected + " }";
+            String expected = "{\"binary\": " + cur.expected + "}";
             assertEquals(expected, stringWriter.toString());
         }
     }
@@ -398,14 +398,14 @@ public class JsonWriterTest {
                 new TestData<BsonBinary>(new BsonBinary(new byte[]{1, 2}), "new BinData(0, \"AQI=\")"),
                 new TestData<BsonBinary>(new BsonBinary(new byte[]{1, 2, 3}), "new BinData(0, \"AQID\")"),
                 new TestData<BsonBinary>(new BsonBinary((byte) 0x80, new byte[]{1, 2, 3}),
-                                                "new BinData(128, \"AQID\")"));
+                        "new BinData(128, \"AQID\")"));
         for (final TestData<BsonBinary> cur : tests) {
             stringWriter = new StringWriter();
             writer = new JsonWriter(stringWriter, JsonWriterSettings.builder().outputMode(JsonMode.SHELL).build());
             writer.writeStartDocument();
             writer.writeBinaryData("binary", cur.value);
             writer.writeEndDocument();
-            String expected = "{ \"binary\" : " + cur.expected + " }";
+            String expected = "{\"binary\": " + cur.expected + "}";
             assertEquals(expected, stringWriter.toString());
         }
     }
@@ -413,16 +413,16 @@ public class JsonWriterTest {
     @Test
     @SuppressWarnings("deprecation")
     public void testDateTimeStrict() {
-        List<TestData<Date>> tests = asList(new TestData<Date>(new Date(0), "{ \"$date\" : 0 }"),
-                new TestData<Date>(new Date(Long.MAX_VALUE), "{ \"$date\" : 9223372036854775807 }"),
-                new TestData<Date>(new Date(Long.MIN_VALUE), "{ \"$date\" : -9223372036854775808 }"));
+        List<TestData<Date>> tests = asList(new TestData<Date>(new Date(0), "{\"$date\": 0}"),
+                new TestData<Date>(new Date(Long.MAX_VALUE), "{\"$date\": 9223372036854775807}"),
+                new TestData<Date>(new Date(Long.MIN_VALUE), "{\"$date\": -9223372036854775808}"));
         for (final TestData<Date> cur : tests) {
             stringWriter = new StringWriter();
             writer = new JsonWriter(stringWriter, JsonWriterSettings.builder().outputMode(JsonMode.STRICT).build());
             writer.writeStartDocument();
             writer.writeDateTime("date", cur.value.getTime());
             writer.writeEndDocument();
-            String expected = "{ \"date\" : " + cur.expected + " }";
+            String expected = "{\"date\": " + cur.expected + "}";
             assertEquals(expected, stringWriter.toString());
         }
     }
@@ -440,7 +440,7 @@ public class JsonWriterTest {
             writer.writeStartDocument();
             writer.writeDateTime("date", cur.value.getTime());
             writer.writeEndDocument();
-            String expected = "{ \"date\" : " + cur.expected + " }";
+            String expected = "{\"date\": " + cur.expected + "}";
             assertEquals(expected, stringWriter.toString());
         }
     }
@@ -450,7 +450,7 @@ public class JsonWriterTest {
         writer.writeStartDocument();
         writer.writeJavaScript("f", "function f() { return 1; }");
         writer.writeEndDocument();
-        String expected = "{ \"f\" : { \"$code\" : \"function f() { return 1; }\" } }";
+        String expected = "{\"f\": {\"$code\": \"function f() { return 1; }\"}}";
         assertEquals(expected, stringWriter.toString());
     }
 
@@ -463,7 +463,7 @@ public class JsonWriterTest {
         writer.writeEndDocument();
         writer.writeEndDocument();
         String expected =
-                "{ \"f\" : { \"$code\" : \"function f() { return n; }\", " + "\"$scope\" : { \"n\" : 1 } } }";
+                "{\"f\": {\"$code\": \"function f() { return n; }\", " + "\"$scope\": {\"n\": 1}}}";
         assertEquals(expected, stringWriter.toString());
     }
 
@@ -472,7 +472,7 @@ public class JsonWriterTest {
         writer.writeStartDocument();
         writer.writeMaxKey("maxkey");
         writer.writeEndDocument();
-        String expected = "{ \"maxkey\" : { \"$maxKey\" : 1 } }";
+        String expected = "{\"maxkey\": {\"$maxKey\": 1}}";
         assertEquals(expected, stringWriter.toString());
     }
 
@@ -481,7 +481,7 @@ public class JsonWriterTest {
         writer.writeStartDocument();
         writer.writeMinKey("minkey");
         writer.writeEndDocument();
-        String expected = "{ \"minkey\" : { \"$minKey\" : 1 } }";
+        String expected = "{\"minkey\": {\"$minKey\": 1}}";
         assertEquals(expected, stringWriter.toString());
     }
 
@@ -492,7 +492,7 @@ public class JsonWriterTest {
         writer.writeStartDocument();
         writer.writeMaxKey("maxkey");
         writer.writeEndDocument();
-        String expected = "{ \"maxkey\" : MaxKey }";
+        String expected = "{\"maxkey\": MaxKey}";
         assertEquals(expected, stringWriter.toString());
     }
 
@@ -502,7 +502,7 @@ public class JsonWriterTest {
         writer.writeStartDocument();
         writer.writeMinKey("minkey");
         writer.writeEndDocument();
-        String expected = "{ \"minkey\" : MinKey }";
+        String expected = "{\"minkey\": MinKey}";
         assertEquals(expected, stringWriter.toString());
     }
 
@@ -511,7 +511,7 @@ public class JsonWriterTest {
         writer.writeStartDocument();
         writer.writeNull("null");
         writer.writeEndDocument();
-        String expected = "{ \"null\" : null }";
+        String expected = "{\"null\": null}";
         assertEquals(expected, stringWriter.toString());
     }
 
@@ -524,7 +524,7 @@ public class JsonWriterTest {
         writer.writeObjectId("_id", objectId);
         writer.writeEndDocument();
 
-        String expected = "{ \"_id\" : ObjectId(\"4d0ce088e447ad08b4721a37\") }";
+        String expected = "{\"_id\": ObjectId(\"4d0ce088e447ad08b4721a37\")}";
         assertEquals(expected, stringWriter.toString());
     }
 
@@ -536,7 +536,7 @@ public class JsonWriterTest {
         writer.writeObjectId("_id", objectId);
         writer.writeEndDocument();
 
-        String expected = "{ \"_id\" : { \"$oid\" : \"4d0ce088e447ad08b4721a37\" } }";
+        String expected = "{\"_id\": {\"$oid\": \"4d0ce088e447ad08b4721a37\"}}";
         assertEquals(expected, stringWriter.toString());
     }
 
@@ -544,21 +544,21 @@ public class JsonWriterTest {
     public void testRegularExpressionShell() {
         List<TestData<BsonRegularExpression>> tests;
         tests = asList(new TestData<BsonRegularExpression>(new BsonRegularExpression(""), "/(?:)/"),
-                       new TestData<BsonRegularExpression>(new BsonRegularExpression("a"), "/a/"),
-                       new TestData<BsonRegularExpression>(new BsonRegularExpression("a/b"), "/a\\/b/"),
-                       new TestData<BsonRegularExpression>(new BsonRegularExpression("a\\b"), "/a\\b/"),
-                       new TestData<BsonRegularExpression>(new BsonRegularExpression("a", "i"), "/a/i"),
-                       new TestData<BsonRegularExpression>(new BsonRegularExpression("a", "m"), "/a/m"),
-                       new TestData<BsonRegularExpression>(new BsonRegularExpression("a", "x"), "/a/x"),
-                       new TestData<BsonRegularExpression>(new BsonRegularExpression("a", "s"), "/a/s"),
-                       new TestData<BsonRegularExpression>(new BsonRegularExpression("a", "imxs"), "/a/imsx"));
+                new TestData<BsonRegularExpression>(new BsonRegularExpression("a"), "/a/"),
+                new TestData<BsonRegularExpression>(new BsonRegularExpression("a/b"), "/a\\/b/"),
+                new TestData<BsonRegularExpression>(new BsonRegularExpression("a\\b"), "/a\\b/"),
+                new TestData<BsonRegularExpression>(new BsonRegularExpression("a", "i"), "/a/i"),
+                new TestData<BsonRegularExpression>(new BsonRegularExpression("a", "m"), "/a/m"),
+                new TestData<BsonRegularExpression>(new BsonRegularExpression("a", "x"), "/a/x"),
+                new TestData<BsonRegularExpression>(new BsonRegularExpression("a", "s"), "/a/s"),
+                new TestData<BsonRegularExpression>(new BsonRegularExpression("a", "imxs"), "/a/imsx"));
         for (final TestData<BsonRegularExpression> cur : tests) {
             stringWriter = new StringWriter();
             writer = new JsonWriter(stringWriter, JsonWriterSettings.builder().outputMode(JsonMode.SHELL).build());
             writer.writeStartDocument();
             writer.writeRegularExpression("regex", cur.value);
             writer.writeEndDocument();
-            String expected = "{ \"regex\" : " + cur.expected + " }";
+            String expected = "{\"regex\": " + cur.expected + "}";
             assertEquals(expected, stringWriter.toString());
         }
     }
@@ -567,41 +567,41 @@ public class JsonWriterTest {
     @SuppressWarnings("deprecation")
     public void testRegularExpressionStrict() {
         List<TestData<BsonRegularExpression>> tests;
-        tests = asList(new TestData<BsonRegularExpression>(new BsonRegularExpression(""), "{ \"$regex\" : \"\", "
-                                                                                  + "\"$options\" : \"\" "
-                                                                                  + "}"),
-                       new TestData<BsonRegularExpression>(new BsonRegularExpression("a"), "{ \"$regex\" : \"a\","
-                                                                                   + " \"$options\" : \"\" "
-                                                                                   + "}"),
-                       new TestData<BsonRegularExpression>(new BsonRegularExpression("a/b"), "{ \"$regex\" : "
-                                                                                     + "\"a/b\", "
-                                                                                     + "\"$options\" : \"\" "
-                                                                                     + "}"),
-                       new TestData<BsonRegularExpression>(new BsonRegularExpression("a\\b"), "{ \"$regex\" : "
-                                                                                      + "\"a\\\\b\", "
-                                                                                      + "\"$options\" : \"\" "
-                                                                                      + "}"),
-                       new TestData<BsonRegularExpression>(new BsonRegularExpression("a", "i"), "{ \"$regex\" : \"a\","
-                                                                                        + " \"$options\" : \"i\""
-                                                                                        + " }"),
-                       new TestData<BsonRegularExpression>(new BsonRegularExpression("a", "m"), "{ \"$regex\" : \"a\","
-                                                                                        + " \"$options\" : \"m\""
-                                                                                        + " }"),
-                       new TestData<BsonRegularExpression>(new BsonRegularExpression("a", "x"), "{ \"$regex\" : \"a\","
-                                                                                        + " \"$options\" : \"x\""
-                                                                                        + " }"),
-                       new TestData<BsonRegularExpression>(new BsonRegularExpression("a", "s"), "{ \"$regex\" : \"a\","
-                                                                                        + " \"$options\" : \"s\""
-                                                                                        + " }"),
-                       new TestData<BsonRegularExpression>(new BsonRegularExpression("a", "imxs"),
-                                                       "{ \"$regex\" : \"a\"," + " \"$options\" : \"imsx\" }"));
+        tests = asList(new TestData<BsonRegularExpression>(new BsonRegularExpression(""), "{\"$regex\": \"\", "
+                        + "\"$options\": \"\""
+                        + "}"),
+                new TestData<BsonRegularExpression>(new BsonRegularExpression("a"), "{\"$regex\": \"a\", "
+                        + "\"$options\": \"\""
+                        + "}"),
+                new TestData<BsonRegularExpression>(new BsonRegularExpression("a/b"), "{\"$regex\": "
+                        + "\"a/b\", "
+                        + "\"$options\": \"\""
+                        + "}"),
+                new TestData<BsonRegularExpression>(new BsonRegularExpression("a\\b"), "{\"$regex\": "
+                        + "\"a\\\\b\", "
+                        + "\"$options\": \"\""
+                        + "}"),
+                new TestData<BsonRegularExpression>(new BsonRegularExpression("a", "i"), "{\"$regex\": \"a\", "
+                        + "\"$options\": \"i\""
+                        + "}"),
+                new TestData<BsonRegularExpression>(new BsonRegularExpression("a", "m"), "{\"$regex\": \"a\", "
+                        + "\"$options\": \"m\""
+                        + "}"),
+                new TestData<BsonRegularExpression>(new BsonRegularExpression("a", "x"), "{\"$regex\": \"a\", "
+                        + "\"$options\": \"x\""
+                        + "}"),
+                new TestData<BsonRegularExpression>(new BsonRegularExpression("a", "s"), "{\"$regex\": \"a\", "
+                        + "\"$options\": \"s\""
+                        + "}"),
+                new TestData<BsonRegularExpression>(new BsonRegularExpression("a", "imxs"),
+                        "{\"$regex\": \"a\", " + "\"$options\": \"imsx\"}"));
         for (final TestData<BsonRegularExpression> cur : tests) {
             stringWriter = new StringWriter();
             writer = new JsonWriter(stringWriter, JsonWriterSettings.builder().outputMode(JsonMode.STRICT).build());
             writer.writeStartDocument();
             writer.writeRegularExpression("regex", cur.value);
             writer.writeEndDocument();
-            String expected = "{ \"regex\" : " + cur.expected + " }";
+            String expected = "{\"regex\": " + cur.expected + "}";
             assertEquals(expected, stringWriter.toString());
         }
     }
@@ -611,7 +611,7 @@ public class JsonWriterTest {
         writer.writeStartDocument();
         writer.writeSymbol("symbol", "name");
         writer.writeEndDocument();
-        String expected = "{ \"symbol\" : { \"$symbol\" : \"name\" } }";
+        String expected = "{\"symbol\": {\"$symbol\": \"name\"}}";
         assertEquals(expected, stringWriter.toString());
     }
 
@@ -621,7 +621,7 @@ public class JsonWriterTest {
         writer.writeStartDocument();
         writer.writeTimestamp("timestamp", new BsonTimestamp(1000, 1));
         writer.writeEndDocument();
-        String expected = "{ \"timestamp\" : { \"$timestamp\" : { \"t\" : 1000, \"i\" : 1 } } }";
+        String expected = "{\"timestamp\": {\"$timestamp\": {\"t\": 1000, \"i\": 1}}}";
         assertEquals(expected, stringWriter.toString());
     }
 
@@ -631,7 +631,7 @@ public class JsonWriterTest {
         writer.writeStartDocument();
         writer.writeTimestamp("timestamp", new BsonTimestamp(1000, 1));
         writer.writeEndDocument();
-        String expected = "{ \"timestamp\" : Timestamp(1000, 1) }";
+        String expected = "{\"timestamp\": Timestamp(1000, 1)}";
         assertEquals(expected, stringWriter.toString());
     }
 
@@ -642,7 +642,7 @@ public class JsonWriterTest {
         writer.writeStartDocument();
         writer.writeUndefined("undefined");
         writer.writeEndDocument();
-        String expected = "{ \"undefined\" : { \"$undefined\" : true } }";
+        String expected = "{\"undefined\": {\"$undefined\": true}}";
         assertEquals(expected, stringWriter.toString());
     }
 
@@ -652,7 +652,7 @@ public class JsonWriterTest {
         writer.writeStartDocument();
         writer.writeUndefined("undefined");
         writer.writeEndDocument();
-        String expected = "{ \"undefined\" : undefined }";
+        String expected = "{\"undefined\": undefined}";
         assertEquals(expected, stringWriter.toString());
     }
 
@@ -661,7 +661,7 @@ public class JsonWriterTest {
         writer.writeStartDocument();
         writer.writeDBPointer("dbPointer", new BsonDbPointer("my.test", new ObjectId("4d0ce088e447ad08b4721a37")));
         writer.writeEndDocument();
-        String expected = "{ \"dbPointer\" : { \"$ref\" : \"my.test\", \"$id\" : { \"$oid\" : \"4d0ce088e447ad08b4721a37\" } } }";
+        String expected = "{\"dbPointer\": {\"$ref\": \"my.test\", \"$id\": {\"$oid\": \"4d0ce088e447ad08b4721a37\"}}}";
         assertEquals(expected, stringWriter.toString());
     }
 }

--- a/bson/src/test/unit/org/bson/json/StrictCharacterStreamJsonWriterSpecification.groovy
+++ b/bson/src/test/unit/org/bson/json/StrictCharacterStreamJsonWriterSpecification.groovy
@@ -37,7 +37,7 @@ class StrictCharacterStreamJsonWriterSpecification extends Specification {
         writer.writeEndObject()
 
         then:
-        stringWriter.toString() == '{ }'
+        stringWriter.toString() == '{}'
     }
 
     def 'should write empty array'() {
@@ -56,18 +56,17 @@ class StrictCharacterStreamJsonWriterSpecification extends Specification {
         writer.writeEndObject()
 
         then:
-        stringWriter.toString() == '{ "n" : null }'
+        stringWriter.toString() == '{"n": null}'
     }
 
     def 'should write boolean'() {
         when:
         writer.writeStartObject()
         writer.writeBoolean('b1', true)
-        writer.writeBoolean('b2', false)
         writer.writeEndObject()
 
         then:
-        stringWriter.toString() == '{ "b1" : true, "b2" : false }'
+        stringWriter.toString() == '{"b1": true}'
     }
 
     def 'should write number'() {
@@ -77,7 +76,7 @@ class StrictCharacterStreamJsonWriterSpecification extends Specification {
         writer.writeEndObject()
 
         then:
-        stringWriter.toString() == '{ "n" : 42 }'
+        stringWriter.toString() == '{"n": 42}'
     }
 
     def 'should write string'() {
@@ -87,7 +86,7 @@ class StrictCharacterStreamJsonWriterSpecification extends Specification {
         writer.writeEndObject()
 
         then:
-        stringWriter.toString() == '{ "n" : "42" }'
+        stringWriter.toString() == '{"n": "42"}'
     }
 
     def 'should write unquoted string'() {
@@ -97,7 +96,7 @@ class StrictCharacterStreamJsonWriterSpecification extends Specification {
         writer.writeEndObject()
 
         then:
-        stringWriter.toString() == '{ "s" : NumberDecimal("42.0") }'
+        stringWriter.toString() == '{"s": NumberDecimal("42.0")}'
     }
 
     def 'should write document'() {
@@ -108,7 +107,7 @@ class StrictCharacterStreamJsonWriterSpecification extends Specification {
         writer.writeEndObject()
 
         then:
-        stringWriter.toString() == '{ "d" : { } }'
+        stringWriter.toString() == '{"d": {}}'
     }
 
     def 'should write array'() {
@@ -119,7 +118,7 @@ class StrictCharacterStreamJsonWriterSpecification extends Specification {
         writer.writeEndObject()
 
         then:
-        stringWriter.toString() == '{ "a" : [] }'
+        stringWriter.toString() == '{"a": []}'
     }
 
     def 'should write array of values'() {
@@ -133,7 +132,7 @@ class StrictCharacterStreamJsonWriterSpecification extends Specification {
         writer.writeEndObject()
 
         then:
-        stringWriter.toString() == '{ "a" : [1, null, "str"] }'
+        stringWriter.toString() == '{"a": [1, null, "str"]}'
     }
 
     def 'should write strings'() {
@@ -143,7 +142,7 @@ class StrictCharacterStreamJsonWriterSpecification extends Specification {
         writer.writeEndObject()
 
         then:
-        stringWriter.toString() == '{ "str" : ' + expected + ' }'
+        stringWriter.toString() == '{"str": ' + expected + '}'
 
         where:
         value                | expected
@@ -167,6 +166,17 @@ class StrictCharacterStreamJsonWriterSpecification extends Specification {
         '\u0080\u0081\u0082' | '"\\u0080\\u0081\\u0082"'
     }
 
+    def 'should write two object elements'() {
+        when:
+        writer.writeStartObject()
+        writer.writeBoolean('b1', true)
+        writer.writeBoolean('b2', false)
+        writer.writeEndObject()
+
+        then:
+        stringWriter.toString() == '{"b1": true, "b2": false}'
+    }
+
     def 'should indent one element'() {
         given:
         writer = new StrictCharacterStreamJsonWriter(stringWriter, StrictCharacterStreamJsonWriterSettings.builder().indent(true).build())
@@ -177,7 +187,7 @@ class StrictCharacterStreamJsonWriterSpecification extends Specification {
         writer.writeEndObject()
 
         then:
-        stringWriter.toString() == format('{%n  "name" : "value"%n}')
+        stringWriter.toString() == format('{%n  "name": "value"%n}')
     }
 
     def 'should indent one element with indent and newline characters'() {
@@ -194,7 +204,7 @@ class StrictCharacterStreamJsonWriterSpecification extends Specification {
         writer.writeEndObject()
 
         then:
-        stringWriter.toString() == format('{\r\t"name" : "value"\r}')
+        stringWriter.toString() == format('{\r\t"name": "value"\r}')
     }
 
     def 'should indent two elements'() {
@@ -208,7 +218,43 @@ class StrictCharacterStreamJsonWriterSpecification extends Specification {
         writer.writeEndObject()
 
         then:
-        stringWriter.toString() == format('{%n  "a" : "x",%n  "b" : "y"%n}')
+        stringWriter.toString() == format('{%n  "a": "x",%n  "b": "y"%n}')
+    }
+
+    def 'should indent two array elements'() {
+        given:
+        writer = new StrictCharacterStreamJsonWriter(stringWriter, StrictCharacterStreamJsonWriterSettings.builder().indent(true).build())
+
+        when:
+        writer.writeStartObject()
+        writer.writeStartArray('a')
+        writer.writeNull()
+        writer.writeNumber('4')
+        writer.writeEndArray()
+        writer.writeEndObject()
+
+        then:
+        stringWriter.toString() == format('{%n  "a": [%n    null,%n    4%n  ]%n}')
+    }
+
+    def 'should indent two document elements'() {
+        given:
+        writer = new StrictCharacterStreamJsonWriter(stringWriter, StrictCharacterStreamJsonWriterSettings.builder().indent(true).build())
+
+        when:
+        writer.writeStartObject()
+        writer.writeStartArray('a')
+        writer.writeStartObject()
+        writer.writeNull('a')
+        writer.writeEndObject()
+        writer.writeStartObject()
+        writer.writeNull('a')
+        writer.writeEndObject()
+        writer.writeEndArray()
+        writer.writeEndObject()
+
+        then:
+        stringWriter.toString() == format('{%n  "a": [%n    {%n      "a": null%n    },%n    {%n      "a": null%n    }%n  ]%n}')
     }
 
     def 'should indent embedded document'() {
@@ -224,7 +270,7 @@ class StrictCharacterStreamJsonWriterSpecification extends Specification {
         writer.writeEndObject()
 
         then:
-        stringWriter.toString() == format('{%n  "doc" : {%n    "a" : 1,%n    "b" : 2%n  }%n}')
+        stringWriter.toString() == format('{%n  "doc": {%n    "a": 1,%n    "b": 2%n  }%n}')
     }
 
     def shouldThrowExceptionForBooleanWhenWritingBeforeStartingDocument() {
@@ -480,7 +526,7 @@ class StrictCharacterStreamJsonWriterSpecification extends Specification {
 
     def shouldStopAtMaxLength() {
         given:
-        def fullJsonText = '{ "n" : null }'
+        def fullJsonText = '{"n": null}'
         writer = new StrictCharacterStreamJsonWriter(stringWriter,
                 StrictCharacterStreamJsonWriterSettings.builder().maxLength(maxLength).build())
 

--- a/bson/src/test/unit/org/bson/json/StrictCharacterStreamJsonWriterSpecification.groovy
+++ b/bson/src/test/unit/org/bson/json/StrictCharacterStreamJsonWriterSpecification.groovy
@@ -406,6 +406,29 @@ class StrictCharacterStreamJsonWriterSpecification extends Specification {
         thrown(BsonInvalidOperationException)
     }
 
+    def shouldThrowAnExceptionWhenStartingAnObjectWhenDone() {
+        given:
+        writer.writeStartObject()
+        writer.writeEndObject()
+
+        when:
+        writer.writeStartObject()
+
+        then:
+        thrown(BsonInvalidOperationException)
+    }
+
+    def shouldThrowAnExceptionWhenStartingAnObjectWhenNameIsExpected() {
+        given:
+        writer.writeStartObject()
+
+        when:
+        writer.writeStartObject()
+
+        then:
+        thrown(BsonInvalidOperationException)
+    }
+
     def shouldThrowAnExceptionWhenAttemptingToEndAnArrayThatWasNotStarted() {
         given:
         writer.writeStartObject()

--- a/driver-core/src/test/unit/com/mongodb/BasicDBObjectTest.java
+++ b/driver-core/src/test/unit/com/mongodb/BasicDBObjectTest.java
@@ -63,17 +63,17 @@ public class BasicDBObjectTest {
         BasicDBObject document = BasicDBObject.parse("{ '_id' : { '$oid' : '000000000000000000000000' }, 'int' : 1, 'string' : 'abc', "
                 + "'dbRef' : { $ref: 'collection', $id: { $oid: '01234567890123456789abcd' }, $db: 'db' } }");
 
-        assertEquals("{ \"_id\" : { \"$oid\" : \"000000000000000000000000\" }, \"int\" : 1, \"string\" : \"abc\", "
-                + "\"dbRef\" : { \"$ref\" : \"collection\", \"$id\" : { \"$oid\" : \"01234567890123456789abcd\" }, \"$db\" : \"db\" } }",
+        assertEquals("{\"_id\": {\"$oid\": \"000000000000000000000000\"}, \"int\": 1, \"string\": \"abc\", "
+                + "\"dbRef\": {\"$ref\": \"collection\", \"$id\": {\"$oid\": \"01234567890123456789abcd\"}, \"$db\": \"db\"}}",
                 document.toJson());
-        assertEquals("{ \"_id\" : ObjectId(\"000000000000000000000000\"), \"int\" : 1, \"string\" : \"abc\", "
-                + "\"dbRef\" : { \"$ref\" : \"collection\", \"$id\" : ObjectId(\"01234567890123456789abcd\"), \"$db\" : \"db\" } }",
+        assertEquals("{\"_id\": ObjectId(\"000000000000000000000000\"), \"int\": 1, \"string\": \"abc\", "
+                + "\"dbRef\": {\"$ref\": \"collection\", \"$id\": ObjectId(\"01234567890123456789abcd\"), \"$db\": \"db\"}}",
                 document.toJson(JsonWriterSettings.builder().outputMode(JsonMode.SHELL).build()));
-        assertEquals("{ \"_id\" : { \"$oid\" : \"000000000000000000000000\" }, \"int\" : 1, \"string\" : \"abc\", "
-                + "\"dbRef\" : { \"$ref\" : \"collection\", \"$id\" : { \"$oid\" : \"01234567890123456789abcd\" }, \"$db\" : \"db\" } }",
+        assertEquals("{\"_id\": {\"$oid\": \"000000000000000000000000\"}, \"int\": 1, \"string\": \"abc\", "
+                + "\"dbRef\": {\"$ref\": \"collection\", \"$id\": {\"$oid\": \"01234567890123456789abcd\"}, \"$db\": \"db\"}}",
                 document.toJson(DECODER));
-        assertEquals("{ \"_id\" : ObjectId(\"000000000000000000000000\"), \"int\" : 1, \"string\" : \"abc\", "
-                + "\"dbRef\" : { \"$ref\" : \"collection\", \"$id\" : ObjectId(\"01234567890123456789abcd\"), \"$db\" : \"db\" } }",
+        assertEquals("{\"_id\": ObjectId(\"000000000000000000000000\"), \"int\": 1, \"string\": \"abc\", "
+                + "\"dbRef\": {\"$ref\": \"collection\", \"$id\": ObjectId(\"01234567890123456789abcd\"), \"$db\": \"db\"}}",
                 document.toJson(JsonWriterSettings.builder().outputMode(JsonMode.SHELL).build(), DECODER));
     }
 

--- a/driver-core/src/test/unit/com/mongodb/MongoCommandExceptionSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/MongoCommandExceptionSpecification.groovy
@@ -57,10 +57,10 @@ class MongoCommandExceptionSpecification extends Specification {
                 .append('codeName', new BsonString('TimeoutError')).append('errmsg', new BsonString('the error message')),
                 new ServerAddress())
                 .getMessage() == 'Command failed with error 26 (TimeoutError): \'the error message\' on server 127.0.0.1:27017. ' +
-                'The full response is { "ok" : false, "code" : 26, "codeName" : "TimeoutError", "errmsg" : "the error message" }'
+                'The full response is {"ok": false, "code": 26, "codeName": "TimeoutError", "errmsg": "the error message"}'
         new MongoCommandException(new BsonDocument('ok', BsonBoolean.FALSE).append('code', new BsonInt32(26))
                 .append('errmsg', new BsonString('the error message')), new ServerAddress())
                 .getMessage() == 'Command failed with error 26: \'the error message\' on server 127.0.0.1:27017. ' +
-                'The full response is { "ok" : false, "code" : 26, "errmsg" : "the error message" }'
+                'The full response is {"ok": false, "code": 26, "errmsg": "the error message"}'
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/AggregatesSpecification.groovy
@@ -360,7 +360,7 @@ class AggregatesSpecification extends Specification {
 
     def 'should create string representation for simple stages'() {
         expect:
-        match(new BsonDocument('x', new BsonInt32(1))).toString() == 'Stage{name=\'$match\', value={ "x" : 1 }}'
+        match(new BsonDocument('x', new BsonInt32(1))).toString() == 'Stage{name=\'$match\', value={"x": 1}}'
     }
 
     def 'should create string representation for group stage'() {

--- a/driver-core/src/test/unit/com/mongodb/client/model/ProjectionsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/ProjectionsSpecification.groovy
@@ -93,9 +93,9 @@ class ProjectionsSpecification extends Specification {
 
     def 'should create string representation for include and exclude'() {
         expect:
-        include(['x', 'y', 'x']).toString() == '{ "y" : 1, "x" : 1 }'
-        exclude(['x', 'y', 'x']).toString() == '{ "y" : 0, "x" : 0 }'
-        excludeId().toString() == '{ "_id" : 0 }'
+        include(['x', 'y', 'x']).toString() == '{"y": 1, "x": 1}'
+        exclude(['x', 'y', 'x']).toString() == '{"y": 0, "x": 0}'
+        excludeId().toString() == '{"_id": 0}'
     }
 
     def 'should create string representation for computed'() {
@@ -112,7 +112,7 @@ class ProjectionsSpecification extends Specification {
 
     def 'should create string representation for fields'() {
         expect:
-        fields(include('x', 'y'), exclude('_id')).toString() == 'Projections{projections=[{ "x" : 1, "y" : 1 }, { "_id" : 0 }]}'
+        fields(include('x', 'y'), exclude('_id')).toString() == 'Projections{projections=[{"x": 1, "y": 1}, {"_id": 0}]}'
     }
 
     def toBson(Bson bson) {

--- a/driver-core/src/test/unit/com/mongodb/client/model/SortsSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/SortsSpecification.groovy
@@ -61,15 +61,15 @@ class SortsSpecification extends Specification {
 
     def 'should create string representation for simple sorts'() {
         expect:
-        ascending('x', 'y').toString() == '{ "x" : 1, "y" : 1 }'
-        descending('x', 'y').toString() == '{ "x" : -1, "y" : -1 }'
-        metaTextScore('x').toString() == '{ "x" : { "$meta" : "textScore" } }'
+        ascending('x', 'y').toString() == '{"x": 1, "y": 1}'
+        descending('x', 'y').toString() == '{"x": -1, "y": -1}'
+        metaTextScore('x').toString() == '{"x": {"$meta": "textScore"}}'
     }
 
     def 'should create string representation for compound sorts'() {
         expect:
         orderBy(ascending('x', 'y'), descending('a', 'b')).toString() ==
-                'Compound Sort{sorts=[{ "x" : 1, "y" : 1 }, { "a" : -1, "b" : -1 }]}'
+                'Compound Sort{sorts=[{"x": 1, "y": 1}, {"a": -1, "b": -1}]}'
     }
 
     def toBson(Bson bson) {

--- a/driver-core/src/test/unit/com/mongodb/client/model/UpdatesSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/client/model/UpdatesSpecification.groovy
@@ -195,7 +195,7 @@ class UpdatesSpecification extends Specification {
                 'options=Push Options{position=0, slice=3, sort=-1}}'
         pushEach('x', [89, 65], new PushOptions().position(0).slice(3).sortDocument(parse('{x : 1}'))).toString() ==
                 'Each Update{fieldName=\'x\', operator=\'$push\', values=[89, 65], ' +
-                'options=Push Options{position=0, slice=3, sortDocument={ "x" : 1 }}}'
+                'options=Push Options{position=0, slice=3, sortDocument={"x": 1}}}'
     }
 
     def 'should create string representation for pull all update'() {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/LoggingCommandEventSenderSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/LoggingCommandEventSenderSpecification.groovy
@@ -104,7 +104,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
 
         then:
         1 * logger.debug {
-            it == "Sending command \'{ \"ping\" : 1, \"\$db\" : \"test\" }\' with request id ${message.getId()} to database test " +
+            it == "Sending command \'{\"ping\": 1, \"\$db\": \"test\"}\' with request id ${message.getId()} to database test " +
                     "on connection [connectionId{localValue:${connectionDescription.connectionId.localValue}}] " +
                     'to server 127.0.0.1:27017'
         }
@@ -148,7 +148,7 @@ class LoggingCommandEventSenderSpecification extends Specification {
 
         then:
         1 * logger.debug {
-            it == "Sending command \'{ \"fake\" : { \"\$binary\" : { \"base64\" : \"${'A' * 961} ...\' " +
+            it == "Sending command \'{\"fake\": {\"\$binary\": {\"base64\": \"${'A' * 967} ...\' " +
                     "with request id ${message.getId()} to database test " +
                     "on connection [connectionId{localValue:${connectionDescription.connectionId.localValue}}] " +
                     'to server 127.0.0.1:27017'

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/NativeAuthenticatorUnitTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/NativeAuthenticatorUnitTest.java
@@ -117,9 +117,9 @@ public class NativeAuthenticatorUnitTest {
 
         String secondCommand = MessageHelper.decodeCommandAsJson(sent.get(1));
 
-        assertEquals("{ \"getnonce\" : 1 }", firstCommand);
-        assertEquals("{ \"authenticate\" : 1, \"user\" : \"\u53f0\u5317\", "
-                     + "\"nonce\" : \"2375531c32080ae8\", "
-                     + "\"key\" : \"4fb55df196e38eea50d2b8b200acfa8b\" }", secondCommand);
+        assertEquals("{\"getnonce\": 1}", firstCommand);
+        assertEquals("{\"authenticate\": 1, \"user\": \"\u53f0\u5317\", "
+                     + "\"nonce\": \"2375531c32080ae8\", "
+                     + "\"key\": \"4fb55df196e38eea50d2b8b200acfa8b\"}", secondCommand);
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/PlainAuthenticatorUnitTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/PlainAuthenticatorUnitTest.java
@@ -68,9 +68,9 @@ public class PlainAuthenticatorUnitTest {
     private void validateMessages() {
         List<BsonInput> sent = connection.getSent();
         String command = MessageHelper.decodeCommandAsJson(sent.get(0));
-        String expectedCommand = "{ \"saslStart\" : 1, "
-                                 + "\"mechanism\" : \"PLAIN\", "
-                                 + "\"payload\" : { \"$binary\" : \"dXNlcgB1c2VyAHBlbmNpbA==\", \"$type\" : \"00\" } }";
+        String expectedCommand = "{\"saslStart\": 1, "
+                                 + "\"mechanism\": \"PLAIN\", "
+                                 + "\"payload\": {\"$binary\": \"dXNlcgB1c2VyAHBlbmNpbA==\", \"$type\": \"00\"}}";
 
         assertEquals(expectedCommand, command);
     }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/X509AuthenticatorNoUserNameTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/X509AuthenticatorNoUserNameTest.java
@@ -106,7 +106,7 @@ public class X509AuthenticatorNoUserNameTest {
     private void validateMessages() {
         List<BsonInput> sent = connection.getSent();
         String command = MessageHelper.decodeCommandAsJson(sent.get(0));
-        assertEquals("{ \"authenticate\" : 1, \"mechanism\" : \"MONGODB-X509\" }", command);
+        assertEquals("{\"authenticate\": 1, \"mechanism\": \"MONGODB-X509\"}", command);
     }
 
     private MongoCredentialWithCache getCredentialWithCache() {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/X509AuthenticatorUnitTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/X509AuthenticatorUnitTest.java
@@ -111,9 +111,9 @@ public class X509AuthenticatorUnitTest {
     private void validateMessages() {
         List<BsonInput> sent = connection.getSent();
         String command = MessageHelper.decodeCommandAsJson(sent.get(0));
-        String expectedCommand = "{ \"authenticate\" : 1, "
-                + "\"user\" : \"CN=client,OU=kerneluser,O=10Gen,L=New York City,ST=New York,C=US\", "
-                + "\"mechanism\" : \"MONGODB-X509\" }";
+        String expectedCommand = "{\"authenticate\": 1, "
+                + "\"user\": \"CN=client,OU=kerneluser,O=10Gen,L=New York City,ST=New York,C=US\", "
+                + "\"mechanism\": \"MONGODB-X509\"}";
 
         assertEquals(expectedCommand, command);
     }


### PR DESCRIPTION
Change JSON whitespace generation to be more consistent with other popular JSON generation libraries:

  1. Omit space before ":"
  2. Omit space after "{" and before "}"
  3. Add newline/indent after each array element

https://jira.mongodb.org/browse/JAVA-3085