### PR TITLE
Add support for new TLS-related connection string options

### DIFF
--- a/driver-core/src/test/resources/uri-options/README.rst
+++ b/driver-core/src/test/resources/uri-options/README.rst
@@ -1,0 +1,52 @@
+=======================
+URI Options Tests
+=======================
+
+The YAML and JSON files in this directory tree are platform-independent tests
+that drivers can use to prove their conformance to the URI Options spec.
+
+These tests use the same format as the Connection String spec tests.
+
+Version
+-------
+
+Files in the "specifications" repository have no version scheme. They are not
+tied to a MongoDB server version.
+
+Format
+------
+
+Each YAML file contains an object with a single ``tests`` key. This key is an
+array of test case objects, each of which have the following keys:
+
+- ``description``: A string describing the test.
+- ``uri``: A string containing the URI to be parsed.
+- ``valid``: A boolean indicating if the URI should be considered valid. 
+  This will always be true, as the Connection String spec tests the validity of the structure, but 
+  it's still included to make it easier to reuse the connection string spec test runners that 
+  drivers already have.
+- ``warning``: A boolean indicating whether URI parsing should emit a warning.
+- ``hosts``: Included for compatibility with the Connection String spec tests. This will always be ``~``.
+- ``auth``: Included for compatibility with the Connection String spec tests. This will always be ``~``.
+- ``options``: An object containing key/value pairs for each parsed query string
+  option.
+
+If a test case includes a null value for one of these keys (e.g. ``auth: ~``,
+``hosts: ~``), no assertion is necessary. This both simplifies parsing of the
+test files (keys should always exist) and allows flexibility for drivers that
+might substitute default values *during* parsing (e.g. omitted ``hosts`` could be
+parsed as ``["localhost"]``).
+
+The ``valid`` and ``warning`` fields are boolean in order to keep the tests
+flexible. We are not concerned with asserting the format of specific error or
+warnings messages strings.
+
+Use as unit tests
+=================
+
+Testing whether a URI is valid or not requires testing whether URI parsing (or
+MongoClient construction) causes a warning due to a URI option being valid and asserting that the 
+options parsed from the URI match those listed in the ``options`` field.
+
+Note that there are tests for each of the options marked as optional; drivers will need to implement
+logic to skip over the optional tests that they don’t implement.

--- a/driver-core/src/test/resources/uri-options/auth-options.json
+++ b/driver-core/src/test/resources/uri-options/auth-options.json
@@ -1,0 +1,20 @@
+{
+  "tests": [
+    {
+      "description": "Valid auth options are parsed correctly",
+      "uri": "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authSource=$external",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "authMechanism": "GSSAPI",
+        "authMechanismProperties": {
+          "SERVICE_NAME": "other",
+          "CANONICALIZE_HOST_NAME": true
+        },
+        "authSource": "$external"
+      }
+    }
+  ]
+}

--- a/driver-core/src/test/resources/uri-options/compression-options.json
+++ b/driver-core/src/test/resources/uri-options/compression-options.json
@@ -1,0 +1,59 @@
+{
+  "tests": [
+    {
+      "description": "Valid compression options are parsed correctly",
+      "uri": "mongodb://example.com/?compressors=zlib&zlibCompressionLevel=9",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "compressors": [
+          "zlib"
+        ],
+        "zlibCompressionLevel": 9
+      }
+    },
+    {
+      "description": "Multiple compressors are parsed correctly",
+      "uri": "mongodb://example.com/?compressors=snappy,zlib",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "compressors": [
+          "snappy",
+          "zlib"
+        ]
+      }
+    },
+    {
+      "description": "Non-numeric zlibCompressionLevel causes a warning",
+      "uri": "mongodb://example.com/?compressors=zlib&zlibCompressionLevel=invalid",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "Too low zlibCompressionLevel causes a warning",
+      "uri": "mongodb://example.com/?compressors=zlib&zlibCompressionLevel=-2",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "Too high zlibCompressionLevel causes a warning",
+      "uri": "mongodb://example.com/?compressors=zlib&zlibCompressionLevel=10",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    }
+  ]
+}

