### PR TITLE
Fix Coverity warning: Explicit null dereferenced

### DIFF
--- a/driver-core/src/main/com/mongodb/DBObjectCodec.java
+++ b/driver-core/src/main/com/mongodb/DBObjectCodec.java
@@ -16,6 +16,7 @@
 
 package com.mongodb;
 
+import com.mongodb.lang.Nullable;
 import org.bson.BSONObject;
 import org.bson.BsonBinary;
 import org.bson.BsonBinarySubType;
@@ -74,7 +75,7 @@ public class DBObjectCodec implements CollectibleCodec<DBObject> {
     private final DBObjectFactory objectFactory;
     private final IdGenerator idGenerator = new ObjectIdGenerator();
 
-    static BsonTypeClassMap createDefaultBsonTypeClassMap() {
+    private static BsonTypeClassMap createDefaultBsonTypeClassMap() {
         Map<BsonType, Class<?>> replacements = new HashMap<BsonType, Class<?>>();
         replacements.put(BsonType.REGULAR_EXPRESSION, Pattern.class);
         replacements.put(BsonType.SYMBOL, String.class);
@@ -197,7 +198,7 @@ public class DBObjectCodec implements CollectibleCodec<DBObject> {
     private void beforeFields(final BsonWriter bsonWriter, final EncoderContext encoderContext, final DBObject document) {
         if (encoderContext.isEncodingCollectibleDocument() && document.containsField(ID_FIELD_NAME)) {
             bsonWriter.writeName(ID_FIELD_NAME);
-            writeValue(bsonWriter, null, document.get(ID_FIELD_NAME));
+            writeValue(bsonWriter, encoderContext, document.get(ID_FIELD_NAME));
         }
     }
 
@@ -211,43 +212,43 @@ public class DBObjectCodec implements CollectibleCodec<DBObject> {
         if (value == null) {
             bsonWriter.writeNull();
         } else if (value instanceof DBRef) {
-            encodeDBRef(bsonWriter, (DBRef) value);
+            encodeDBRef(bsonWriter, (DBRef) value, encoderContext);
         } else if (value instanceof Map) {
-            encodeMap(bsonWriter, (Map<String, Object>) value);
+            encodeMap(bsonWriter, (Map<String, Object>) value, encoderContext);
         } else if (value instanceof Iterable) {
-            encodeIterable(bsonWriter, (Iterable) value);
+            encodeIterable(bsonWriter, (Iterable) value, encoderContext);
         } else if (value instanceof BSONObject) {
-            encodeBsonObject(bsonWriter, ((BSONObject) value));
+            encodeBsonObject(bsonWriter, (BSONObject) value, encoderContext);
         } else if (value instanceof CodeWScope) {
-            encodeCodeWScope(bsonWriter, (CodeWScope) value);
+            encodeCodeWScope(bsonWriter, (CodeWScope) value, encoderContext);
         } else if (value instanceof byte[]) {
             encodeByteArray(bsonWriter, (byte[]) value);
         } else if (value.getClass().isArray()) {
-            encodeArray(bsonWriter, value);
+            encodeArray(bsonWriter, value, encoderContext);
         } else if (value instanceof Symbol) {
             bsonWriter.writeSymbol(((Symbol) value).getSymbol());
         } else {
             Codec codec = codecRegistry.get(value.getClass());
-            codec.encode(bsonWriter, value, encoderContext);
+            encoderContext.encodeWithChildContext(codec, bsonWriter, value);
         }
     }
 
-    private void encodeMap(final BsonWriter bsonWriter, final Map<String, Object> document) {
+    private void encodeMap(final BsonWriter bsonWriter, final Map<String, Object> document, final EncoderContext encoderContext) {
         bsonWriter.writeStartDocument();
 
         for (final Map.Entry<String, Object> entry : document.entrySet()) {
             bsonWriter.writeName(entry.getKey());
-            writeValue(bsonWriter, null, entry.getValue());
+            writeValue(bsonWriter, encoderContext.getChildContext(), entry.getValue());
         }
         bsonWriter.writeEndDocument();
     }
 
-    private void encodeBsonObject(final BsonWriter bsonWriter, final BSONObject document) {
+    private void encodeBsonObject(final BsonWriter bsonWriter, final BSONObject document, final EncoderContext encoderContext) {
         bsonWriter.writeStartDocument();
 
         for (String key : document.keySet()) {
             bsonWriter.writeName(key);
-            writeValue(bsonWriter, null, document.get(key));
+            writeValue(bsonWriter, encoderContext.getChildContext(), document.get(key));
         }
         bsonWriter.writeEndDocument();
     }
@@ -256,44 +257,43 @@ public class DBObjectCodec implements CollectibleCodec<DBObject> {
         bsonWriter.writeBinaryData(new BsonBinary(value));
     }
 
-    private void encodeArray(final BsonWriter bsonWriter, final Object value) {
+    private void encodeArray(final BsonWriter bsonWriter, final Object value, final EncoderContext encoderContext) {
         bsonWriter.writeStartArray();
 
         int size = Array.getLength(value);
         for (int i = 0; i < size; i++) {
-            writeValue(bsonWriter, null, Array.get(value, i));
+            writeValue(bsonWriter, encoderContext.getChildContext(), Array.get(value, i));
         }
 
         bsonWriter.writeEndArray();
     }
 
-    private void encodeDBRef(final BsonWriter bsonWriter, final DBRef dbRef) {
+    private void encodeDBRef(final BsonWriter bsonWriter, final DBRef dbRef, final EncoderContext encoderContext) {
         bsonWriter.writeStartDocument();
 
         bsonWriter.writeString("$ref", dbRef.getCollectionName());
         bsonWriter.writeName("$id");
-        writeValue(bsonWriter, null, dbRef.getId());
+        writeValue(bsonWriter, encoderContext.getChildContext(), dbRef.getId());
         if (dbRef.getDatabaseName() != null) {
             bsonWriter.writeString("$db", dbRef.getDatabaseName());
         }
         bsonWriter.writeEndDocument();
     }
 
-    @SuppressWarnings("unchecked")
-    private void encodeCodeWScope(final BsonWriter bsonWriter, final CodeWScope value) {
+    private void encodeCodeWScope(final BsonWriter bsonWriter, final CodeWScope value, final EncoderContext encoderContext) {
         bsonWriter.writeJavaScriptWithScope(value.getCode());
-        encodeBsonObject(bsonWriter, value.getScope());
+        encodeBsonObject(bsonWriter, value.getScope(), encoderContext.getChildContext());
     }
 
-    private void encodeIterable(final BsonWriter bsonWriter, final Iterable iterable) {
+    private void encodeIterable(final BsonWriter bsonWriter, final Iterable iterable, final EncoderContext encoderContext) {
         bsonWriter.writeStartArray();
         for (final Object cur : iterable) {
-            writeValue(bsonWriter, null, cur);
+            writeValue(bsonWriter, encoderContext.getChildContext(), cur);
         }
         bsonWriter.writeEndArray();
     }
 
-    private Object readValue(final BsonReader reader, final DecoderContext decoderContext, final String fieldName,
+    private Object readValue(final BsonReader reader, final DecoderContext decoderContext, @Nullable final String fieldName,
                              final List<String> path) {
         Object initialRetVal;
         BsonType bsonType = reader.getCurrentBsonType();


### PR DESCRIPTION
Ensure that DBObjectCodec invokes nested Codecs with the correct
EncoderContext.

Also address a few other warnings from IntelliJ in the same file.

JAVA-3157