### PR TITLE
Make DefaultServer.invalidate a no-op when server is closed

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultServer.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultServer.java
@@ -122,14 +122,14 @@ class DefaultServer implements ClusterableServer {
 
     @Override
     public void invalidate() {
-        isTrue("open", !isClosed());
-
-        serverStateListener.stateChanged(new ChangeEvent<ServerDescription>(description, ServerDescription.builder()
-                                                                                                          .state(CONNECTING)
-                                                                                                          .address(serverId.getAddress())
-                .build()));
-        connectionPool.invalidate();
-        connect();
+        if (!isClosed()) {
+            serverStateListener.stateChanged(new ChangeEvent<ServerDescription>(description, ServerDescription.builder()
+                    .state(CONNECTING)
+                    .address(serverId.getAddress())
+                    .build()));
+            connectionPool.invalidate();
+            connect();
+        }
     }
 
     @Override

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultConnectionPoolSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultConnectionPoolSpecification.groovy
@@ -466,6 +466,19 @@ class DefaultConnectionPoolSpecification extends Specification {
         thrown(MongoWaitQueueFullException)
     }
 
+    def 'invalidate should do nothing when pool is closed'() {
+        given:
+        pool = new DefaultConnectionPool(SERVER_ID, connectionFactory,
+                builder().maxSize(1).maxWaitQueueSize(1).build())
+        pool.close()
+
+        when:
+        pool.invalidate()
+
+        then:
+        noExceptionThrown()
+    }
+
     def selectConnectionAsyncAndGet(DefaultConnectionPool pool) {
         selectConnectionAsync(pool).get()
     }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultServerSpecification.groovy
@@ -136,6 +136,28 @@ class DefaultServerSpecification extends Specification {
         server?.close()
     }
 
+    def 'invalidate should do nothing when server is closed'() {
+        given:
+        def clusterTime = new ClusterClock()
+        def connectionPool = Mock(ConnectionPool)
+        def connectionFactory = Mock(ConnectionFactory)
+        def serverMonitorFactory = Stub(ServerMonitorFactory)
+        def serverMonitor = Mock(ServerMonitor)
+        connectionPool.get() >> { throw exceptionToThrow }
+        serverMonitorFactory.create(_) >> { serverMonitor }
+
+        def server = new DefaultServer(serverId, SINGLE, connectionPool, connectionFactory, serverMonitorFactory,
+                NO_OP_SERVER_LISTENER, null, clusterTime)
+        server.close()
+
+        when:
+        server.invalidate()
+
+        then:
+        0 * connectionPool.invalidate()
+        0 * serverMonitor.connect()
+    }
+
     def 'failed open should invalidate the server'() {
         given:
         def clusterTime = new ClusterClock()


### PR DESCRIPTION
This method can easily be called in situations where the server instance
is already called, and having it throw an IllegalStateException in that
situation is not the desired behavior.

JAVA-3130