--- a/driver-core/src/test/resources/uri-options/concern-options.json
+++ b/driver-core/src/test/resources/uri-options/concern-options.json
@@ -1,0 +1,76 @@
+{
+  "tests": [
+    {
+      "description": "Valid read and write concern are parsed correctly",
+      "uri": "mongodb://example.com/?readConcernLevel=majority&w=5&wTimeoutMS=30000&journal=false",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "readConcernLevel": "majority",
+        "w": 5,
+        "wTimeoutMS": 30000,
+        "journal": false
+      }
+    },
+    {
+      "description": "Arbitrary string readConcernLevel does not cause a warning",
+      "uri": "mongodb://example.com/?readConcernLevel=arbitraryButStillValid",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "readConcernLevel": "arbitraryButStillValid"
+      }
+    },
+    {
+      "description": "Arbitrary string w doesn't cause a warning",
+      "uri": "mongodb://example.com/?w=arbitraryButStillValid",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "w": "arbitraryButStillValid"
+      }
+    },
+    {
+      "description": "Too low w causes a warning",
+      "uri": "mongodb://example.com/?w=-2",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "Non-numeric wTimeoutMS causes a warning",
+      "uri": "mongodb://example.com/?wTimeoutMS=invalid",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "Too low wTimeoutMS causes a warning",
+      "uri": "mongodb://example.com/?wTimeoutMS=-2",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "Invalid journal causes a warning",
+      "uri": "mongodb://example.com/?journal=invalid",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    }
+  ]
+}

--- a/driver-core/src/test/resources/uri-options/connection-options.json
+++ b/driver-core/src/test/resources/uri-options/connection-options.json
@@ -1,0 +1,122 @@
+{
+  "tests": [
+    {
+      "description": "Valid connection and timeout options are parsed correctly",
+      "uri": "mongodb://example.com/?appname=URI-OPTIONS-SPEC-TEST&connectTimeoutMS=20000&heartbeatFrequencyMS=5000&localThresholdMS=3000&maxIdleTimeMS=50000&replicaSet=uri-options-spec&retryWrites=true&serverSelectionTimeoutMS=15000&socketTimeoutMS=7500",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "appname": "URI-OPTIONS-SPEC-TEST",
+        "connectTimeoutMS": 20000,
+        "heartbeatFrequencyMS": 5000,
+        "localThresholdMS": 3000,
+        "maxIdleTimeMS": 50000,
+        "replicaSet": "uri-options-spec",
+        "retryWrites": true,
+        "serverSelectionTimeoutMS": 15000,
+        "socketTimeoutMS": 7500
+      }
+    },
+    {
+      "description": "Non-numeric connectTimeoutMS causes a warning",
+      "uri": "mongodb://example.com/?connectTimeoutMS=invalid",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "Too low connectTimeoutMS causes a warning",
+      "uri": "mongodb://example.com/?connectTimeoutMS=-2",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "Non-numeric heartbeatFrequencyMS causes a warning",
+      "uri": "mongodb://example.com/?heartbeatFrequencyMS=invalid",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "Too low heartbeatFrequencyMS causes a warning",
+      "uri": "mongodb://example.com/?heartbeatFrequencyMS=-2",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "Non-numeric localThresholdMS causes a warning",
+      "uri": "mongodb://example.com/?localThresholdMS=invalid",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "Too low localThresholdMS causes a warning",
+      "uri": "mongodb://example.com/?localThresholdMS=-2",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "Invalid retryWrites causes a warning",
+      "uri": "mongodb://example.com/?retryWrites=invalid",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "Non-numeric serverSelectionTimeoutMS causes a warning",
+      "uri": "mongodb://example.com/?serverSelectionTimeoutMS=invalid",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "Too low serverSelectionTimeoutMS causes a warning",
+      "uri": "mongodb://example.com/?serverSelectionTimeoutMS=-2",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "Non-numeric socketTimeoutMS causes a warning",
+      "uri": "mongodb://example.com/?socketTimeoutMS=invalid",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "Too low socketTimeoutMS causes a warning",
+      "uri": "mongodb://example.com/?socketTimeoutMS=-2",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    }
+  ]
+}

