### PR TITLE
J3068 events

### DIFF
--- a/driver-core/src/main/com/mongodb/connection/ConnectionId.java
+++ b/driver-core/src/main/com/mongodb/connection/ConnectionId.java
@@ -50,7 +50,20 @@ public final class ConnectionId {
         this(serverId, INCREMENTING_ID.incrementAndGet(), null);
     }
 
-    private ConnectionId(final ServerId serverId, final int localValue, final Integer serverValue) {
+    /**
+     * Construct an instance with the given serverId, localValue, and serverValue.
+     *
+     * <p>
+     *     Useful for testing, but generally prefer {@link #withServerValue(int)}
+     * </p>
+     *
+     * @param serverId the server id
+     * @param localValue the local value
+     * @param serverValue the server value, which may be null
+     * @see #withServerValue(int)
+     * @since 3.11
+     */
+    public ConnectionId(final ServerId serverId, final int localValue, final Integer serverValue) {
         this.serverId = notNull("serverId", serverId);
         this.localValue = localValue;
         this.serverValue = serverValue;

--- a/driver-core/src/main/com/mongodb/event/ConnectionRemovedEvent.java
+++ b/driver-core/src/main/com/mongodb/event/ConnectionRemovedEvent.java
@@ -17,8 +17,7 @@
 package com.mongodb.event;
 
 import com.mongodb.connection.ConnectionId;
-
-import static com.mongodb.assertions.Assertions.notNull;
+import org.bson.assertions.Assertions;
 
 /**
  * An event for removing a connection from the pool.
@@ -26,16 +25,69 @@ import static com.mongodb.assertions.Assertions.notNull;
  * @since 3.5
  */
 public final class ConnectionRemovedEvent {
+
+    /**
+     * An enumeration of the reasons a connection could be closed
+     * @since 3.11
+     */
+    public enum Reason {
+        /**
+         * Reason unknown
+         */
+        UNKNOWN,
+
+        /**
+         * The pool became stale because the pool has been cleared
+         */
+        STALE,
+
+        /**
+         * The connection became stale by being idle for too long
+         */
+        MAX_IDLE_TIME_EXCEEDED,
+
+        /**
+         * The connection became stale by being open for too long
+         */
+        MAX_LIFE_TIME_EXCEEDED,
+
+        /**
+         * The connection experienced an error, making it no longer valid
+         */
+        ERROR,
+
+        /**
+         * The pool was closed, making the connection no longer valid
+         */
+        POOL_CLOSED,
+   }
+
     private final ConnectionId connectionId;
+    private final Reason reason;
 
     /**
      * Construct an instance
      *
      * @param connectionId the connectionId
+     * @deprecated Prefer {@link #ConnectionRemovedEvent(ConnectionId, Reason)}
      */
+    @Deprecated
     public ConnectionRemovedEvent(final ConnectionId connectionId) {
-        this.connectionId = notNull("connectionId", connectionId);
+        this(connectionId, Reason.UNKNOWN);
     }
+
+    /**
+     * Constructs an instance.
+     *
+     * @param connectionId the connection id
+     * @param reason the reason the connection was closed
+     * @since 3.11
+     */
+    public ConnectionRemovedEvent(final ConnectionId connectionId, final Reason reason) {
+        this.connectionId = Assertions.notNull("connectionId", connectionId);
+        this.reason = Assertions.notNull("reason", reason);
+    }
+
 
     /**
      * Gets the connection id
@@ -46,10 +98,21 @@ public final class ConnectionRemovedEvent {
         return connectionId;
     }
 
+    /**
+     * Get the reason the connection was removed.
+     *
+     * @return the reason
+     * @since 3.11
+     */
+    public Reason getReason() {
+        return reason;
+    }
+
     @Override
     public String toString() {
         return "ConnectionRemovedEvent{"
-                       + "connectionId=" + connectionId
-                       + '}';
+                + "connectionId=" + connectionId
+                + ", reason=" + reason
+                + '}';
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultConnectionPool.java
@@ -78,12 +78,12 @@ class DefaultConnectionPool implements ConnectionPool {
                           final ConnectionPoolSettings settings) {
         this.serverId = notNull("serverId", serverId);
         this.settings = notNull("settings", settings);
-        UsageTrackingInternalConnectionItemFactory connectionItemFactory
-        = new UsageTrackingInternalConnectionItemFactory(internalConnectionFactory);
+        UsageTrackingInternalConnectionItemFactory connectionItemFactory =
+                new UsageTrackingInternalConnectionItemFactory(internalConnectionFactory);
         pool = new ConcurrentPool<UsageTrackingInternalConnection>(settings.getMaxSize(), connectionItemFactory);
+        this.connectionPoolListener = getConnectionPoolListener(settings);
         maintenanceTask = createMaintenanceTask();
         sizeMaintenanceTimer = createMaintenanceTimer();
-        this.connectionPoolListener = getConnectionPoolListener(settings);
         connectionPoolListener.connectionPoolOpened(new ConnectionPoolOpenedEvent(serverId, settings));
     }
 
@@ -400,11 +400,9 @@ class DefaultConnectionPool implements ConnectionPool {
         public void close() {
             // All but the first call is a no-op
             if (!isClosed.getAndSet(true)) {
-                if (!DefaultConnectionPool.this.closed) {
-                    connectionPoolListener.connectionCheckedIn(new ConnectionCheckedInEvent(getId(wrapped)));
-                    if (LOGGER.isTraceEnabled()) {
-                        LOGGER.trace(format("Checked in connection [%s] to server %s", getId(wrapped), serverId.getAddress()));
-                    }
+                connectionPoolListener.connectionCheckedIn(new ConnectionCheckedInEvent(getId(wrapped)));
+                if (LOGGER.isTraceEnabled()) {
+                    LOGGER.trace(format("Checked in connection [%s] to server %s", getId(wrapped), serverId.getAddress()));
                 }
                 pool.release(wrapped, wrapped.isClosed() || shouldPrune(wrapped));
             }
@@ -529,9 +527,7 @@ class DefaultConnectionPool implements ConnectionPool {
 
         @Override
         public void close(final UsageTrackingInternalConnection connection) {
-            if (!closed) {
-                connectionPoolListener.connectionRemoved(new ConnectionRemovedEvent(getId(connection)));
-            }
+            connectionPoolListener.connectionRemoved(new ConnectionRemovedEvent(getId(connection)));
             if (LOGGER.isInfoEnabled()) {
                 LOGGER.info(format("Closed connection [%s] to %s because %s.", getId(connection), serverId.getAddress(),
                                   getReasonForClosing(connection)));

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/README.rst
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/README.rst
@@ -1,0 +1,149 @@
+.. role:: javascript(code)
+  :language: javascript
+
+========================================
+Connection Monitoring and Pooling (CMAP)
+========================================
+
+.. contents::
+
+--------
+
+Introduction
+============
+
+The YAML and JSON files in this directory are platform-independent tests that
+drivers can use to prove their conformance to the Connection Monitoring and Pooling (CMAP) Spec.
+
+Several prose tests, which are not easily expressed in YAML, are also presented
+in this file. Those tests will need to be manually implemented by each driver.
+
+Common Test Format
+==================
+
+Each YAML file has the following keys:
+
+- ``version``: A version number indicating the expected format of the spec tests (current version = 1)
+- ``style``: A string indicating what style of tests this file contains. Currently ``unit`` is the only valid value
+- ``description``: A text description of what the test is meant to assert
+
+Unit Test Format:
+=================
+
+All Unit Tests have some of the following fields:
+
+- ``poolOptions``: if present, connection pool options to use when creating a pool
+- ``operations``: A list of operations to perform. All operations support the following fields:
+
+  - ``name``: A string describing which operation to issue.
+  - ``thread``: The name of the thread in which to run this operation. If not specified, runs in the default thread
+
+- ``error``: Indicates that the main thread is expected to error during this test. An error may include of the following fields:
+
+  - ``type``: the type of error emitted
+  - ``message``: the message associated with that error
+  - ``address``: Address of pool emitting error
+
+- ``events``: An array of all connection monitoring events expected to occur while running ``operations``. An event may contain any of the following fields
+
+  - ``type``: The type of event emitted
+  - ``address``: The address of the pool emitting the event
+  - ``connectionId``: The id of a connection associated with the event
+  - ``options``: Options used to create the pool
+  - ``reason``: A reason giving mroe information on why the event was emitted
+
+- ``ignore``: An array of event names to ignore
+
+Valid Unit Test Operations are the following:
+
+- ``start(target)``: Starts a new thread named ``target``
+
+  - ``target``: The name of the new thread to start
+
+- ``wait(ms)``: Sleep the current thread for ``ms`` milliseconds
+
+  - ``ms``: The number of milliseconds to sleep the current thread for
+
+- ``waitFor(target)``: wait for thread ``target`` to finish executing. Propagate any errors to the main thread.
+
+  - ``target``: The name of the thread to wait for.
+
+- ``label = pool.checkOut()``: call ``checkOut`` on pool, returning the checked out connection
+
+  - ``label``: If specified, associate this label with the returned connection, so that it may be referenced in later operations
+
+- ``pool.checkIn(connection)``: call ``checkIn`` on pool
+
+  - ``connection``: A string label identifying which connection to check in. Should be a label that was previously set with ``checkOut``
+
+- ``pool.clear()``: call ``clear`` on Pool
+- ``pool.close()``: call ``close`` on Pool
+
+Spec Test Match Function
+========================
+
+The definition of MATCH or MATCHES in the Spec Test Runner is as follows:
+
+- MATCH takes two values, ``expected`` and ``actual``
+- Notation is "Assert [actual] MATCHES [expected]
+- Assertion passes if ``expected`` is a subset of ``actual``, with the values ``42`` and ``"42"`` acting as placeholders for "any value"
+
+Pseudocode implementation of ``actual`` MATCHES ``expected``:
+
+::
+  
+  If expected is "42" or 42:
+    Assert that actual exists (is not null or undefined)
+  Else:
+    Assert that actual is of the same JSON type as expected
+    If expected is a JSON array:
+      For every idx/value in expected:
+        Assert that actual[idx] MATCHES value
+    Else if expected is a JSON object:
+      For every key/value in expected
+        Assert that actual[key] MATCHES value
+    Else:
+      Assert that expected equals actual
+
+Unit Test Runner:
+=================
+
+For the unit tests, the behavior of a Connection is irrelevant beyond the need to asserting ``connection.id``. Drivers MAY use a mock connection class for testing the pool behavior in unit tests
+
+For each YAML file with ``style: unit``:
+
+- Create a Pool ``pool``, subscribe and capture any Connection Monitoring events emitted in order.
+
+  - If ``poolOptions`` is specified, use those options to initialize both pools
+  - The returned pool must have an ``address`` set as a string value.
+
+- Execute each ``operation`` in ``operations``
+
+  - If a ``thread`` is specified, execute in that corresponding thread. Otherwise, execute in the main thread.
+
+- Wait for the main thread to finish executing all of its operations
+- If ``error`` is presented
+
+  - Assert that an actual error ``actualError`` was thrown by the main thread
+  - Assert that ``actualError`` MATCHES ``error``
+
+- Else: 
+
+  - Assert that no errors were thrown by the main thread
+
+- calculate ``actualEvents`` as every Connection Event emitted whose ``type`` is not in ``ignore``
+- if ``events`` is not empty, then for every ``idx``/``expectedEvent`` in ``events``
+
+  - Assert that ``actualEvents[idx]`` exists
+  - Assert that ``actualEvents[idx]`` MATCHES ``expectedEvent``
+
+
+Prose Tests
+===========
+
+The following tests have not yet been automated, but MUST still be tested
+
+#. All ConnectionPoolOptions MUST be specified at the MongoClient level
+#. All ConnectionPoolOptions MUST be the same for all pools created by a MongoClient
+#. A user MUST be able to specify all ConnectionPoolOptions via a URI string
+#. A user MUST be able to subscribe to Connection Monitoring Events in a manner idiomatic to their language and driver

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/connection-must-have-id.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/connection-must-have-id.json
@@ -1,0 +1,42 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "must have an ID number associated with it",
+  "operations": [
+    {
+      "name": "checkOut"
+    },
+    {
+      "name": "checkOut"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionPoolCreated",
+    "ConnectionPoolClosed",
+    "ConnectionReady"
+  ]
+}

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/connection-must-order-ids.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/connection-must-order-ids.json
@@ -1,0 +1,42 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "must have IDs assigned in order of creation",
+  "operations": [
+    {
+      "name": "checkOut"
+    },
+    {
+      "name": "checkOut"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 2
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 2
+    }
+  ],
+  "ignore": [
+    "ConnectionPoolCreated",
+    "ConnectionPoolClosed",
+    "ConnectionReady"
+  ]
+}

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkin-destroy-closed.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkin-destroy-closed.json
@@ -1,0 +1,43 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "must destroy checked in connection if pool has been closed",
+  "operations": [
+    {
+      "name": "checkOut",
+      "label": "conn"
+    },
+    {
+      "name": "close"
+    },
+    {
+      "name": "checkIn",
+      "connection": "conn"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionPoolClosed",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedIn",
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionClosed",
+      "connectionId": 1,
+      "reason": "poolClosed"
+    }
+  ],
+  "ignore": [
+    "ConnectionPoolCreated",
+    "ConnectionCreated",
+    "ConnectionReady",
+    "ConnectionCheckOutStarted"
+  ]
+}

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkin-destroy-stale.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkin-destroy-stale.json
@@ -1,0 +1,43 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "must destroy checked in connection if it is stale",
+  "operations": [
+    {
+      "name": "checkOut",
+      "label": "conn"
+    },
+    {
+      "name": "clear"
+    },
+    {
+      "name": "checkIn",
+      "connection": "conn"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionPoolCleared",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckedIn",
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionClosed",
+      "connectionId": 1,
+      "reason": "stale"
+    }
+  ],
+  "ignore": [
+    "ConnectionPoolCreated",
+    "ConnectionCreated",
+    "ConnectionReady",
+    "ConnectionCheckOutStarted"
+  ]
+}

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkin-make-available.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkin-make-available.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "must make valid checked in connection available",
+  "operations": [
+    {
+      "name": "checkOut",
+      "label": "conn"
+    },
+    {
+      "name": "checkIn",
+      "connection": "conn"
+    },
+    {
+      "name": "checkOut"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionCheckedIn",
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 1
+    }
+  ],
+  "ignore": [
+    "ConnectionPoolCreated",
+    "ConnectionCreated",
+    "ConnectionReady",
+    "ConnectionCheckOutStarted"
+  ]
+}

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkin.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkin.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "must have a method of allowing the driver to check in a connection",
+  "operations": [
+    {
+      "name": "checkOut",
+      "label": "conn"
+    },
+    {
+      "name": "checkIn",
+      "connection": "conn"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionCheckedIn",
+      "connectionId": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionPoolCreated",
+    "ConnectionCreated",
+    "ConnectionReady",
+    "ConnectionClosed",
+    "ConnectionCheckOutStarted",
+    "ConnectionCheckedOut"
+  ]
+}

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkout-connection.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkout-connection.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "must be able to check out a connection",
+  "operations": [
+    {
+      "name": "checkOut"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 1
+    }
+  ],
+  "ignore": [
+    "ConnectionPoolCreated",
+    "ConnectionCreated",
+    "ConnectionReady"
+  ]
+}

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkout-error-closed.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkout-error-closed.json
@@ -1,0 +1,50 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "must throw error if checkOut is called on a closed pool",
+  "operations": [
+    {
+      "name": "checkOut",
+      "label": "conn1"
+    },
+    {
+      "name": "checkIn",
+      "connection": "conn1"
+    },
+    {
+      "name": "close"
+    },
+    {
+      "name": "checkOut"
+    }
+  ],
+  "error": {
+    "type": "PoolClosedError",
+    "message": "Attempted to check out a connection from closed connection pool"
+  },
+  "events": [
+    {
+      "type": "ConnectionPoolCreated",
+      "address": 42,
+      "options": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckedIn",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionPoolClosed",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionCreated",
+    "ConnectionReady",
+    "ConnectionClosed",
+    "ConnectionCheckOutStarted"
+  ]
+}

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkout-multiple.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkout-multiple.json
@@ -1,0 +1,71 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "must be able to check out multiple connections at the same time",
+  "operations": [
+    {
+      "name": "start",
+      "target": "thread1"
+    },
+    {
+      "name": "wait",
+      "ms": 10
+    },
+    {
+      "name": "start",
+      "target": "thread2"
+    },
+    {
+      "name": "wait",
+      "ms": 20
+    },
+    {
+      "name": "start",
+      "target": "thread3"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread1"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread2"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread3"
+    },
+    {
+      "name": "waitFor",
+      "target": "thread1"
+    },
+    {
+      "name": "waitFor",
+      "target": "thread2"
+    },
+    {
+      "name": "waitFor",
+      "target": "thread3"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 2
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 3
+    }
+  ],
+  "ignore": [
+    "ConnectionCreated",
+    "ConnectionReady",
+    "ConnectionPoolCreated",
+    "ConnectionCheckOutStarted"
+  ]
+}

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkout-no-idle.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkout-no-idle.json
@@ -1,0 +1,66 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "must destroy and must not check out an idle connection if found while iterating available connections",
+  "poolOptions": {
+    "maxIdleTimeMS": 10
+  },
+  "operations": [
+    {
+      "name": "checkOut",
+      "label": "conn"
+    },
+    {
+      "name": "checkIn",
+      "connection": "conn"
+    },
+    {
+      "name": "wait",
+      "ms": 50
+    },
+    {
+      "name": "checkOut"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionPoolCreated",
+      "address": 42,
+      "options": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionCheckedIn",
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionClosed",
+      "connectionId": 1,
+      "reason": "idle"
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 2
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 2
+    }
+  ],
+  "ignore": [
+    "ConnectionReady"
+  ]
+}

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkout-no-stale.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkout-no-stale.json
@@ -1,0 +1,57 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "must destroy and must not check out a stale connection if found while iterating available connections",
+  "poolOptions": {
+    "minPoolSize": 3
+  },
+  "operations": [
+    {
+      "name": "wait",
+      "ms": 20
+    },
+    {
+      "name": "clear"
+    },
+    {
+      "name": "checkOut"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionPoolCreated",
+      "address": 42,
+      "options": 42
+    },
+    {
+      "type": "ConnectionPoolCleared",
+      "address": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionClosed",
+      "connectionId": 42,
+      "reason": "stale"
+    },
+    {
+      "type": "ConnectionClosed",
+      "connectionId": 42,
+      "reason": "stale"
+    },
+    {
+      "type": "ConnectionClosed",
+      "connectionId": 42,
+      "reason": "stale"
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 4
+    }
+  ],
+  "ignore": [
+    "ConnectionCreated",
+    "ConnectionReady"
+  ]
+}

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-close-destroy-conns.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-close-destroy-conns.json
@@ -1,0 +1,46 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "When a pool is closed, it MUST first destroy all available connections in that pool",
+  "operations": [
+    {
+      "name": "checkOut"
+    },
+    {
+      "name": "checkOut",
+      "label": "conn"
+    },
+    {
+      "name": "checkOut"
+    },
+    {
+      "name": "checkIn",
+      "connection": "conn"
+    },
+    {
+      "name": "close"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionCheckedIn",
+      "connectionId": 2
+    },
+    {
+      "type": "ConnectionClosed",
+      "connectionId": 2,
+      "reason": "poolClosed"
+    },
+    {
+      "type": "ConnectionPoolClosed",
+      "address": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionCreated",
+    "ConnectionReady",
+    "ConnectionPoolCreated",
+    "ConnectionCheckOutStarted",
+    "ConnectionCheckedOut"
+  ]
+}

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-close.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-close.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "must be able to manually close a pool",
+  "operations": [
+    {
+      "name": "close"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionPoolCreated",
+      "address": 42,
+      "options": 42
+    },
+    {
+      "type": "ConnectionPoolClosed",
+      "address": 42
+    }
+  ]
+}

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-create-max-size.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-create-max-size.json
@@ -1,0 +1,113 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "must never exceed maxPoolSize total connections",
+  "poolOptions": {
+    "maxPoolSize": 3
+  },
+  "operations": [
+    {
+      "name": "checkOut",
+      "label": "conn1"
+    },
+    {
+      "name": "checkOut"
+    },
+    {
+      "name": "checkOut",
+      "label": "conn2"
+    },
+    {
+      "name": "checkIn",
+      "connection": "conn2"
+    },
+    {
+      "name": "checkOut"
+    },
+    {
+      "name": "start",
+      "target": "thread1"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread1"
+    },
+    {
+      "name": "wait",
+      "ms": 10
+    },
+    {
+      "name": "checkIn",
+      "connection": "conn1"
+    },
+    {
+      "name": "waitFor",
+      "target": "thread1"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionPoolCreated",
+      "address": 42,
+      "options": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckedIn",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionCheckedIn",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionReady"
+  ]
+}

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-create-min-size.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-create-min-size.json
@@ -1,0 +1,55 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "must be able to start a pool with minPoolSize connections",
+  "poolOptions": {
+    "minPoolSize": 5
+  },
+  "operations": [
+    {
+      "name": "wait",
+      "ms": 50
+    },
+    {
+      "name": "checkOut"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionPoolCreated",
+      "address": 42,
+      "options": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCreated",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionReady",
+    "ConnectionClosed"
+  ]
+}

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-create-with-options.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-create-with-options.json
@@ -1,0 +1,30 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "must be able to start a pool with various options set",
+  "poolOptions": {
+    "maxPoolSize": 50,
+    "minPoolSize": 5,
+    "maxIdleTimeMS": 100
+  },
+  "operations": [
+    {
+      "name": "wait",
+      "ms": 20
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionPoolCreated",
+      "address": 42,
+      "options": {
+        "maxPoolSize": 50,
+        "minPoolSize": 5,
+        "maxIdleTimeMS": 100
+      }
+    }
+  ],
+  "ignore": [
+    "ConnectionCreated"
+  ]
+}

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-create.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-create.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "must be able to create a pool",
+  "operations": [
+    {
+      "name": "wait",
+      "ms": 10
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionPoolCreated",
+      "address": 42,
+      "options": 42
+    }
+  ]
+}

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/wait-queue-fairness.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/wait-queue-fairness.json
@@ -1,0 +1,158 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "must issue Connections to threads in the order that the threads entered the queue",
+  "poolOptions": {
+    "maxPoolSize": 1,
+    "waitQueueTimeoutMS": 1000
+  },
+  "operations": [
+    {
+      "name": "checkOut",
+      "label": "conn0"
+    },
+    {
+      "name": "start",
+      "target": "thread1"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread1",
+      "label": "conn1"
+    },
+    {
+      "name": "wait",
+      "ms": 10
+    },
+    {
+      "name": "start",
+      "target": "thread2"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread2",
+      "label": "conn2"
+    },
+    {
+      "name": "wait",
+      "ms": 10
+    },
+    {
+      "name": "start",
+      "target": "thread3"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread3",
+      "label": "conn3"
+    },
+    {
+      "name": "wait",
+      "ms": 10
+    },
+    {
+      "name": "start",
+      "target": "thread4"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread4",
+      "label": "conn4"
+    },
+    {
+      "name": "wait",
+      "ms": 10
+    },
+    {
+      "name": "checkIn",
+      "connection": "conn0"
+    },
+    {
+      "name": "waitFor",
+      "target": "thread1"
+    },
+    {
+      "name": "checkIn",
+      "connection": "conn1"
+    },
+    {
+      "name": "waitFor",
+      "target": "thread2"
+    },
+    {
+      "name": "checkIn",
+      "connection": "conn2"
+    },
+    {
+      "name": "waitFor",
+      "target": "thread3"
+    },
+    {
+      "name": "checkIn",
+      "connection": "conn3"
+    },
+    {
+      "name": "waitFor",
+      "target": "thread4"
+    }
+  ],
+  "events": [
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionCheckedIn",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckedIn",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckedIn",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckedIn",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionCreated",
+    "ConnectionReady",
+    "ConnectionClosed",
+    "ConnectionPoolCreated"
+  ]
+}

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/wait-queue-timeout.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/wait-queue-timeout.json
@@ -1,0 +1,65 @@
+{
+  "version": 1,
+  "style": "unit",
+  "description": "must aggressively timeout threads enqueued longer than waitQueueTimeoutMS",
+  "poolOptions": {
+    "maxPoolSize": 1,
+    "waitQueueTimeoutMS": 20
+  },
+  "operations": [
+    {
+      "name": "checkOut",
+      "label": "conn0"
+    },
+    {
+      "name": "start",
+      "target": "thread1"
+    },
+    {
+      "name": "checkOut",
+      "thread": "thread1"
+    },
+    {
+      "name": "wait",
+      "ms": 40
+    },
+    {
+      "name": "checkIn",
+      "connection": "conn0"
+    },
+    {
+      "name": "waitFor",
+      "target": "thread1"
+    }
+  ],
+  "error": {
+    "type": "WaitQueueTimeoutError",
+    "message": "Timed out while checking out a connection from connection pool"
+  },
+  "events": [
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 42
+    },
+    {
+      "type": "ConnectionCheckOutStarted"
+    },
+    {
+      "type": "ConnectionCheckOutFailed",
+      "reason": "timeout"
+    },
+    {
+      "type": "ConnectionCheckedIn",
+      "connectionId": 42
+    }
+  ],
+  "ignore": [
+    "ConnectionCreated",
+    "ConnectionReady",
+    "ConnectionClosed",
+    "ConnectionPoolCreated"
+  ]
+}

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ConnectionPoolTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ConnectionPoolTest.java
@@ -193,10 +193,35 @@ public class ConnectionPoolTest {
                 } else if (type.equals("ConnectionClosed")) {
                     ConnectionRemovedEvent actualEvent = getNextEvent(actualEventsIterator, ConnectionRemovedEvent.class);
                     assertConnectionIdMatch(expectedEvent, actualEvent.getConnectionId());
+                    assertReasonMatch(expectedEvent, actualEvent);
                 } else {
                     throw new UnsupportedOperationException("Unsupported event type " + type);
                 }
             }
