### PR TITLE
Fix NullPointerException when using mongodb+srv scheme

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/AbstractMultiServerCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AbstractMultiServerCluster.java
@@ -33,7 +33,6 @@ import org.bson.types.ObjectId;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -91,6 +90,7 @@ public abstract class AbstractMultiServerCluster extends BaseCluster {
     }
 
     protected void initialize(final Collection<ServerAddress> serverAddresses) {
+        ClusterDescription currentDescription = getCurrentDescription();
         ClusterDescription newDescription;
 
         // synchronizing this code because addServer registers a callback which is re-entrant to this instance.
@@ -101,12 +101,7 @@ public abstract class AbstractMultiServerCluster extends BaseCluster {
             }
             newDescription = updateDescription();
         }
-        fireChangeEvent(new ClusterDescriptionChangedEvent(getClusterId(), newDescription, createInitialDescription()));
-    }
-
-    private ClusterDescription createInitialDescription() {
-        return new ClusterDescription(getSettings().getMode(), ClusterType.UNKNOWN, Collections.<ServerDescription>emptyList(),
-                getSettings(), getServerFactory().getSettings());
+        fireChangeEvent(new ClusterDescriptionChangedEvent(getClusterId(), newDescription, currentDescription));
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BaseCluster.java
@@ -42,6 +42,7 @@ import com.mongodb.selector.ServerSelector;
 import org.bson.BsonTimestamp;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
@@ -86,6 +87,8 @@ abstract class BaseCluster implements Cluster {
         this.serverFactory = notNull("serverFactory", serverFactory);
         this.clusterListener = getClusterListener(settings);
         clusterListener.clusterOpening(new ClusterOpeningEvent(clusterId));
+        description = new ClusterDescription(settings.getMode(), ClusterType.UNKNOWN, Collections.<ServerDescription>emptyList(),
+                settings, serverFactory.getSettings());
     }
 
     @Override

--- a/driver-core/src/main/com/mongodb/internal/connection/SingleServerCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SingleServerCluster.java
@@ -103,18 +103,12 @@ public final class SingleServerCluster extends BaseCluster {
         if (clusterType == ClusterType.UNKNOWN && serverDescription != null) {
             clusterType = serverDescription.getClusterType();
         }
-        ClusterDescription oldDescription = getCurrentDescription();
+        ClusterDescription currentDescription = getCurrentDescription();
         ClusterDescription description = new ClusterDescription(ClusterConnectionMode.SINGLE, clusterType,
                 serverDescription == null ? Collections.<ServerDescription>emptyList() : singletonList(serverDescription), getSettings(),
                 getServerFactory().getSettings());
 
         updateDescription(description);
-        fireChangeEvent(new ClusterDescriptionChangedEvent(getClusterId(), description,
-                oldDescription == null ? getInitialDescription() : oldDescription));
-    }
-
-    private ClusterDescription getInitialDescription() {
-        return new ClusterDescription(getSettings().getMode(), getSettings().getRequiredClusterType(),
-                Collections.<ServerDescription>emptyList(), getSettings(), getServerFactory().getSettings());
+        fireChangeEvent(new ClusterDescriptionChangedEvent(getClusterId(), description, currentDescription));
     }
 }

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DnsMultiServerClusterSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DnsMultiServerClusterSpecification.groovy
@@ -17,7 +17,6 @@
 package com.mongodb.internal.connection
 
 import com.mongodb.MongoConfigurationException
-import com.mongodb.MongoTimeoutException
 import com.mongodb.ServerAddress
 import com.mongodb.connection.ClusterId
 import com.mongodb.connection.ClusterSettings
@@ -80,24 +79,13 @@ class DnsMultiServerClusterSpecification extends Specification {
         then: 'the description is not null'
         description != null
 
-        when: 'the description is accessed before initialization'
-        cluster.getDescription()
-
-        then: 'a MongoTimeoutException is thrown'
-        thrown(MongoTimeoutException)
-
-        when: 'a server is selected before initialization'
-        cluster.selectServer { def clusterDescription -> [] }
-
-        then: 'a MongoTimeoutException is thrown'
-        thrown(MongoTimeoutException)
-
         when: 'the listener is initialized with an exception'
         initializer.initialize(exception)
+        description = cluster.getCurrentDescription()
 
         then: 'the description includes the exception'
-        cluster.getCurrentDescription().getServerDescriptions() == []
-        cluster.getCurrentDescription().getSrvResolutionException() == exception
+        description.getServerDescriptions() == []
+        description.getSrvResolutionException() == exception
 
         when: 'the listener is initialized with servers'
         initializer.initialize([firstServer, secondServer] as Set)


### PR DESCRIPTION
A simple test would have caught this, but it didn't exist

* The InitialDnsSeedlistDiscoveryTest waits for the topology to be discovered before trying to executing a command, so the NPE path was not hit
* The Atlas connectivity tests would have caught it, but aren't configured to use mongodb+srv URIs.

https://jira.mongodb.org/browse/JAVA-3167

https://evergreen.mongodb.com/version/5c5e1f92e3c331144eacf189