### PR TITLE
Update connection pool spec tests

### DIFF
--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/README.rst
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/README.rst
@@ -64,9 +64,14 @@ Valid Unit Test Operations are the following:
 
   - ``ms``: The number of milliseconds to sleep the current thread for
 
-- ``waitFor(target)``: wait for thread ``target`` to finish executing. Propagate any errors to the main thread.
+- ``waitForThread(target)``: wait for thread ``target`` to finish executing. Propagate any errors to the main thread.
 
   - ``target``: The name of the thread to wait for.
+
+- ``waitForEvent(event, count)``: block the current thread until ``event`` has occurred ``count`` times
+
+  - ``event``: The name of the event
+  - ``count``: The number of times the event must occur (counting from the start of the test)
 
 - ``label = pool.checkOut()``: call ``checkOut`` on pool, returning the checked out connection
 
@@ -137,6 +142,8 @@ For each YAML file with ``style: unit``:
   - Assert that ``actualEvents[idx]`` exists
   - Assert that ``actualEvents[idx]`` MATCHES ``expectedEvent``
 
+
+It is important to note that the ``ignore`` list is used for calculating ``actualEvents``, but is NOT used for the ``waitForEvent`` command
 
 Prose Tests
 ===========

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkout-multiple.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkout-multiple.json
@@ -8,16 +8,8 @@
       "target": "thread1"
     },
     {
-      "name": "wait",
-      "ms": 10
-    },
-    {
       "name": "start",
       "target": "thread2"
-    },
-    {
-      "name": "wait",
-      "ms": 20
     },
     {
       "name": "start",
@@ -36,30 +28,30 @@
       "thread": "thread3"
     },
     {
-      "name": "waitFor",
+      "name": "waitForThread",
       "target": "thread1"
     },
     {
-      "name": "waitFor",
+      "name": "waitForThread",
       "target": "thread2"
     },
     {
-      "name": "waitFor",
+      "name": "waitForThread",
       "target": "thread3"
     }
   ],
   "events": [
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 1
+      "connectionId": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 2
+      "connectionId": 42
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 3
+      "connectionId": 42
     }
   ],
   "ignore": [

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkout-no-idle.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkout-no-idle.json
@@ -29,13 +29,6 @@
       "options": 42
     },
     {
-      "type": "ConnectionCreated",
-      "connectionId": 1
-    },
-    {
-      "type": "ConnectionCheckOutStarted"
-    },
-    {
       "type": "ConnectionCheckedOut",
       "connectionId": 1
     },
@@ -44,16 +37,9 @@
       "connectionId": 1
     },
     {
-      "type": "ConnectionCheckOutStarted"
-    },
-    {
       "type": "ConnectionClosed",
       "connectionId": 1,
       "reason": "idle"
-    },
-    {
-      "type": "ConnectionCreated",
-      "connectionId": 2
     },
     {
       "type": "ConnectionCheckedOut",
@@ -61,6 +47,8 @@
     }
   ],
   "ignore": [
-    "ConnectionReady"
+    "ConnectionReady",
+    "ConnectionCreated",
+    "ConnectionCheckOutStarted"
   ]
 }

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkout-no-stale.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-checkout-no-stale.json
@@ -2,13 +2,14 @@
   "version": 1,
   "style": "unit",
   "description": "must destroy and must not check out a stale connection if found while iterating available connections",
