### PR TITLE
Add Java 11 to the testing matrix.

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -554,6 +554,10 @@ axes:
   - id: jdk
     display_name: JDK
     values:
+      - id: "jdk11"
+        display_name: JDK11
+        variables:
+          JDK: "jdk11"
       - id: "jdk9"
         display_name: JDK9
         variables:
@@ -609,8 +613,8 @@ buildvariants:
   tasks:
      - name: "test"
 
-- matrix_name: "tests-jdk8-secure"
-  matrix_spec: { auth: "auth", ssl: "ssl", jdk: "jdk8", version: ["4.0", "latest"], topology: "*", os: "linux" }
+- matrix_name: "tests-jdk-newer-secure"
+  matrix_spec: { auth: "auth", ssl: "ssl", jdk: ["jdk8", "jdk11"], version: ["4.0", "latest"], topology: "*", os: "linux" }
   display_name: "${version} ${topology} ${auth} ${ssl} ${jdk} ${os} "
   tags: ["tests-variant"]
   tasks:


### PR DESCRIPTION
Execute the same matrix for Java 11 as we do for Java 8

JAVA-3113

Patch build: https://evergreen.mongodb.com/version/5c2eb387e3c33184cc840278