+        }
+    }
+
+    private void assertReasonMatch(final BsonDocument expectedEvent, final ConnectionRemovedEvent connectionRemovedEvent) {
+        if (!expectedEvent.containsKey("reason")) {
+            return;
+        }
+
+        String expectedReason = expectedEvent.getString("reason").getValue();
+        switch (connectionRemovedEvent.getReason()) {
+            case STALE:
+                assertEquals(expectedReason, "stale");
+                break;
+            case MAX_IDLE_TIME_EXCEEDED:
+                assertEquals(expectedReason, "idle");
+                break;
+            case ERROR:
+                assertEquals(expectedReason, "error");
+                break;
+            case POOL_CLOSED:
+                assertEquals(expectedReason, "poolClosed");
+                break;
+            default:
+                fail("Unexpected reason to close connection " + connectionRemovedEvent.getReason());
         }
     }
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ConnectionPoolTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ConnectionPoolTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.connection;
+
+import com.mongodb.MongoTimeoutException;
+import com.mongodb.ServerAddress;
+import com.mongodb.connection.ClusterId;
+import com.mongodb.connection.ConnectionId;
+import com.mongodb.connection.ConnectionPoolSettings;
+import com.mongodb.connection.ServerId;
+import com.mongodb.event.ConnectionAddedEvent;
+import com.mongodb.event.ConnectionCheckedInEvent;
+import com.mongodb.event.ConnectionCheckedOutEvent;
+import com.mongodb.event.ConnectionPoolClosedEvent;
+import com.mongodb.event.ConnectionPoolOpenedEvent;
+import com.mongodb.event.ConnectionPoolWaitQueueEnteredEvent;
+import com.mongodb.event.ConnectionPoolWaitQueueExitedEvent;
+import com.mongodb.event.ConnectionRemovedEvent;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import util.JsonPoweredTestHelper;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+// Implementation of
+// https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst
+// specification tests
+@RunWith(Parameterized.class)
+public class ConnectionPoolTest {
+    private final String fileName;
+    private final String description;
+    private final BsonDocument definition;
+    private final TestConnectionPoolListener listener;
+    private final ServerAddress serverAddress = new ServerAddress("host1");
+    private final DefaultConnectionPool pool;
+    private ConnectionPoolSettings settings;
+    private final Map<String, ExecutorService> executorServiceMap = new HashMap<String, ExecutorService>();
+    private final Map<String, Future<Exception>> futureMap = new HashMap<String, Future<Exception>>();
+    private final Map<String, InternalConnection> connectionMap = new HashMap<String, InternalConnection>();
+
+    public ConnectionPoolTest(final String fileName, final String description, final BsonDocument definition) {
+        this.fileName = fileName;
+        this.description = description;
+        this.definition = definition;
+
+        ConnectionPoolSettings.Builder settingsBuilder = ConnectionPoolSettings.builder();
+        BsonDocument poolOptions = definition.getDocument("poolOptions", new BsonDocument());
+
+        if (poolOptions.containsKey("maxPoolSize")) {
+            settingsBuilder.maxSize(poolOptions.getNumber("maxPoolSize").intValue());
+        }
+        if (poolOptions.containsKey("minPoolSize")) {
+            settingsBuilder.minSize(poolOptions.getNumber("minPoolSize").intValue());
+        }
+        if (poolOptions.containsKey("maxIdleTimeMS")) {
+            settingsBuilder.maxConnectionIdleTime(poolOptions.getNumber("maxIdleTimeMS").intValue(), TimeUnit.MILLISECONDS);
+        }
+        if (poolOptions.containsKey("waitQueueTimeoutMS")) {
+            settingsBuilder.maxWaitTime(poolOptions.getNumber("waitQueueTimeoutMS").intValue(), TimeUnit.MILLISECONDS);
+        }
+
+        listener = new TestConnectionPoolListener();
+        settingsBuilder.addConnectionPoolListener(listener);
+        settings = settingsBuilder.build();
+
+        pool = new DefaultConnectionPool(new ServerId(new ClusterId(), serverAddress), new TestInternalConnectionFactory(),
+                settings);
+    }
+
+    @After
+    public void tearDown() {
+        for (ExecutorService cur : executorServiceMap.values()) {
+            cur.shutdownNow();
+        }
+    }
+
+    @Test
+    public void shouldPassAllOutcomes() throws Exception {
+        try {
+            for (BsonValue cur : definition.getArray("operations")) {
+                final BsonDocument operation = cur.asDocument();
+                String name = operation.getString("name").getValue();
+
+                if (name.equals("start")) {
+                    String target = operation.getString("target", new BsonString("")).getValue();
+                    executorServiceMap.put(target, Executors.newSingleThreadExecutor());
+                } else if (name.equals("waitFor")) {
+                    String target = operation.getString("target", new BsonString("")).getValue();
+                    Exception exceptionFromFuture = futureMap.remove(target).get(5, TimeUnit.SECONDS);
+                    if (exceptionFromFuture != null) {
+                        throw exceptionFromFuture;
+                    }
+                } else if (name.equals("wait")) {
+                    Thread.sleep(operation.getNumber("ms").intValue());
+                } else if (name.equals("clear")) {
+                    pool.invalidate();
+                } else if (name.equals("close")) {
+                    pool.close();
+                } else {
+                    Callable<Exception> callable = createCallable(operation);
+                    if (operation.containsKey("thread")) {
+                        String threadTarget = operation.getString("thread").getValue();
+                        ExecutorService executorService = executorServiceMap.get(threadTarget);
+                        futureMap.put(threadTarget, executorService.submit(callable));
+                    } else {
+                        callable.call();
+                    }
+                }
+            }
+        } catch (Exception e) {
+            if (!definition.containsKey("error")) {
+                throw e;
+            }
+            BsonDocument errorDocument = definition.getDocument("error");
+            String exceptionType = errorDocument.getString("type").getValue();
+            if (exceptionType.equals("PoolClosedError")) {
+                assertEquals(IllegalStateException.class, e.getClass());
+            } else if (exceptionType.equals("WaitQueueTimeoutError")) {
+                assertEquals(MongoTimeoutException.class, e.getClass());
+            } else {
+                fail("Unexpected exception type " + exceptionType);
+            }
+        }
+
+        if (definition.containsKey("events")) {
+            Iterator<Object> actualEventsIterator = getNonIgnoredActualEvents().iterator();
+            BsonArray expectedEvents = definition.getArray("events");
+            for (BsonValue cur : expectedEvents) {
+                BsonDocument expectedEvent = cur.asDocument();
+                String type = expectedEvent.getString("type").getValue();
+                if (type.equals("ConnectionPoolCreated")) {
+                    ConnectionPoolOpenedEvent actualEvent = getNextEvent(actualEventsIterator, ConnectionPoolOpenedEvent.class);
+                    assertEquals(serverAddress, actualEvent.getServerId().getAddress());
+                    assertEquals(settings, actualEvent.getSettings());
+                } else if (type.equals("ConnectionPoolClosed")) {
+                    ConnectionPoolClosedEvent actualEvent = getNextEvent(actualEventsIterator, ConnectionPoolClosedEvent.class);
+                    assertEquals(serverAddress, actualEvent.getServerId().getAddress());
+                } else if (type.equals("ConnectionPoolCleared")) {
+                    // TODO
+                } else if (type.equals("ConnectionReady")) {
+                    // TODO
+                } else if (type.equals("ConnectionCheckOutStarted")) {
+                    // TODO
+                } else if (type.equals("ConnectionCheckOutFailed")) {
+                    // TODO
+                } else if (type.equals("ConnectionCreated")) {
+                    ConnectionAddedEvent actualEvent = getNextEvent(actualEventsIterator, ConnectionAddedEvent.class);
+                    assertConnectionIdMatch(expectedEvent, actualEvent.getConnectionId());
+                } else if (type.equals("ConnectionCheckedOut")) {
+                    ConnectionCheckedOutEvent actualEvent = getNextEvent(actualEventsIterator, ConnectionCheckedOutEvent.class);
+                    assertConnectionIdMatch(expectedEvent, actualEvent.getConnectionId());
+                } else if (type.equals("ConnectionCheckedIn")) {
+                    ConnectionCheckedInEvent actualEvent = getNextEvent(actualEventsIterator, ConnectionCheckedInEvent.class);
+                    assertConnectionIdMatch(expectedEvent, actualEvent.getConnectionId());
+                } else if (type.equals("ConnectionClosed")) {
+                    ConnectionRemovedEvent actualEvent = getNextEvent(actualEventsIterator, ConnectionRemovedEvent.class);
+                    assertConnectionIdMatch(expectedEvent, actualEvent.getConnectionId());
+                } else {
+                    throw new UnsupportedOperationException("Unsupported event type " + type);
+                }
+            }
+        }
+    }
+
+    private void assertConnectionIdMatch(final BsonDocument expectedEvent, final ConnectionId actualConnectionId) {
+        int expectedConnectionId = expectedEvent.getNumber("connectionId").intValue();
+        if (expectedConnectionId != 42) {
+            assertEquals("Connection id does not match", (int) expectedConnectionId, actualConnectionId.getLocalValue());
+        }
+    }
+
+    private List<Object> getNonIgnoredActualEvents() {
+        List<Object> nonIgnoredActualEvents = new ArrayList<Object>();
+        Set<Class<?>> ignoredEventClasses = getIgnoredEventClasses();
+        for (Object cur : listener.getEvents()) {
+            if (!ignoredEventClasses.contains(cur.getClass())) {
+                nonIgnoredActualEvents.add(cur);
+            }
+        }
+        return nonIgnoredActualEvents;
+    }
+
+    private Set<Class<?>> getIgnoredEventClasses() {
+        Set<Class<?>> ignoredEventClasses = new HashSet<Class<?>>();
+        ignoredEventClasses.add(ConnectionPoolWaitQueueEnteredEvent.class);
+        ignoredEventClasses.add(ConnectionPoolWaitQueueExitedEvent.class);
+        for (BsonValue cur : definition.getArray("ignore", new BsonArray())) {
+            String type = cur.asString().getValue();
+            if (type.equals("ConnectionPoolCreated")) {
+                ignoredEventClasses.add(ConnectionPoolOpenedEvent.class);
+            } else if (type.equals("ConnectionPoolClosed")) {
+                ignoredEventClasses.add(ConnectionPoolClosedEvent.class);
+            } else if (type.equals("ConnectionPoolCleared")) {
+                // TODO
+            } else if (type.equals("ConnectionReady")) {
+                // TODO
+            } else if (type.equals("ConnectionCheckOutStarted")) {
+                // TODO
+            } else if (type.equals("ConnectionCheckOutFailed")) {
+                // TODO
+            } else if (type.equals("ConnectionCreated")) {
+                ignoredEventClasses.add(ConnectionAddedEvent.class);
+            } else if (type.equals("ConnectionCheckedOut")) {
+                ignoredEventClasses.add(ConnectionCheckedOutEvent.class);
+            } else if (type.equals("ConnectionCheckedIn")) {
+                ignoredEventClasses.add(ConnectionCheckedInEvent.class);
+            } else if (type.equals("ConnectionClosed")) {
+                ignoredEventClasses.add(ConnectionRemovedEvent.class);
+            } else {
+                throw new UnsupportedOperationException("Unsupported event type " + type);
+            }
+        }
+        return ignoredEventClasses;
+    }
+
+    private <Event> Event getNextEvent(final Iterator<Object> eventsIterator, final Class<Event> expectedType) {
+        if (!eventsIterator.hasNext()) {
+           fail("Expected event of type " + expectedType + " but there are no more events");
+        }
+        Object next = eventsIterator.next();
+        assertEquals(expectedType, next.getClass());
+        return expectedType.cast(next);
+    }
+
+    private Callable<Exception> createCallable(final BsonDocument operation) {
+        String name = operation.getString("name").getValue();
+        if (name.equals("checkOut")) {
+            return new Callable<Exception>() {
+                @Override
+                public Exception call() {
+                    try {
+                        InternalConnection connection = pool.get();
+                        if (operation.containsKey("label")) {
+                            connectionMap.put(operation.getString("label").getValue(), connection);
+                        }
+                        return null;
+                    } catch (Exception e) {
+                        return e;
+                    }
+                }
+            };
+        } else if (name.equals("checkIn")) {
+            return new Callable<Exception>() {
+                @Override
+                public Exception call() {
+                    try {
+                        InternalConnection connection = connectionMap.get(operation.getString("connection").getValue());
+                        connection.close();
+                        return null;
+                    } catch (Exception e) {
+                        return e;
+                    }
+                }
+            };
+        } else {
+            throw new UnsupportedOperationException("Operation " + name + " not supported");
+        }
+    }
+
+    @Parameterized.Parameters(name = "{0}: {1}")
+    public static Collection<Object[]> data() throws URISyntaxException, IOException {
+        List<Object[]> data = new ArrayList<Object[]>();
+        for (File file : JsonPoweredTestHelper.getTestFiles("/connection-monitoring-and-pooling")) {
+            BsonDocument testDocument = JsonPoweredTestHelper.getTestDocument(file);
+            data.add(new Object[]{file.getName(), testDocument.getString("description").getValue(), testDocument});
+        }
+        return data;
+    }
+
+}

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ConnectionPoolTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ConnectionPoolTest.java
@@ -174,13 +174,13 @@ public class ConnectionPoolTest {
                     ConnectionPoolClosedEvent actualEvent = getNextEvent(actualEventsIterator, ConnectionPoolClosedEvent.class);
                     assertEquals(serverAddress, actualEvent.getServerId().getAddress());
                 } else if (type.equals("ConnectionPoolCleared")) {
-                    // TODO
+                    // TODO in 4.0, when this event will be implemented
                 } else if (type.equals("ConnectionReady")) {
-                    // TODO
+                    // TODO in 4.0, when this event will be implemented
                 } else if (type.equals("ConnectionCheckOutStarted")) {
-                    // TODO
+                    // TODO in 4.0, when this event will be implemented
                 } else if (type.equals("ConnectionCheckOutFailed")) {
-                    // TODO
+                    // TODO in 4.0, when this event will be implemented
                 } else if (type.equals("ConnectionCreated")) {
                     ConnectionAddedEvent actualEvent = getNextEvent(actualEventsIterator, ConnectionAddedEvent.class);
                     assertConnectionIdMatch(expectedEvent, actualEvent.getConnectionId());
@@ -254,13 +254,13 @@ public class ConnectionPoolTest {
             } else if (type.equals("ConnectionPoolClosed")) {
                 ignoredEventClasses.add(ConnectionPoolClosedEvent.class);
             } else if (type.equals("ConnectionPoolCleared")) {
-                // TODO
+                // TODO in 4.0, when this event will be implemented
             } else if (type.equals("ConnectionReady")) {
-                // TODO
+                // TODO in 4.0, when this event will be implemented
             } else if (type.equals("ConnectionCheckOutStarted")) {
-                // TODO
+                // TODO in 4.0, when this event will be implemented
             } else if (type.equals("ConnectionCheckOutFailed")) {
-                // TODO
+                // TODO in 4.0, when this event will be implemented
             } else if (type.equals("ConnectionCreated")) {
                 ignoredEventClasses.add(ConnectionAddedEvent.class);
             } else if (type.equals("ConnectionCheckedOut")) {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultConnectionPoolSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultConnectionPoolSpecification.groovy
@@ -392,7 +392,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         1 * listener.connectionCheckedIn { it.connectionId.serverId == SERVER_ID }
     }
 
-    def 'should not fire any more events after pool is closed'() {
+    def 'should continue to fire events after pool is closed'() {
         def listener = Mock(ConnectionPoolListener)
         pool = new DefaultConnectionPool(SERVER_ID, connectionFactory, builder().maxSize(1).maxWaitQueueSize(1)
                 .addConnectionPoolListener(listener).build())
@@ -403,8 +403,8 @@ class DefaultConnectionPoolSpecification extends Specification {
         connection.close()
 
         then:
-        0 * listener.connectionCheckedIn { it.connectionId.serverId == SERVER_ID && it.clusterId == SERVER_ID.clusterId }
-        0 * listener.connectionRemoved { it.connectionId.serverId == SERVER_ID && it.clusterId == SERVER_ID.clusterId }
+        1 * listener.connectionCheckedIn { it.connectionId.serverId == SERVER_ID }
+        1 * listener.connectionRemoved { it.connectionId.serverId == SERVER_ID }
     }
 
     def 'should select connection asynchronously if one is immediately available'() {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/TestConnectionPoolListener.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/TestConnectionPoolListener.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.connection;
+
+import com.mongodb.event.ConnectionAddedEvent;
+import com.mongodb.event.ConnectionCheckedInEvent;
+import com.mongodb.event.ConnectionCheckedOutEvent;
+import com.mongodb.event.ConnectionPoolClosedEvent;
+import com.mongodb.event.ConnectionPoolListener;
+import com.mongodb.event.ConnectionPoolOpenedEvent;
+import com.mongodb.event.ConnectionPoolWaitQueueEnteredEvent;
+import com.mongodb.event.ConnectionPoolWaitQueueExitedEvent;
+import com.mongodb.event.ConnectionRemovedEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class TestConnectionPoolListener implements ConnectionPoolListener {
+
+    private final List<Object> events = new ArrayList<Object>();
+
+    public List<Object> getEvents() {
+        return events;
+    }
+
+    @Override
+    public void connectionPoolOpened(final ConnectionPoolOpenedEvent event) {
+        events.add(event);
+    }
+
+    @Override
+    public void connectionPoolClosed(final ConnectionPoolClosedEvent event) {
+        events.add(event);
+    }
+
+    @Override
+    public void connectionCheckedOut(final ConnectionCheckedOutEvent event) {
+        events.add(event);
+    }
+
+    @Override
+    public void connectionCheckedIn(final ConnectionCheckedInEvent event) {
+        events.add(event);
+    }
+
+    @Override
+    public void waitQueueEntered(final ConnectionPoolWaitQueueEnteredEvent event) {
+        events.add(event);
+    }
+
+    @Override
+    public void waitQueueExited(final ConnectionPoolWaitQueueExitedEvent event) {
+        events.add(event);
+    }
+
+    @Override
+    public void connectionAdded(final ConnectionAddedEvent event) {
+        events.add(event);
+    }
+
+    @Override
+    public void connectionRemoved(final ConnectionRemovedEvent event) {
+        events.add(event);
+    }
+}


### PR DESCRIPTION
This PR implements the features of the CMAP spec that are possible to do without making binary incompatible changes to the existing `ConnectionPoolListener` interface.  In 4.0, when Java 8 is the minimum supported version, we can add default methods to the interface for the new events.

Ticket: https://jira.mongodb.org/browse/JAVA-3068
Spec: https://github.com/mongodb/specifications/tree/master/source/connection-monitoring-and-pooling
Patch build: https://evergreen.mongodb.com/version/5c656e04e3c3312e624fd854
