### PR TITLE
Fix race condition in DefaultConnectionPool constructor

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/ConnectionPool.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/ConnectionPool.java
@@ -23,6 +23,9 @@ import java.util.concurrent.TimeUnit;
 
 interface ConnectionPool extends Closeable {
 
+    // Start any maintenance task background tasks associated with the connection pool
+    void start();
+
     InternalConnection get();
 
     InternalConnection get(long timeout, TimeUnit timeUnit);

--- a/driver-core/src/main/com/mongodb/internal/connection/DefaultClusterableServerFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DefaultClusterableServerFactory.java
@@ -71,6 +71,8 @@ public class DefaultClusterableServerFactory implements ClusterableServerFactory
                 new InternalStreamConnectionFactory(streamFactory, credentialList, applicationName,
                         mongoDriverInformation, compressorList, commandListener), connectionPoolSettings);
 
+        connectionPool.start();
+
         // no credentials, compressor list, or command listener for the server monitor factory
         ServerMonitorFactory serverMonitorFactory =
             new DefaultServerMonitorFactory(new ServerId(clusterId, serverAddress), serverSettings, clusterClock,

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/DefaultConnectionPoolTest.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/DefaultConnectionPoolTest.java
@@ -62,6 +62,8 @@ public class DefaultConnectionPoolTest {
                                                                    .maxWaitQueueSize(1)
                                                                    .maxWaitTime(50, MILLISECONDS)
                                                                    .build());
+        provider.start();
+
         provider.get();
 
         // when
@@ -83,6 +85,7 @@ public class DefaultConnectionPoolTest {
                                                                    .maxWaitQueueSize(1)
                                                                    .maxWaitTime(500, MILLISECONDS)
                                                                    .build());
+        provider.start();
 
         provider.get();
 
@@ -109,6 +112,7 @@ public class DefaultConnectionPoolTest {
                                                                    .maintenanceInitialDelay(5, MINUTES)
                                                                    .maxConnectionLifeTime(50, MILLISECONDS)
                                                                    .build());
+        provider.start();
 
         // when
         provider.get().close();
@@ -129,6 +133,7 @@ public class DefaultConnectionPoolTest {
                                                                    .maxSize(1)
                                                                    .maxWaitQueueSize(1)
                                                                    .maxConnectionLifeTime(20, MILLISECONDS).build());
+        provider.start();
 
         // when
         InternalConnection connection = provider.get();
@@ -149,6 +154,7 @@ public class DefaultConnectionPoolTest {
                                                                    .maxWaitQueueSize(1)
                                                                    .maintenanceInitialDelay(5, MINUTES)
                                                                    .maxConnectionIdleTime(50, MILLISECONDS).build());
+        provider.start();
 
         // when
         provider.get().close();
@@ -170,6 +176,7 @@ public class DefaultConnectionPoolTest {
                                                                    .maxWaitQueueSize(1)
                                                                    .maintenanceInitialDelay(5, MINUTES)
                                                                    .maxConnectionLifeTime(20, MILLISECONDS).build());
+        provider.start();
 
         // when
         provider.get().close();
@@ -191,6 +198,7 @@ public class DefaultConnectionPoolTest {
                                                                    .maxWaitQueueSize(1)
                                                                    .maintenanceInitialDelay(5, MINUTES)
                                                                    .maxConnectionLifeTime(20, MILLISECONDS).build());
+        provider.start();
 
         // when
         provider.get().close();
@@ -214,7 +222,8 @@ public class DefaultConnectionPoolTest {
                                                                    .maintenanceInitialDelay(5, MINUTES)
                                                                    .maxWaitQueueSize(1)
                                                                    .build());
-        provider.get().close();
+        provider.get().close();                                                  provider.start();
+
 
         // when
         Thread.sleep(10);
@@ -237,6 +246,7 @@ public class DefaultConnectionPoolTest {
                                                                    .maxWaitTime(5, SECONDS)
                                                                    .addConnectionPoolListener(listener)
                                                                    .build());
+        provider.start();
 
         // then
         assertEquals(0, listener.getWaitQueueSize());

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/ConnectionPoolTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/ConnectionPoolTest.java
@@ -103,6 +103,7 @@ public class ConnectionPoolTest {
 
         pool = new DefaultConnectionPool(new ServerId(new ClusterId(), serverAddress), new TestInternalConnectionFactory(),
                 settings);
+        pool.start();
     }
 
     @After

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultConnectionPoolSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DefaultConnectionPoolSpecification.groovy
@@ -60,6 +60,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         given:
         pool = new DefaultConnectionPool(SERVER_ID, connectionFactory,
                                          builder().maxSize(1).maxWaitQueueSize(1).build())
+        pool.start();
 
         expect:
         pool.get() != null
@@ -69,6 +70,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         given:
         pool = new DefaultConnectionPool(SERVER_ID, connectionFactory,
                                          builder().maxSize(1).maxWaitQueueSize(1).build())
+        pool.start();
 
         when:
         pool.get().close()
@@ -82,6 +84,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         given:
         pool = new DefaultConnectionPool(SERVER_ID, connectionFactory,
                                          builder().maxSize(1).maxWaitQueueSize(1).build())
+        pool.start();
 
         when:
         pool.get().close()
@@ -94,6 +97,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         given:
         pool = new DefaultConnectionPool(SERVER_ID, connectionFactory,
                                          builder().maxSize(1).maxWaitQueueSize(1).maxWaitTime(1, MILLISECONDS).build())
+        pool.start();
 
         when:
         def first = pool.get()
@@ -112,6 +116,8 @@ class DefaultConnectionPoolSpecification extends Specification {
         given:
         pool = new DefaultConnectionPool(SERVER_ID, connectionFactory,
                                          builder().maxSize(1).maxWaitQueueSize(1).maxWaitTime(50, MILLISECONDS).build())
+        pool.start();
+
         pool.get()
 
         when:
@@ -142,6 +148,8 @@ class DefaultConnectionPoolSpecification extends Specification {
         }
 
         pool = new DefaultConnectionPool(SERVER_ID, mockConnectionFactory, builder().maxSize(2).maxWaitQueueSize(1).build())
+        pool.start();
+
         when:
         def c1 = pool.get()
         def c2 = pool.get()
@@ -224,6 +232,8 @@ class DefaultConnectionPoolSpecification extends Specification {
 
         pool = new DefaultConnectionPool(SERVER_ID, mockConnectionFactory,
                                          builder().maxSize(2).maxWaitQueueSize(1).build())
+        pool.start();
+
         when:
         def c1 = pool.get()
         def c2 = pool.get()
@@ -293,6 +303,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         given:
         pool = new DefaultConnectionPool(SERVER_ID, connectionFactory,
                                          builder().maxSize(10).maintenanceInitialDelay(5, MINUTES).build())
+        pool.start();
 
         when:
         pool.doMaintenance()
@@ -306,6 +317,7 @@ class DefaultConnectionPoolSpecification extends Specification {
         given:
         pool = new DefaultConnectionPool(SERVER_ID, connectionFactory,
                                          builder().maxSize(10).minSize(5).maintenanceInitialDelay(5, MINUTES).build())
+        pool.start();
 
         when:
         pool.doMaintenance()

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/JMXConnectionPoolListenerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/JMXConnectionPoolListenerSpecification.groovy
@@ -43,6 +43,7 @@ class JMXConnectionPoolListenerSpecification extends Specification {
         provider = new DefaultConnectionPool(SERVER_ID, connectionFactory,
                 ConnectionPoolSettings.builder().minSize(0).maxSize(5).maxWaitQueueSize(1)
                         .addConnectionPoolListener(jmxListener).build())
+        provider.start();
 
         when:
         provider.get()
@@ -68,6 +69,7 @@ class JMXConnectionPoolListenerSpecification extends Specification {
         provider = new DefaultConnectionPool(SERVER_ID, connectionFactory,
                 ConnectionPoolSettings.builder().minSize(0).maxSize(5).maxWaitQueueSize(1)
                         .addConnectionPoolListener(jmxListener).build())
+        provider.start();
 
         then:
         ManagementFactory.getPlatformMBeanServer().isRegistered(
@@ -82,6 +84,8 @@ class JMXConnectionPoolListenerSpecification extends Specification {
         provider = new DefaultConnectionPool(SERVER_ID, connectionFactory,
                 ConnectionPoolSettings.builder().minSize(0).maxSize(5).maxWaitQueueSize(1)
                         .addConnectionPoolListener(jmxListener).build())
+        provider.start();
+
         when:
         provider.close()
 

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/TestConnectionPool.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/TestConnectionPool.java
@@ -39,6 +39,10 @@ public class TestConnectionPool implements ConnectionPool {
     }
 
     @Override
+    public void start() {
+    }
+
+    @Override
     public InternalConnection get() {
         return new InternalConnection() {
             @Override


### PR DESCRIPTION
The race condition is due to the constructor starting a thread which
access final fields of the containing class.  Since the thread may
execute before the constructor completes, there is no guarantee that
the final fields have been "published" to main memory, and therefore
the fields set in the constructor may not be visible to the thread
immediately.

The fix is to defer starting the thread to a start method that the
driver should call immediately after construction.

JAVA-3206