-  "poolOptions": {
-    "minPoolSize": 3
-  },
   "operations": [
     {
-      "name": "wait",
-      "ms": 20
+      "name": "checkOut",
+      "label": "conn"
+    },
+    {
+      "name": "checkIn",
+      "connection": "conn"
     },
     {
       "name": "clear"
@@ -24,34 +25,30 @@
       "options": 42
     },
     {
+      "type": "ConnectionCheckedOut",
+      "connectionId": 1
+    },
+    {
+      "type": "ConnectionCheckedIn",
+      "connectionId": 1
+    },
+    {
       "type": "ConnectionPoolCleared",
       "address": 42
     },
     {
-      "type": "ConnectionCheckOutStarted"
-    },
-    {
       "type": "ConnectionClosed",
-      "connectionId": 42,
-      "reason": "stale"
-    },
-    {
-      "type": "ConnectionClosed",
-      "connectionId": 42,
-      "reason": "stale"
-    },
-    {
-      "type": "ConnectionClosed",
-      "connectionId": 42,
+      "connectionId": 1,
       "reason": "stale"
     },
     {
       "type": "ConnectionCheckedOut",
-      "connectionId": 4
+      "connectionId": 2
     }
   ],
   "ignore": [
+    "ConnectionReady",
     "ConnectionCreated",
-    "ConnectionReady"
+    "ConnectionCheckOutStarted"
   ]
 }

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-create-max-size.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-create-max-size.json
@@ -33,15 +33,16 @@
       "thread": "thread1"
     },
     {
-      "name": "wait",
-      "ms": 10
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutStarted",
+      "count": 5
     },
     {
       "name": "checkIn",
       "connection": "conn1"
     },
     {
-      "name": "waitFor",
+      "name": "waitForThread",
       "target": "thread1"
     }
   ],

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-create-min-size.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-create-min-size.json
@@ -3,12 +3,13 @@
   "style": "unit",
   "description": "must be able to start a pool with minPoolSize connections",
   "poolOptions": {
-    "minPoolSize": 5
+    "minPoolSize": 3
   },
   "operations": [
     {
-      "name": "wait",
-      "ms": 50
+      "name": "waitForEvent",
+      "event": "ConnectionCreated",
+      "count": 3
     },
     {
       "name": "checkOut"
@@ -33,23 +34,13 @@
       "connectionId": 42
     },
     {
-      "type": "ConnectionCreated",
-      "connectionId": 42
-    },
-    {
-      "type": "ConnectionCreated",
-      "connectionId": 42
-    },
-    {
-      "type": "ConnectionCheckOutStarted"
-    },
-    {
       "type": "ConnectionCheckedOut",
       "connectionId": 42
     }
   ],
   "ignore": [
     "ConnectionReady",
-    "ConnectionClosed"
+    "ConnectionClosed",
+    "ConnectionCheckOutStarted"
   ]
 }

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-create-with-options.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-create-with-options.json
@@ -9,8 +9,9 @@
   },
   "operations": [
     {
-      "name": "wait",
-      "ms": 20
+      "name": "waitForEvent",
+      "event": "ConnectionPoolCreated",
+      "count": 1
     }
   ],
   "events": [

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-create.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/pool-create.json
@@ -4,8 +4,9 @@
   "description": "must be able to create a pool",
   "operations": [
     {
-      "name": "wait",
-      "ms": 10
+      "name": "waitForEvent",
+      "event": "ConnectionPoolCreated",
+      "count": 1
     }
   ],
   "events": [

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/wait-queue-fairness.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/wait-queue-fairness.json
@@ -21,8 +21,9 @@
       "label": "conn1"
     },
     {
-      "name": "wait",
-      "ms": 10
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutStarted",
+      "count": 2
     },
     {
       "name": "start",
@@ -34,8 +35,9 @@
       "label": "conn2"
     },
     {
-      "name": "wait",
-      "ms": 10
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutStarted",
+      "count": 3
     },
     {
       "name": "start",
@@ -47,8 +49,9 @@
       "label": "conn3"
     },
     {
-      "name": "wait",
-      "ms": 10
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutStarted",
+      "count": 4
     },
     {
       "name": "start",
@@ -60,15 +63,16 @@
       "label": "conn4"
     },
     {
-      "name": "wait",
-      "ms": 10
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutStarted",
+      "count": 5
     },
     {
       "name": "checkIn",
       "connection": "conn0"
     },
     {
-      "name": "waitFor",
+      "name": "waitForThread",
       "target": "thread1"
     },
     {
@@ -76,7 +80,7 @@
       "connection": "conn1"
     },
     {
-      "name": "waitFor",
+      "name": "waitForThread",
       "target": "thread2"
     },
     {
@@ -84,7 +88,7 @@
       "connection": "conn2"
     },
     {
-      "name": "waitFor",
+      "name": "waitForThread",
       "target": "thread3"
     },
     {
@@ -92,7 +96,7 @@
       "connection": "conn3"
     },
     {
-      "name": "waitFor",
+      "name": "waitForThread",
       "target": "thread4"
     }
   ],

--- a/driver-core/src/test/resources/connection-monitoring-and-pooling/wait-queue-timeout.json
+++ b/driver-core/src/test/resources/connection-monitoring-and-pooling/wait-queue-timeout.json
@@ -20,15 +20,16 @@
       "thread": "thread1"
     },
     {
-      "name": "wait",
-      "ms": 40
+      "name": "waitForEvent",
+      "event": "ConnectionCheckOutFailed",
+      "count": 1
     },
     {
       "name": "checkIn",
       "connection": "conn0"
     },
     {
-      "name": "waitFor",
+      "name": "waitForThread",
       "target": "thread1"
     }
   ],


### PR DESCRIPTION
The new tests remove some race conditions inherent in the existing tests.

It turns out that most of the uses of `wait` in the tests were racy.  In the new tests, they are almost all replaced with the new `waitForEvent` operation.

Jira: https://jira.mongodb.org/browse/JAVA-3068
Patch build: https://evergreen.mongodb.com/version/5c746a9ae3c331049c155176