--- a/driver-core/src/test/resources/uri-options/connection-pool-options.json
+++ b/driver-core/src/test/resources/uri-options/connection-pool-options.json
@@ -1,0 +1,33 @@
+{
+  "tests": [
+    {
+      "description": "Valid connection pool options are parsed correctly",
+      "uri": "mongodb://example.com/?maxIdleTimeMS=50000",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "maxIdleTimeMS": 50000
+      }
+    },
+    {
+      "description": "Non-numeric maxIdleTimeMS causes a warning",
+      "uri": "mongodb://example.com/?maxIdleTimeMS=invalid",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "Too low maxIdleTimeMS causes a warning",
+      "uri": "mongodb://example.com/?maxIdleTimeMS=-2",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    }
+  ]
+}

--- a/driver-core/src/test/resources/uri-options/read-preference-options.json
+++ b/driver-core/src/test/resources/uri-options/read-preference-options.json
@@ -1,0 +1,52 @@
+{
+  "tests": [
+    {
+      "description": "Valid read preference options are parsed correctly",
+      "uri": "mongodb://example.com/?readPreference=primaryPreferred&readPreferenceTags=dc:ny,rack:1&maxStalenessSeconds=120&readPreferenceTags=dc:ny",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "readPreference": "primaryPreferred",
+        "readPreferenceTags": [
+          {
+            "dc": "ny",
+            "rack": "1"
+          },
+          {
+            "dc": "ny"
+          }
+        ],
+        "maxStalenessSeconds": 120
+      }
+    },
+    {
+      "description": "Invalid readPreferenceTags causes a warning",
+      "uri": "mongodb://example.com/?readPreferenceTags=invalid",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "Non-numeric maxStalenessSeconds causes a warning",
+      "uri": "mongodb://example.com/?maxStalenessSeconds=invalid",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "Too low maxStalenessSeconds causes a warning",
+      "uri": "mongodb://example.com/?maxStalenessSeconds=-2",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    }
+  ]
+}

--- a/driver-core/src/test/resources/uri-options/single-threaded-options.json
+++ b/driver-core/src/test/resources/uri-options/single-threaded-options.json
@@ -1,0 +1,24 @@
+{
+  "tests": [
+    {
+      "description": "Valid options specific to single-threaded drivers are parsed correctly",
+      "uri": "mongodb://example.com/?serverSelectionTryOnce=false",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "serverSelectionTryOnce": false
+      }
+    },
+    {
+      "description": "Invalid serverSelectionTryOnce causes a warning",
+      "uri": "mongodb://example.com/?serverSelectionTryOnce=invalid",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    }
+  ]
+}

