### PR TITLE
Fix and re-enable failing command monitoring tests on MongoDB 4.2+

### DIFF
--- a/driver-core/src/test/functional/com/mongodb/client/CommandMonitoringTestHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/client/CommandMonitoringTestHelper.java
@@ -187,9 +187,12 @@ public final class CommandMonitoringTestHelper {
             if (response.containsKey("writeErrors")) {
                 for (BsonValue bsonValue : response.getArray("writeErrors")) {
                     BsonDocument cur = bsonValue.asDocument();
-                    cur.put("code", new BsonInt32(42));
-                    cur.put("errmsg", new BsonString(""));
-                    cur.remove("codeName");
+                    BsonDocument newWriteErrorDocument =
+                            new BsonDocument().append("index", cur.get("index"))
+                                    .append("code", new BsonInt32(42))
+                                    .append("errmsg", new BsonString(""));
+                    cur.clear();
+                    cur.putAll(newWriteErrorDocument);
                 }
             }
             if (actual.getCommandName().equals("update")) {

--- a/driver-sync/src/test/functional/com/mongodb/client/CommandMonitoringTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/CommandMonitoringTest.java
@@ -48,7 +48,6 @@ import java.util.List;
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet;
 import static com.mongodb.ClusterFixture.isSharded;
 import static com.mongodb.ClusterFixture.isStandalone;
-import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static com.mongodb.client.CommandMonitoringTestHelper.getExpectedEvents;
 import static com.mongodb.client.Fixture.getDefaultDatabaseName;
 import static com.mongodb.client.Fixture.getMongoClientSettingsBuilder;
@@ -94,11 +93,6 @@ public class CommandMonitoringTest {
 
     @Before
     public void setUp() {
-        if (serverVersionAtLeast(4, 1)) {
-            assumeFalse(description.equals("A successful insert one command with write errors"));
-            assumeFalse(description.equals("A successful insert many command with write errors"));
-        }
-
         ServerVersion serverVersion = ClusterFixture.getServerVersion();
         if (definition.containsKey("ignore_if_server_version_less_than")) {
             assumeFalse(serverVersion.compareTo(getServerVersion("ignore_if_server_version_less_than")) < 0);


### PR DESCRIPTION
Make the tests pass again by ignoring extra fields in the writeError
document; these extra fields (e.g. keyPattern) are being inserted by
MongoDB 4.2+

JAVA-3098