### PR TITLE
Deprecate LazyDBList#toString

### DIFF
--- a/driver-legacy/src/main/com/mongodb/LazyDBList.java
+++ b/driver-legacy/src/main/com/mongodb/LazyDBList.java
@@ -61,8 +61,11 @@ public class LazyDBList extends LazyBSONList implements DBObject {
      * Returns a JSON serialization of this object
      *
      * @return JSON serialization
+     * @deprecated there is no replacement for this method, as the driver no longer supports generating top-level JSON arrays. To encode
+     * an instance of this class to JSON it must be embedded inside a document.
      */
     @SuppressWarnings("deprecation")
+    @Deprecated
     public String toString() {
         return com.mongodb.util.JSON.serialize(this);
     }


### PR DESCRIPTION
I noticed this will looking at what it will take to remove deprecated API elements (in this case the JSON class).  I'm concerned now that we need to actually do all the removal work for 4.0 in order to know for sure that we won't need to deprecate anything else for 3.11

https://jira.mongodb.org/browse/JAVA-3217