--- a/driver-core/src/test/resources/uri-options/tls-options.json
+++ b/driver-core/src/test/resources/uri-options/tls-options.json
@@ -1,0 +1,105 @@
+{
+  "tests": [
+    {
+      "description": "Valid required tls options are parsed correctly",
+      "uri": "mongodb://example.com/?tls=true&tlsCAFile=ca.pem&tlsCertificateKeyFile=cert.pem&tlsCertificateKeyFilePassword=hunter2",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "tls": true,
+        "tlsCAFile": "ca.pem",
+        "tlsCertificateKeyFile": "cert.pem",
+        "tlsCertificateKeyFilePassword": "hunter2"
+      }
+    },
+    {
+      "description": "Invalid tlsAllowInvalidCertificates causes a warning",
+      "uri": "mongodb://example.com/?tlsAllowInvalidCertificates=invalid",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsAllowInvalidCertificates is parsed correctly",
+      "uri": "mongodb://example.com/?tlsAllowInvalidCertificates=true",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "tlsAllowInvalidCertificates": true
+      }
+    },
+    {
+      "description": "Invalid tlsAllowInvalidCertificates causes a warning",
+      "uri": "mongodb://example.com/?tlsAllowInvalidCertificates=invalid",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsAllowInvalidHostnames is parsed correctly",
+      "uri": "mongodb://example.com/?tlsAllowInvalidHostnames=true",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "tlsAllowInvalidHostnames": true
+      }
+    },
+    {
+      "description": "Invalid tlsAllowInvalidHostnames causes a warning",
+      "uri": "mongodb://example.com/?tlsAllowInvalidHostnames=invalid",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsInsecure is parsed correctly",
+      "uri": "mongodb://example.com/?tlsInsecure=true",
+      "valid": true,
+      "warning": false,
+      "hosts": null,
+      "auth": null,
+      "options": {
+        "tlsInsecure": true
+      }
+    },
+    {
+      "description": "Invalid tlsAllowInsecure causes a warning",
+      "uri": "mongodb://example.com/?tlsAllowInsecure=invalid",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsInsecure=true and tlsAllowInvalidCertificates=false warns",
+      "uri": "mongodb://example.com/?tlsInsecure=true&tlsAllowInvalidCertificates=false",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    },
+    {
+      "description": "tlsInsecure=true and tlsAllowInvalidHostnames=false warns",
+      "uri": "mongodb://example.com/?tlsInsecure=true&tlsAllowInvalidHostnames=false",
+      "valid": true,
+      "warning": true,
+      "hosts": null,
+      "auth": null,
+      "options": {}
+    }
+  ]
+}

--- a/driver-core/src/test/unit/com/mongodb/AbstractConnectionStringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/AbstractConnectionStringTest.java
@@ -34,9 +34,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-// See https://github.com/mongodb/specifications/tree/master/source/connection-string/tests
 @RunWith(Parameterized.class)
