### PR TITLE
Remove MONGODB-CR public API support

### DIFF
--- a/driver-core/src/main/com/mongodb/AuthenticationMechanism.java
+++ b/driver-core/src/main/com/mongodb/AuthenticationMechanism.java
@@ -41,14 +41,6 @@ public enum AuthenticationMechanism {
     MONGODB_X509("MONGODB-X509"),
 
     /**
-     * The MongoDB Challenge Response mechanism.
-     *
-     * @deprecated This mechanism was replaced by {@link #SCRAM_SHA_1} in MongoDB 3.0, and is now deprecated
-     */
-    @Deprecated
-    MONGODB_CR("MONGODB-CR"),
-
-    /**
      * The SCRAM-SHA-1 mechanism.  See the <a href="http://tools.ietf.org/html/rfc5802">RFC</a>.
      */
     SCRAM_SHA_1("SCRAM-SHA-1"),

--- a/driver-core/src/main/com/mongodb/ConnectionString.java
+++ b/driver-core/src/main/com/mongodb/ConnectionString.java
@@ -663,7 +663,14 @@ public class ConnectionString {
             }
 
             if (key.equals("authmechanism")) {
-                mechanism = AuthenticationMechanism.fromMechanismName(value);
+                if (value.equals("MONGODB-CR")) {
+                    if (userName == null) {
+                        throw new IllegalArgumentException("username can not be null");
+                    }
+                    LOGGER.warn("Deprecated MONGDOB-CR authentication mechanism used in connection string");
+                } else {
+                    mechanism = AuthenticationMechanism.fromMechanismName(value);
+                }
             } else if (key.equals("authsource")) {
                 authSource = value;
             } else if (key.equals("gssapiservicename")) {
@@ -735,9 +742,6 @@ public class ConnectionString {
                 break;
             case PLAIN:
                 credential = MongoCredential.createPlainCredential(userName, mechanismAuthSource, password);
-                break;
-            case MONGODB_CR:
-                credential = MongoCredential.createMongoCRCredential(userName, mechanismAuthSource, password);
                 break;
             case MONGODB_X509:
                 if (password != null) {

--- a/driver-core/src/main/com/mongodb/MongoCredential.java
+++ b/driver-core/src/main/com/mongodb/MongoCredential.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.mongodb.AuthenticationMechanism.GSSAPI;
-import static com.mongodb.AuthenticationMechanism.MONGODB_CR;
 import static com.mongodb.AuthenticationMechanism.MONGODB_X509;
 import static com.mongodb.AuthenticationMechanism.PLAIN;
 import static com.mongodb.AuthenticationMechanism.SCRAM_SHA_1;
@@ -46,15 +45,6 @@ public final class MongoCredential {
     private final String source;
     private final char[] password;
     private final Map<String, Object> mechanismProperties;
-
-    /**
-     * The MongoDB Challenge Response mechanism.
-     * @mongodb.driver.manual core/authentication/#mongodb-cr-authentication MONGODB-CR
-     * @deprecated This mechanism was replaced by {@link #SCRAM_SHA_1_MECHANISM} in MongoDB 3.0, and is now deprecated
-     */
-    @SuppressWarnings("deprecation")
-    @Deprecated
-    public static final String MONGODB_CR_MECHANISM = AuthenticationMechanism.MONGODB_CR.getMechanismName();
 
     /**
      * The GSSAPI mechanism.  See the <a href="http://tools.ietf.org/html/rfc4752">RFC</a>.
@@ -208,27 +198,6 @@ public final class MongoCredential {
     }
 
     /**
-     * Creates a MongoCredential instance for the MongoDB Challenge Response protocol. Use this method only if you want to ensure that
-     * the driver uses the MONGODB_CR mechanism regardless of whether the server you are connecting to supports a more secure
-     * authentication mechanism.  Otherwise use the {@link #createCredential(String, String, char[])} method to allow the driver to
-     * negotiate the best mechanism based on the server version.
-     *
-     * @param userName the user name
-     * @param database the database where the user is defined
-     * @param password the user's password
-     * @return the credential
-     * @see #createCredential(String, String, char[])
-     * @mongodb.driver.manual core/authentication/#mongodb-cr-authentication MONGODB-CR
-     * @deprecated MONGODB-CR was replaced by SCRAM-SHA-1 in MongoDB 3.0, and is now deprecated. Use
-     * the {@link #createCredential(String, String, char[])} factory method instead.
-     */
-    @SuppressWarnings("deprecation")
-    @Deprecated
-    public static MongoCredential createMongoCRCredential(final String userName, final String database, final char[] password) {
-        return new MongoCredential(MONGODB_CR, userName, database, password);
-    }
-
-    /**
      * Creates a MongoCredential instance for the MongoDB X.509 protocol.
      *
      * @param userName the user name
@@ -370,9 +339,8 @@ public final class MongoCredential {
         this.mechanismProperties = new HashMap<String, Object>(mechanismProperties);
     }
 
-    @SuppressWarnings("deprecation")
     private boolean mechanismRequiresPassword(@Nullable final AuthenticationMechanism mechanism) {
-        return mechanism == PLAIN || mechanism == MONGODB_CR || mechanism == SCRAM_SHA_1 || mechanism == SCRAM_SHA_256;
+        return mechanism == PLAIN || mechanism == SCRAM_SHA_1 || mechanism == SCRAM_SHA_256;
 
     }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionFactory.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionFactory.java
@@ -73,8 +73,6 @@ class InternalStreamConnectionFactory implements InternalConnectionFactory {
             case SCRAM_SHA_1:
             case SCRAM_SHA_256:
                 return new ScramShaAuthenticator(credential);
-            case MONGODB_CR:
-                return new NativeAuthenticator(credential);
             default:
                 throw new IllegalArgumentException("Unsupported authentication mechanism " + credential.getAuthenticationMechanism());
         }

--- a/driver-core/src/test/functional/com/mongodb/operation/DropUserOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/DropUserOperationSpecification.groovy
@@ -25,10 +25,9 @@ import spock.lang.IgnoreIf
 import static com.mongodb.ClusterFixture.getBinding
 import static com.mongodb.ClusterFixture.isDiscoverableReplicaSet
 import static com.mongodb.ClusterFixture.serverVersionAtLeast
-import static com.mongodb.MongoCredential.createMongoCRCredential
+import static com.mongodb.MongoCredential.createCredential
 import static com.mongodb.MongoCredential.createScramSha1Credential
 import static com.mongodb.MongoCredential.createScramSha256Credential
-
 
 class DropUserOperationSpecification extends OperationFunctionalSpecification {
 
@@ -69,7 +68,7 @@ class DropUserOperationSpecification extends OperationFunctionalSpecification {
     @IgnoreIf({ !serverVersionAtLeast(3, 4) || !isDiscoverableReplicaSet() })
     def 'should throw MongoCommandException on write concern error'() {
         given:
-        def credential = createMongoCRCredential('userToDrop', databaseName, '123'.toCharArray())
+        def credential = createCredential('userToDrop', databaseName, '123'.toCharArray())
         new CreateUserOperation(credential, true).execute(getBinding())
         def operation = new DropUserOperation(databaseName, credential.userName, new WriteConcern(5))
 

--- a/driver-core/src/test/unit/com/mongodb/AbstractConnectionStringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/AbstractConnectionStringTest.java
@@ -109,8 +109,13 @@ public abstract class AbstractConnectionStringTest extends TestCase {
 
             if (option.getKey().equals("authmechanism")) {
                 String expected = option.getValue().asString().getValue();
-                String actual = connectionString.getCredential().getAuthenticationMechanism().getMechanismName();
-                assertEquals(expected, actual);
+                if (expected.equals("MONGODB-CR"))  {
+                    assertNotNull(connectionString.getCredential());
+                    assertNull(connectionString.getCredential().getAuthenticationMechanism());
+                } else {
+                    String actual = connectionString.getCredential().getAuthenticationMechanism().getMechanismName();
+                    assertEquals(expected, actual);
+                }
             } else if (option.getKey().toLowerCase().equals("retrywrites")) {
                 boolean expected = option.getValue().asBoolean().getValue();
                 assertEquals(expected, connectionString.getRetryWritesValue().booleanValue());
@@ -235,7 +240,6 @@ public abstract class AbstractConnectionStringTest extends TestCase {
             } else {
                 switch (mechanism) {
                     case PLAIN:
-                    case MONGODB_CR:
                     case SCRAM_SHA_1:
                     case SCRAM_SHA_256:
                         assertString("auth.password", password);

--- a/driver-core/src/test/unit/com/mongodb/AuthConnectionStringTest.java
+++ b/driver-core/src/test/unit/com/mongodb/AuthConnectionStringTest.java
@@ -105,8 +105,13 @@ public class AuthConnectionStringTest extends TestCase {
             for (Map.Entry<String, BsonValue> option : definition.getDocument("options").entrySet()) {
                 if (option.getKey().equals("authmechanism")) {
                     String expected = option.getValue().asString().getValue();
-                    String actual = connectionString.getCredential().getAuthenticationMechanism().getMechanismName();
-                    assertEquals(expected, actual);
+                    if (expected.equals("MONGODB-CR")) {
+                        assertNotNull(connectionString.getCredential());
+                        assertNull(connectionString.getCredential().getAuthenticationMechanism());
+                    } else {
+                        String actual = connectionString.getCredential().getAuthenticationMechanism().getMechanismName();
+                        assertEquals(expected, actual);
+                    }
                 }
             }
         }

--- a/driver-core/src/test/unit/com/mongodb/ConnectionStringSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/ConnectionStringSpecification.groovy
@@ -24,7 +24,6 @@ import static com.mongodb.MongoCompressor.createZlibCompressor
 import static com.mongodb.MongoCompressor.createZstdCompressor
 import static com.mongodb.MongoCredential.createCredential
 import static com.mongodb.MongoCredential.createGSSAPICredential
-import static com.mongodb.MongoCredential.createMongoCRCredential
 import static com.mongodb.MongoCredential.createMongoX509Credential
 import static com.mongodb.MongoCredential.createPlainCredential
 import static com.mongodb.MongoCredential.createScramSha1Credential
@@ -372,10 +371,10 @@ class ConnectionStringSpecification extends Specification {
         new ConnectionString('mongodb://jeff:123@localhost/?' +
                            '&authSource=test')                | createCredential('jeff', 'test', '123'.toCharArray())
         new ConnectionString('mongodb://jeff:123@localhost/?' +
-                           'authMechanism=MONGODB-CR')        | createMongoCRCredential('jeff', 'admin', '123'.toCharArray())
+                           'authMechanism=MONGODB-CR')        | createCredential('jeff', 'admin', '123'.toCharArray())
         new ConnectionString('mongodb://jeff:123@localhost/?' +
                            'authMechanism=MONGODB-CR' +
-                           '&authSource=test')                | createMongoCRCredential('jeff', 'test', '123'.toCharArray())
+                           '&authSource=test')                | createCredential('jeff', 'test', '123'.toCharArray())
         new ConnectionString('mongodb://jeff:123@localhost/?' +
                              'authMechanism=SCRAM-SHA-1')     | createScramSha1Credential('jeff', 'admin', '123'.toCharArray())
         new ConnectionString('mongodb://jeff:123@localhost/?' +

--- a/driver-core/src/test/unit/com/mongodb/MongoCredentialSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/MongoCredentialSpecification.groovy
@@ -18,7 +18,6 @@ package com.mongodb
 
 import spock.lang.Specification
 
-import static com.mongodb.AuthenticationMechanism.MONGODB_CR
 import static com.mongodb.AuthenticationMechanism.PLAIN
 import static com.mongodb.AuthenticationMechanism.SCRAM_SHA_1
 import static com.mongodb.AuthenticationMechanism.SCRAM_SHA_256
@@ -39,41 +38,6 @@ class MongoCredentialSpecification extends Specification {
         password == credential.getPassword()
         !credential.getAuthenticationMechanism()
         !credential.getMechanism()
-    }
-
-    def 'creating a challenge-response credential should populate correct fields'() {
-        given:
-        AuthenticationMechanism mechanism = MONGODB_CR
-        String userName = 'user'
-        String database = 'test'
-        char[] password = 'pwd'.toCharArray()
-
-        when:
-        MongoCredential credential = MongoCredential.createMongoCRCredential(userName, database, password)
-
-        then:
-        userName == credential.getUserName()
-        database == credential.getSource()
-        password == credential.getPassword()
-        mechanism == credential.getAuthenticationMechanism()
-        MongoCredential.MONGODB_CR_MECHANISM == credential.getMechanism()
-    }
-
-    def 'should throw IllegalArgumentException when required parameter is not supplied for challenge-response'() {
-        when:
-        MongoCredential.createMongoCRCredential(null, 'test', 'pwd'.toCharArray())
-        then:
-        thrown(IllegalArgumentException)
-
-        when:
-        MongoCredential.createMongoCRCredential('user', null, 'pwd'.toCharArray())
-        then:
-        thrown(IllegalArgumentException)
-
-        when:
-        MongoCredential.createMongoCRCredential('user', 'test', null)
-        then:
-        thrown(IllegalArgumentException)
     }
 
     def 'creating a Plain credential should populate all required fields'() {
@@ -284,15 +248,15 @@ class MongoCredentialSpecification extends Specification {
         def propertyValue = 'valueOne'
 
         when:
-        def credentialOne = MongoCredential.createMongoCRCredential(userName, database, password.toCharArray())
+        def credentialOne = MongoCredential.createScramSha256Credential(userName, database, password.toCharArray())
         def credentialTwo = credentialOne.withMechanismProperty(propertyKey, propertyValue)
 
         then:
-        MongoCredential.createMongoCRCredential(userName, database, password.toCharArray()) == credentialOne
+        MongoCredential.createScramSha256Credential(userName, database, password.toCharArray()) == credentialOne
         credentialOne.withMechanismProperty(propertyKey, propertyValue) == credentialTwo
         credentialOne != credentialTwo
 
-        MongoCredential.createMongoCRCredential(userName, database, password.toCharArray()).hashCode() == credentialOne.hashCode()
+        MongoCredential.createScramSha256Credential(userName, database, password.toCharArray()).hashCode() == credentialOne.hashCode()
         credentialOne.hashCode() != credentialTwo.hashCode()
 
         !credentialOne.toString().contains(password)
@@ -307,8 +271,6 @@ class MongoCredentialSpecification extends Specification {
         credential << [
             { MongoCredential.createCredential('user', 'database', 'pwd'.toCharArray()) },
             { MongoCredential.createCredential('user', 'database', 'pwd'.toCharArray()).withMechanismProperty('foo', 'bar') },
-            { MongoCredential.createMongoCRCredential('user', 'database', 'pwd'.toCharArray()) },
-            { MongoCredential.createMongoCRCredential('user', 'database', 'pwd'.toCharArray()).withMechanismProperty('foo', 'bar') },
             { MongoCredential.createPlainCredential('user', '$external', 'pwd'.toCharArray()) },
             { MongoCredential.createPlainCredential('user', '$external', 'pwd'.toCharArray()).withMechanismProperty('foo', 'bar') },
             { MongoCredential.createScramSha1Credential('user', '$external', 'pwd'.toCharArray()) },

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/NativeAuthenticatorUnitTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/NativeAuthenticatorUnitTest.java
@@ -39,12 +39,11 @@ public class NativeAuthenticatorUnitTest {
     private NativeAuthenticator subject;
     private ConnectionDescription connectionDescription;
 
-    @SuppressWarnings("deprecation")
     @Before
     public void before() {
         connection = new TestInternalConnection(new ServerId(new ClusterId(), new ServerAddress("localhost", 27017)));
         connectionDescription = new ConnectionDescription(new ServerId(new ClusterId(), new ServerAddress()));
-        MongoCredential credential = MongoCredential.createMongoCRCredential("\u53f0\u5317", "database",
+        MongoCredential credential = MongoCredential.createCredential("\u53f0\u5317", "database",
                 "Ta\u0301ibe\u030Ci".toCharArray());
         subject = new NativeAuthenticator(new MongoCredentialWithCache(credential));
     }

--- a/driver-legacy/src/test/unit/com/mongodb/MongoClientURISpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/MongoClientURISpecification.groovy
@@ -16,7 +16,6 @@
 
 package com.mongodb
 
-
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -24,7 +23,6 @@ import javax.net.ssl.SSLContext
 
 import static com.mongodb.MongoCredential.createCredential
 import static com.mongodb.MongoCredential.createGSSAPICredential
-import static com.mongodb.MongoCredential.createMongoCRCredential
 import static com.mongodb.MongoCredential.createMongoX509Credential
 import static com.mongodb.MongoCredential.createPlainCredential
 import static com.mongodb.MongoCredential.createScramSha1Credential
@@ -244,10 +242,10 @@ class MongoClientURISpecification extends Specification {
         uri                                                   | credentialList
         new MongoClientURI('mongodb://jeff:123@localhost')    | createCredential('jeff', 'admin', '123'.toCharArray())
         new MongoClientURI('mongodb://jeff:123@localhost/?' +
-                           'authMechanism=MONGODB-CR')        | createMongoCRCredential('jeff', 'admin', '123'.toCharArray())
+                           'authMechanism=MONGODB-CR')        | createCredential('jeff', 'admin', '123'.toCharArray())
         new MongoClientURI('mongodb://jeff:123@localhost/?' +
                            'authMechanism=MONGODB-CR' +
-                           '&authSource=test')                | createMongoCRCredential('jeff', 'test', '123'.toCharArray())
+                           '&authSource=test')                | createCredential('jeff', 'test', '123'.toCharArray())
         new MongoClientURI('mongodb://jeff:123@localhost/?' +
                            'authMechanism=SCRAM-SHA-1')       | createScramSha1Credential('jeff', 'admin', '123'.toCharArray())
         new MongoClientURI('mongodb://jeff:123@localhost/?' +


### PR DESCRIPTION
Note: MONGODB-CR authentication mechanism is still supported.  The only difference is that an application can no longer specify it explicitly. On the connection string the MONGODB-CR now uses
MongoCredential#createCredential instead of MongoCredential#createMongoCRCredential. Applications that create MongoCredential instances explicitly can use MongoCredential#createCredential as well.

https://jira.mongodb.org/browse/JAVA-3177