### PR TITLE
Removed deprecated ConnectionString#getStreamType method

### DIFF
--- a/driver-core/src/main/com/mongodb/ConnectionString.java
+++ b/driver-core/src/main/com/mongodb/ConnectionString.java
@@ -16,7 +16,6 @@
 
 package com.mongodb;
 
-import com.mongodb.connection.StreamFactoryFactory;
 import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
 import com.mongodb.internal.dns.DefaultDnsResolver;
@@ -119,9 +118,6 @@ import static java.util.Collections.unmodifiableList;
  * <li>{@code socketTimeoutMS=ms}: How long a send or receive on a socket can take before timing out.</li>
  * <li>{@code maxIdleTimeMS=ms}: Maximum idle time of a pooled connection. A connection that exceeds this limit will be closed</li>
  * <li>{@code maxLifeTimeMS=ms}: Maximum life time of a pooled connection. A connection that exceeds this limit will be closed</li>
- * <li>{@code streamType=nio2|netty}: The stream type to use for connections. If unspecified, nio2 will be used for asynchronous
- * clients.  Note that this query parameter has been deprecated and applications should use
- * {@link MongoClientSettings.Builder#streamFactoryFactory(StreamFactoryFactory)} instead.</li>
  * </ul>
  * <p>Connection pool configuration:</p>
  * <ul>
@@ -260,7 +256,6 @@ public class ConnectionString {
     private Integer socketTimeout;
     private Boolean sslEnabled;
     private Boolean sslInvalidHostnameAllowed;
-    private String streamType;
     private String requiredReplicaSetName;
     private Integer serverSelectionTimeout;
     private Integer localThreshold;
@@ -513,7 +508,6 @@ public class ConnectionString {
             } else if (key.equals("tls")) {
                 initializeSslEnabled("tls", value);
             } else if (key.equals("streamtype")) {
-                streamType = value;
                 LOGGER.warn("The streamType query parameter is deprecated and support for it will be removed"
                         + " in the next major release.");
             } else if (key.equals("replicaset")) {
@@ -1231,19 +1225,6 @@ public class ConnectionString {
     @Nullable
     public Boolean getSslEnabled() {
         return sslEnabled;
-    }
-
-    /**
-     * Gets the stream type value specified in the connection string.
-     * @return the stream type value
-     * @since 3.3
-     * @deprecated Use {@link MongoClientSettings.Builder#streamFactoryFactory(StreamFactoryFactory)} to configure the stream type
-     * programmatically
-     */
-    @Deprecated
-    @Nullable
-    public String getStreamType() {
-        return streamType;
     }
 
     /**

--- a/driver-core/src/test/unit/com/mongodb/ConnectionStringSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/ConnectionStringSpecification.groovy
@@ -159,7 +159,6 @@ class ConnectionStringSpecification extends Specification {
         connectionString.getServerSelectionTimeout() == 25000
         connectionString.getLocalThreshold() == 30
         connectionString.getHeartbeatFrequency() == 20000
-        connectionString.getStreamType() == 'netty'
         connectionString.getApplicationName() == 'app1'
 
         where:
@@ -167,7 +166,7 @@ class ConnectionStringSpecification extends Specification {
                 [new ConnectionString('mongodb://localhost/?minPoolSize=5&maxPoolSize=10&waitQueueMultiple=7&waitQueueTimeoutMS=150&'
                                             + 'maxIdleTimeMS=200&maxLifeTimeMS=300&replicaSet=test&'
                                             + 'connectTimeoutMS=2500&socketTimeoutMS=5500&'
-                                            + 'safe=false&w=1&wtimeout=2500&fsync=true&readPreference=primary&ssl=true&streamType=netty&'
+                                            + 'safe=false&w=1&wtimeout=2500&fsync=true&readPreference=primary&ssl=true&'
                                             + 'sslInvalidHostNameAllowed=true&'
                                             + 'serverSelectionTimeoutMS=25000&'
                                             + 'localThresholdMS=30&'
@@ -176,7 +175,7 @@ class ConnectionStringSpecification extends Specification {
                  new ConnectionString('mongodb://localhost/?minPoolSize=5;maxPoolSize=10;waitQueueMultiple=7;waitQueueTimeoutMS=150;'
                                             + 'maxIdleTimeMS=200;maxLifeTimeMS=300;replicaSet=test;'
                                             + 'connectTimeoutMS=2500;socketTimeoutMS=5500;'
-                                            + 'safe=false;w=1;wtimeout=2500;fsync=true;readPreference=primary;ssl=true;streamType=netty;'
+                                            + 'safe=false;w=1;wtimeout=2500;fsync=true;readPreference=primary;ssl=true;'
                                             + 'sslInvalidHostNameAllowed=true;'
                                             + 'serverSelectionTimeoutMS=25000;'
                                             + 'localThresholdMS=30;'
@@ -186,7 +185,7 @@ class ConnectionStringSpecification extends Specification {
                                             + 'maxIdleTimeMS=200&maxLifeTimeMS=300&replicaSet=test;'
                                             + 'connectTimeoutMS=2500;'
                                             + 'socketTimeoutMS=5500&'
-                                            + 'safe=false&w=1;wtimeout=2500;fsync=true&readPreference=primary;ssl=true&streamType=netty;'
+                                            + 'safe=false&w=1;wtimeout=2500;fsync=true&readPreference=primary;ssl=true;'
                                             + 'sslInvalidHostNameAllowed=true;'
                                             + 'serverSelectionTimeoutMS=25000&'
                                             + 'localThresholdMS=30;'
@@ -353,7 +352,6 @@ class ConnectionStringSpecification extends Specification {
         connectionString.getRequiredReplicaSetName() == null
         connectionString.getSslEnabled() == null
         connectionString.getSslInvalidHostnameAllowed() == null
-        connectionString.getStreamType() == null
         connectionString.getApplicationName() == null
         connectionString.getCompressorList() == []
         !connectionString.getRetryWrites()


### PR DESCRIPTION
Netty is now supported only via programmatic configuration of a NettyStreamFactoryFactory

https://jira.mongodb.org/browse/JAVA-3177