-public class AbstractConnectionStringTest extends TestCase {
+public abstract class AbstractConnectionStringTest extends TestCase {
     private final String filename;
     private final String description;
     private final String input;
@@ -50,47 +49,15 @@ public class AbstractConnectionStringTest extends TestCase {
         this.definition = definition;
     }
 
-    @Test
-    public void shouldPassAllOutcomes() {
-        if (filename.equals("invalid-uris.json")) {
-            testInvalidUris();
-        } else if (filename.equals("valid-auth.json")) {
-            testValidAuth();
-        } else if (filename.equals("valid-db-with-dotted-name.json")) {
-            testValidHostIdentifiers();
-            testValidAuth();
-        } else if (filename.equals("valid-host_identifiers.json")) {
-            testValidHostIdentifiers();
-        } else if (filename.equals("valid-options.json")) {
-            testValidOptions();
-        } else if (filename.equals("valid-unix_socket-absolute.json")) {
-            testValidHostIdentifiers();
-        } else if (filename.equals("valid-unix_socket-relative.json")) {
-            testValidHostIdentifiers();
-        } else if (filename.equals("valid-warnings.json")) {
-            testValidHostIdentifiers();
-            if (!definition.get("options").isNull()) {
-                testValidOptions();
-            }
-        } else {
-            throw new IllegalArgumentException("Unsupported file: " + filename);
-        }
+    protected String getFilename() {
+        return filename;
     }
 
-    @Parameterized.Parameters(name = "{1}")
-    public static Collection<Object[]> data() throws URISyntaxException, IOException {
-        List<Object[]> data = new ArrayList<Object[]>();
-        for (File file : JsonPoweredTestHelper.getTestFiles("/connection-string")) {
-            BsonDocument testDocument = JsonPoweredTestHelper.getTestDocument(file);
-            for (BsonValue test : testDocument.getArray("tests")) {
-                data.add(new Object[]{file.getName(), test.asDocument().getString("description").getValue(),
-                        test.asDocument().getString("uri").getValue(), test.asDocument()});
-            }
-        }
-        return data;
+    protected BsonDocument getDefinition() {
+        return definition;
     }
 
-    private void testInvalidUris() {
+    protected void testInvalidUris() {
         Throwable expectedError = null;
 
         try {
@@ -103,7 +70,7 @@ public class AbstractConnectionStringTest extends TestCase {
                 expectedError instanceof IllegalArgumentException);
     }
 
-    private void testValidHostIdentifiers() {
+    protected void testValidHostIdentifiers() {
         ConnectionString connectionString = null;
         try {
             connectionString = new ConnectionString(input);
@@ -114,7 +81,7 @@ public class AbstractConnectionStringTest extends TestCase {
         assertExpectedHosts(connectionString.getHosts());
     }
 
-    private void testValidOptions() {
+    protected void testValidOptions() {
         ConnectionString connectionString = null;
 
         try {
@@ -140,7 +107,7 @@ public class AbstractConnectionStringTest extends TestCase {
         }
     }
 
-    private void testValidAuth() {
+    protected void testValidAuth() {
         ConnectionString connectionString = null;
 
         try {

--- a/driver-core/src/test/unit/com/mongodb/AbstractConnectionStringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/AbstractConnectionStringTest.java
@@ -36,14 +36,14 @@ import java.util.concurrent.TimeUnit;
 
 // See https://github.com/mongodb/specifications/tree/master/source/connection-string/tests
 @RunWith(Parameterized.class)
-public class ConnectionStringTest extends TestCase {
+public class AbstractConnectionStringTest extends TestCase {
     private final String filename;
     private final String description;
     private final String input;
     private final BsonDocument definition;
 
-    public ConnectionStringTest(final String filename, final String description, final String input,
-                                final BsonDocument definition) {
+    public AbstractConnectionStringTest(final String filename, final String description, final String input,
+                                        final BsonDocument definition) {
         this.filename = filename;
         this.description = description;
         this.input = input;

--- a/driver-core/src/test/unit/com/mongodb/ConnectionStringSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/ConnectionStringSpecification.groovy
@@ -195,6 +195,110 @@ class ConnectionStringSpecification extends Specification {
         type << ['amp', 'semi', 'mixed']
     }
 
+    def 'should parse options to enable TLS'() {
+        when:
+        def connectionString = new ConnectionString('mongodb://localhost/?ssl=false')
+
+        then:
+        connectionString.getSslEnabled() == false
+
+        when:
+        connectionString = new ConnectionString('mongodb://localhost/?ssl=true')
+
+        then:
+        connectionString.getSslEnabled()
+
+        when:
+        connectionString = new ConnectionString('mongodb://localhost/?tls=false')
+
+        then:
+        connectionString.getSslEnabled() == false
+
+        when:
+        connectionString = new ConnectionString('mongodb://localhost/?tls=true')
+
+        then:
+        connectionString.getSslEnabled()
+
+        when:
+        connectionString = new ConnectionString('mongodb://localhost/?tls=true&ssl=false')
+
+        then:
+        connectionString.getSslEnabled()
+
+        when:
+        connectionString = new ConnectionString('mongodb://localhost/?tls=false&ssl=true')
+
+        then:
+        connectionString.getSslEnabled() == false
+    }
+
+    def 'should parse options to enable TLS invalid host names'() {
+        when:
+        def connectionString = new ConnectionString('mongodb://localhost/?ssl=true&sslInvalidHostNameAllowed=false')
+
+        then:
+        connectionString.getSslInvalidHostnameAllowed() == false
+
+        when:
+        connectionString = new ConnectionString('mongodb://localhost/?ssl=true&sslInvalidHostNameAllowed=true')
+
+        then:
+        connectionString.getSslInvalidHostnameAllowed()
+
+        when:
+        connectionString = new ConnectionString('mongodb://localhost/?tls=true&tlsAllowInvalidHostnames=false')
+
+        then:
+        connectionString.getSslInvalidHostnameAllowed() == false
+
+        when:
+        connectionString = new ConnectionString('mongodb://localhost/?tls=true&tlsAllowInvalidHostnames=true')
+
+        then:
+        connectionString.getSslInvalidHostnameAllowed()
+
+        when:
+        connectionString = new ConnectionString(
+                'mongodb://localhost/?tls=true&tlsAllowInvalidHostnames=false&sslInvalidHostNameAllowed=true')
+
+        then:
+        connectionString.getSslInvalidHostnameAllowed() == false
+
+        when:
+        connectionString = new ConnectionString(
+                'mongodb://localhost/?tls=true&tlsAllowInvalidHostnames=true&sslInvalidHostNameAllowed=false')
+
+        then:
+        connectionString.getSslInvalidHostnameAllowed()
+    }
+
+    def 'should parse options to enable unsecured TLS'() {
+        when:
+        def connectionString = new ConnectionString('mongodb://localhost/?tls=true&tlsInsecure=true')
+
+        then:
+        connectionString.getSslInvalidHostnameAllowed()
+
+        when:
+        connectionString = new ConnectionString('mongodb://localhost/?tls=true&tlsInsecure=false')
+
+        then:
+        connectionString.getSslInvalidHostnameAllowed() == false
+
+        when:
+        connectionString = new ConnectionString('mongodb://localhost/?tls=true&tlsInsecure=true&tlsAllowInvalidHostnames=false')
+
+        then:
+        connectionString.getSslInvalidHostnameAllowed() == false
+
+        when:
+        connectionString = new ConnectionString('mongodb://localhost/?tls=true&tlsInsecure=false&tlsAllowInvalidHostnames=true')
+
+        then:
+        connectionString.getSslInvalidHostnameAllowed()
+    }
+
     @Unroll
     def 'should throw IllegalArgumentException when the string #cause'() {
         when:
@@ -247,6 +351,7 @@ class ConnectionStringSpecification extends Specification {
         connectionString.getReadPreference() == null;
         connectionString.getRequiredReplicaSetName() == null
         connectionString.getSslEnabled() == null
+        connectionString.getSslInvalidHostnameAllowed() == null
         connectionString.getStreamType() == null
         connectionString.getApplicationName() == null
         connectionString.getCompressorList() == []

--- a/driver-core/src/test/unit/com/mongodb/ConnectionStringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/ConnectionStringTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb;
+
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+import util.JsonPoweredTestHelper;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+// See https://github.com/mongodb/specifications/tree/master/source/connection-string/tests
+public class ConnectionStringTest extends AbstractConnectionStringTest {
+    public ConnectionStringTest(final String filename, final String description, final String input, final BsonDocument definition) {
+        super(filename, description, input, definition);
+    }
+
+    @Test
+    public void shouldPassAllOutcomes() {
+        if (getFilename().equals("invalid-uris.json")) {
+            testInvalidUris();
+        } else if (getFilename().equals("valid-auth.json")) {
+            testValidAuth();
+        } else if (getFilename().equals("valid-db-with-dotted-name.json")) {
+            testValidHostIdentifiers();
+            testValidAuth();
+        } else if (getFilename().equals("valid-host_identifiers.json")) {
+            testValidHostIdentifiers();
+        } else if (getFilename().equals("valid-options.json")) {
+            testValidOptions();
+        } else if (getFilename().equals("valid-unix_socket-absolute.json")) {
+            testValidHostIdentifiers();
+        } else if (getFilename().equals("valid-unix_socket-relative.json")) {
+            testValidHostIdentifiers();
+        } else if (getFilename().equals("valid-warnings.json")) {
+            testValidHostIdentifiers();
+            if (!getDefinition().get("options").isNull()) {
+                testValidOptions();
+            }
+        } else {
+            throw new IllegalArgumentException("Unsupported file: " + getFilename());
+        }
+    }
+
+
+    @Parameterized.Parameters(name = "{1}")
+    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+        List<Object[]> data = new ArrayList<Object[]>();
+        for (File file : JsonPoweredTestHelper.getTestFiles("/connection-string")) {
+            BsonDocument testDocument = JsonPoweredTestHelper.getTestDocument(file);
+            for (BsonValue test : testDocument.getArray("tests")) {
+                data.add(new Object[]{file.getName(), test.asDocument().getString("description").getValue(),
+                        test.asDocument().getString("uri").getValue(), test.asDocument()});
+            }
+        }
+        return data;
+    }
+}

--- a/driver-core/src/test/unit/com/mongodb/UriOptionsTest.java
+++ b/driver-core/src/test/unit/com/mongodb/UriOptionsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb;
+
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+import util.JsonPoweredTestHelper;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.Assume.assumeFalse;
+
+// See https://github.com/mongodb/specifications/tree/master/source/uri-options/tests
+public class UriOptionsTest extends AbstractConnectionStringTest {
+    public UriOptionsTest(final String filename, final String description, final String input, final BsonDocument definition) {
+        super(filename, description, input, definition);
+    }
+
+    @Test
+    public void shouldPassAllOutcomes() {
+        assumeFalse(getDefinition().getBoolean("warning", BsonBoolean.FALSE).getValue());
+        assumeFalse(getDescription().equals("Arbitrary string readConcernLevel does not cause a warning"));
+
+        testValidOptions();
+    }
+
+    @Parameterized.Parameters(name = "{1}")
+    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+        List<Object[]> data = new ArrayList<Object[]>();
+        for (File file : JsonPoweredTestHelper.getTestFiles("/uri-options")) {
+            BsonDocument testDocument = JsonPoweredTestHelper.getTestDocument(file);
+            for (BsonValue test : testDocument.getArray("tests")) {
+                data.add(new Object[]{file.getName(), test.asDocument().getString("description").getValue(),
+                        test.asDocument().getString("uri").getValue(), test.asDocument()});
+            }
+        }
+        return data;
+    }
+}

--- a/driver-legacy/src/main/com/mongodb/MongoClientURI.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClientURI.java
@@ -89,8 +89,14 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * <p>Connection Configuration:</p>
  * <ul>
- * <li>{@code ssl=true|false}: Whether to connect using SSL.</li>
- * <li>{@code sslInvalidHostNameAllowed=true|false}: Whether to allow invalid host names for SSL connections.</li>
+ * <li>{@code ssl=true|false}: Whether to connect using TLS.</li>
+ * <li>{@code tls=true|false}: Whether to connect using TLS. Supersedes the ssl option</li>
+ * <li>{@code tlsInsecure=true|false}: If connecting with TLS, this option enables insecure TLS connections. Currently this has the
+ * same effect of setting tlsAllowInvalidHostnames to true. Other mechanism for relaxing TLS security constraints must be handled in
+ * the application by customizing the {@link javax.net.ssl.SSLContext}</li>
+ * <li>{@code sslInvalidHostNameAllowed=true|false}: Whether to allow invalid host names for TLS connections.</li>
+ * <li>{@code tlsAllowInvalidHostnames=true|false}: Whether to allow invalid host names for TLS connections. Supersedes the
+ * sslInvalidHostNameAllowed option</li>
  * <li>{@code connectTimeoutMS=ms}: How long a connection can take to be opened before timing out.</li>
  * <li>{@code socketTimeoutMS=ms}: How long a send or receive on a socket can take before timing out.</li>
  * <li>{@code maxIdleTimeMS=ms}: Maximum idle time of a pooled connection. A connection that exceeds this limit will be closed</li>


### PR DESCRIPTION
Seems that these are the only ones that the driver is missing:

* tls=true|false
* tlsInsecure=true|false
* tlsAllowInvalidHostnames=true|false

Java issue: https://jira.mongodb.org/browse/JAVA-3066

Spec link: https://github.com/mongodb/specifications/blob/master/source/uri-options/uri-options.rst

No patch build since these are just unit tests.

