### PR TITLE
Remove deprecated MD5 support from async GridFS API

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/gridfs/GridFSBucket.java
+++ b/driver-async/src/main/com/mongodb/async/client/gridfs/GridFSBucket.java
@@ -76,14 +76,6 @@ public interface GridFSBucket {
     ReadConcern getReadConcern();
 
     /**
-     * Returns true if computing MD5 checksums when uploading files is disabled.
-     *
-     * @return true if computing MD5 checksums when uploading files is disabled.
-     * @since 3.8
-     */
-    boolean getDisableMD5();
-
-    /**
      * Create a new GridFSBucket instance with a new chunk size in bytes.
      *
      * @param chunkSizeBytes the new chunk size in bytes.
@@ -116,15 +108,6 @@ public interface GridFSBucket {
      * @mongodb.driver.manual reference/readConcern/ Read Concern
      */
     GridFSBucket withReadConcern(ReadConcern readConcern);
-
-    /**
-     * Create a new GridFSBucket instance with the set disable MD5 value.
-     *
-     * @param disableMD5 true if computing MD5 checksums when uploading files should be disabled.
-     * @return a new GridFSBucket instance with the new disable MD5 value.
-     * @since 3.8
-     */
-    GridFSBucket withDisableMD5(boolean disableMD5);
 
     /**
      * Opens a AsyncOutputStream that the application can write the contents of the file to.

--- a/driver-async/src/main/com/mongodb/async/client/gridfs/GridFSBucketImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/gridfs/GridFSBucketImpl.java
@@ -60,7 +60,6 @@ final class GridFSBucketImpl implements GridFSBucket {
     private final int chunkSizeBytes;
     private final MongoCollection<GridFSFile> filesCollection;
     private final MongoCollection<Document> chunksCollection;
-    private final boolean disableMD5;
 
     GridFSBucketImpl(final MongoDatabase database) {
         this(database, "fs");
@@ -69,16 +68,15 @@ final class GridFSBucketImpl implements GridFSBucket {
     GridFSBucketImpl(final MongoDatabase database, final String bucketName) {
         this(notNull("bucketName", bucketName), DEFAULT_CHUNKSIZE_BYTES,
                 getFilesCollection(notNull("database", database), bucketName),
-                getChunksCollection(database, bucketName), false);
+                getChunksCollection(database, bucketName));
     }
 
     GridFSBucketImpl(final String bucketName, final int chunkSizeBytes, final MongoCollection<GridFSFile> filesCollection,
-                     final MongoCollection<Document> chunksCollection, final boolean disableMD5) {
+                     final MongoCollection<Document> chunksCollection) {
         this.bucketName = notNull("bucketName", bucketName);
         this.chunkSizeBytes = chunkSizeBytes;
         this.filesCollection = notNull("filesCollection", filesCollection);
         this.chunksCollection = notNull("chunksCollection", chunksCollection);
-        this.disableMD5 = disableMD5;
     }
 
     @Override
@@ -107,39 +105,29 @@ final class GridFSBucketImpl implements GridFSBucket {
     }
 
     @Override
-    public boolean getDisableMD5() {
-        return disableMD5;
-    }
-
-    @Override
     public GridFSBucket withChunkSizeBytes(final int chunkSizeBytes) {
-        return new GridFSBucketImpl(bucketName, chunkSizeBytes, filesCollection, chunksCollection, disableMD5);
+        return new GridFSBucketImpl(bucketName, chunkSizeBytes, filesCollection, chunksCollection);
     }
 
     @Override
     public GridFSBucket withReadPreference(final ReadPreference readPreference) {
         notNull("readPreference", readPreference);
         return new GridFSBucketImpl(bucketName, chunkSizeBytes, filesCollection.withReadPreference(readPreference),
-                chunksCollection.withReadPreference(readPreference), disableMD5);
+                chunksCollection.withReadPreference(readPreference));
     }
 
     @Override
     public GridFSBucket withWriteConcern(final WriteConcern writeConcern) {
         notNull("writeConcern", writeConcern);
         return new GridFSBucketImpl(bucketName, chunkSizeBytes, filesCollection.withWriteConcern(writeConcern),
-                chunksCollection.withWriteConcern(writeConcern), disableMD5);
+                chunksCollection.withWriteConcern(writeConcern));
     }
 
     @Override
     public GridFSBucket withReadConcern(final ReadConcern readConcern) {
         notNull("readConcern", readConcern);
         return new GridFSBucketImpl(bucketName, chunkSizeBytes, filesCollection.withReadConcern(readConcern),
-                chunksCollection.withReadConcern(readConcern), disableMD5);
-    }
-
-    @Override
-    public GridFSBucket withDisableMD5(final boolean disableMD5) {
-        return new GridFSBucketImpl(bucketName, chunkSizeBytes, filesCollection, chunksCollection, disableMD5);
+                chunksCollection.withReadConcern(readConcern));
     }
 
     @Override
@@ -190,7 +178,7 @@ final class GridFSBucketImpl implements GridFSBucket {
         notNull("options", options);
         Integer chunkSizeBytes = options.getChunkSizeBytes();
         int chunkSize = chunkSizeBytes == null ? this.chunkSizeBytes : chunkSizeBytes;
-        return new GridFSUploadStreamImpl(clientSession, filesCollection, chunksCollection, id, filename, chunkSize, disableMD5,
+        return new GridFSUploadStreamImpl(clientSession, filesCollection, chunksCollection, id, filename, chunkSize,
                 options.getMetadata(), new GridFSIndexCheckImpl(clientSession, filesCollection, chunksCollection));
     }
 

--- a/driver-async/src/test/functional/com/mongodb/async/client/gridfs/GridFSBucketSmokeTestSpecification.groovy
+++ b/driver-async/src/test/functional/com/mongodb/async/client/gridfs/GridFSBucketSmokeTestSpecification.groovy
@@ -34,7 +34,6 @@ import org.junit.experimental.categories.Category
 import spock.lang.Unroll
 
 import java.nio.ByteBuffer
-import java.security.MessageDigest
 import java.security.SecureRandom
 
 import static com.mongodb.async.client.Fixture.getDefaultDatabaseName
@@ -78,8 +77,7 @@ class GridFSBucketSmokeTestSpecification extends FunctionalSpecification {
         def content = multiChunk ? multiChunkString : singleChunkString
         def contentBytes = content as byte[]
         def expectedLength = contentBytes.length
-        def expectedMD5 = md5Disabled ? null : MessageDigest.getInstance('MD5').digest(contentBytes).encodeHex().toString()
-        def bucket = gridFSBucket.withDisableMD5(md5Disabled)
+        def bucket = gridFSBucket
         ObjectId fileId
 
         when:
@@ -103,7 +101,6 @@ class GridFSBucketSmokeTestSpecification extends FunctionalSpecification {
         fileInfo.getId().getValue() == fileId
         fileInfo.getChunkSize() == bucket.getChunkSizeBytes()
         fileInfo.getLength() == expectedLength
-        fileInfo.getMD5() == expectedMD5
         fileInfo.getMetadata() == null
 
         when:
@@ -120,13 +117,11 @@ class GridFSBucketSmokeTestSpecification extends FunctionalSpecification {
         byteBuffer.array() == contentBytes
 
         where:
-        description                     | multiChunk | chunkCount | direct | md5Disabled
-        'a small file directly'         | false      | 1          | true   | false
-        'a small file to stream'        | false      | 1          | false  | false
-        'a large file directly'         | true       | 5          | true   | false
-        'a large file to stream'        | true       | 5          | false  | false
-        'a small file directly no md5'  | false      | 1          | true   | true
-        'a small file to stream no md5' | false      | 1          | false  | true
+        description                     | multiChunk | chunkCount | direct
+        'a small file directly'         | false      | 1          | true
+        'a small file to stream'        | false      | 1          | false
+        'a large file directly'         | true       | 5          | true
+        'a large file to stream'        | true       | 5          | false
     }
 
     @Category(Slow)
@@ -304,7 +299,6 @@ class GridFSBucketSmokeTestSpecification extends FunctionalSpecification {
         def content = multiChunkString
         def contentBytes = content as byte[]
         def expectedLength = contentBytes.length as Long
-        def expectedMD5 = MessageDigest.getInstance('MD5').digest(contentBytes).encodeHex().toString()
         ObjectId fileId
 
         when:
@@ -321,7 +315,6 @@ class GridFSBucketSmokeTestSpecification extends FunctionalSpecification {
         fileInfo.getObjectId() == fileId
         fileInfo.getChunkSize() == gridFSBucket.getChunkSizeBytes()
         fileInfo.getLength() == expectedLength
-        fileInfo.getMD5() == expectedMD5
         fileInfo.getMetadata() == null
 
         when:
@@ -343,7 +336,6 @@ class GridFSBucketSmokeTestSpecification extends FunctionalSpecification {
         def contentBytes = content as byte[]
         def expectedLength = contentBytes.length as Long
         def expectedNoChunks = Math.ceil((expectedLength as double) / chunkSize) as int
-        def expectedMD5 = MessageDigest.getInstance('MD5').digest(contentBytes).encodeHex().toString()
         ObjectId fileId
 
         when:
@@ -367,7 +359,6 @@ class GridFSBucketSmokeTestSpecification extends FunctionalSpecification {
         fileInfo.getId().getValue() == fileId
         fileInfo.getChunkSize() == options.getChunkSizeBytes()
         fileInfo.getLength() == expectedLength
-        fileInfo.getMD5() == expectedMD5
         fileInfo.getMetadata() == options.getMetadata()
 
         when:

--- a/driver-async/src/test/functional/com/mongodb/async/client/gridfs/GridFSTest.java
+++ b/driver-async/src/test/functional/com/mongodb/async/client/gridfs/GridFSTest.java
@@ -334,9 +334,6 @@ public class GridFSTest extends DatabaseTestCase {
             if (rawOptions.containsKey("metadata")) {
                 options.metadata(Document.parse(rawOptions.getDocument("metadata").toJson()));
             }
-            if (rawOptions.containsKey("disableMD5")) {
-                bucket = bucket.withDisableMD5(rawOptions.getBoolean("disableMD5").getValue());
-            }
             final GridFSBucket gridFSUploadBucket = bucket;
 
             objectId = new MongoOperation<ObjectId>() {
@@ -373,7 +370,6 @@ public class GridFSTest extends DatabaseTestCase {
                     for (BsonDocument expected : documents) {
                         assertEquals(expected.get("length"), actual.get("length"));
                         assertEquals(expected.get("chunkSize"), actual.get("chunkSize"));
-                        assertEquals(expected.get("md5"), actual.get("md5"));
                         assertEquals(expected.get("filename"), actual.get("filename"));
 
                         if (expected.containsKey("metadata")) {

--- a/driver-async/src/test/unit/com/mongodb/async/client/gridfs/GridFSBucketSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/gridfs/GridFSBucketSpecification.groovy
@@ -99,7 +99,7 @@ class GridFSBucketSpecification extends Specification {
         def newReadPreference = secondary()
 
         when:
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection, disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
                 .withReadPreference(newReadPreference)
 
         then:
@@ -120,7 +120,7 @@ class GridFSBucketSpecification extends Specification {
         def newWriteConcern = WriteConcern.MAJORITY
 
         when:
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection, disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
                 .withWriteConcern(newWriteConcern)
 
         then:
@@ -141,7 +141,7 @@ class GridFSBucketSpecification extends Specification {
         def newReadConcern = ReadConcern.MAJORITY
 
         when:
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection, disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
                 .withReadConcern(newReadConcern)
 
         then:
@@ -153,20 +153,6 @@ class GridFSBucketSpecification extends Specification {
 
         then:
         1 * filesCollection.getReadConcern() >> newReadConcern
-    }
-
-    def 'should behave correctly when using withDisableMD5'() {
-        when:
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, Stub(MongoCollection), Stub(MongoCollection), disableMD5)
-
-        then:
-        !gridFSBucket.getDisableMD5()
-
-        when:
-        gridFSBucket = gridFSBucket.withDisableMD5(true)
-
-        then:
-        gridFSBucket.getDisableMD5()
     }
 
     def 'should get defaults from MongoDatabase'() {
@@ -189,7 +175,7 @@ class GridFSBucketSpecification extends Specification {
         given:
         def filesCollection = Stub(MongoCollection)
         def chunksCollection = Stub(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection, disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
 
         when:
         def stream
@@ -201,7 +187,7 @@ class GridFSBucketSpecification extends Specification {
 
         then:
         expect stream, isTheSameAs(new GridFSUploadStreamImpl(clientSession, filesCollection, chunksCollection, stream.getId(),
-                'filename', 255, disableMD5, null, new GridFSIndexCheckImpl(clientSession, filesCollection, chunksCollection)),
+                'filename', 255, null, new GridFSIndexCheckImpl(clientSession, filesCollection, chunksCollection)),
                 ['md5', 'closeAndWritingLock'])
 
         where:
@@ -213,7 +199,7 @@ class GridFSBucketSpecification extends Specification {
         def findIterable = Mock(FindIterable)
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection, disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
         def contentBytes = 'content' as byte[]
         def inputStream = toAsyncInputStream(new ByteArrayInputStream(contentBytes))
 
@@ -252,7 +238,7 @@ class GridFSBucketSpecification extends Specification {
         def findIterable = Mock(FindIterable)
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection, disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
         def inputStream = Mock(AsyncInputStream) {
             2 * read(_, _) >> { it[0].put(new byte[255]); it.last().onResult(255, null) } >> {
                 it.last().onResult(null, new IOException('stream failure'))
@@ -310,7 +296,7 @@ class GridFSBucketSpecification extends Specification {
         def findIterable = Mock(FindIterable)
         def chunksCollection = Mock(MongoCollection)
         def alternativeException = new MongoGridFSException('Alternative failure')
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection, disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
         def inputStream = Mock(AsyncInputStream) {
             2 * read(_, _) >> {  it[0].put(new byte[255]); it.last().onResult(255, null) } >> {
                 it.last().onResult(null, alternativeException)
@@ -359,7 +345,7 @@ class GridFSBucketSpecification extends Specification {
         def findIterable = Mock(FindIterable)
         def chunksCollection = Mock(MongoCollection)
         def uploadStreamException = new MongoException('Alternative failure')
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection, disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
         def inputStream = Mock(AsyncInputStream)
         def futureResult = new FutureResultCallback()
 
@@ -439,7 +425,7 @@ class GridFSBucketSpecification extends Specification {
         def gridFSFindIterable = new GridFSFindIterableImpl(findIterable)
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Stub(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection, disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
 
         when:
         def stream
@@ -478,7 +464,7 @@ class GridFSBucketSpecification extends Specification {
         def tenBytes = new byte[sizeOfStream]
         def chunkDocument = new Document('files_id', fileInfo.getId()).append('n', 0).append('data', new Binary(tenBytes))
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection, disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
         def outputStream = new ByteArrayOutputStream(1024)
         def asyncOutputStream = toAsyncOutputStream(outputStream)
 
@@ -533,7 +519,7 @@ class GridFSBucketSpecification extends Specification {
         def tenBytes = new byte[sizeOfStream]
         def chunkDocument = new Document('files_id', fileId).append('n', 0).append('data', new Binary(tenBytes))
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection, disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
         def outputStream = new ByteArrayOutputStream(1024)
         def asyncOutputStream = toAsyncOutputStream(outputStream)
 
@@ -592,7 +578,7 @@ class GridFSBucketSpecification extends Specification {
         def tenBytes = new byte[sizeOfStream]
         def chunkDocument = new Document('files_id', fileId).append('n', 0).append('data', new Binary(tenBytes))
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection, disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
         def outputStream = new ByteArrayOutputStream(1024)
         def asyncOutputStream = toAsyncOutputStream(outputStream)
 
@@ -642,7 +628,7 @@ class GridFSBucketSpecification extends Specification {
         def findIterable = Mock(FindIterable)
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Stub(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection, disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
 
         when:
         def futureResult = new FutureResultCallback()
@@ -681,7 +667,7 @@ class GridFSBucketSpecification extends Specification {
         def findIterable = Mock(FindIterable)
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Stub(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection, disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
 
         when:
         def futureResult = new FutureResultCallback()
@@ -729,7 +715,7 @@ class GridFSBucketSpecification extends Specification {
         given:
         def collection = Mock(MongoCollection)
         def findIterable = Mock(FindIterable)
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, collection, Stub(MongoCollection), disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, collection, Stub(MongoCollection))
 
 
         when:
@@ -778,7 +764,7 @@ class GridFSBucketSpecification extends Specification {
         def findIterable = Mock(FindIterable)
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Stub(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection, disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
         when:
         def futureResult = new FutureResultCallback()
         def stream
@@ -813,7 +799,7 @@ class GridFSBucketSpecification extends Specification {
         def fileId = new ObjectId()
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection, disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
 
         when:
         def futureResult = new FutureResultCallback()
@@ -837,7 +823,7 @@ class GridFSBucketSpecification extends Specification {
         def fileId = new ObjectId()
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection, disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
 
         when:
         def futureResult = new FutureResultCallback()
@@ -865,7 +851,7 @@ class GridFSBucketSpecification extends Specification {
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
         def deleteException = new MongoException('delete failed')
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection, disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
 
         when:
         def futureResult = new FutureResultCallback()
@@ -911,7 +897,7 @@ class GridFSBucketSpecification extends Specification {
         def fileId = new ObjectId()
         def filesCollection = Mock(MongoCollection)
         def newFilename = 'newFilename'
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, Stub(MongoCollection), disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, Stub(MongoCollection))
 
         when:
         def futureResult = new FutureResultCallback()
@@ -934,7 +920,7 @@ class GridFSBucketSpecification extends Specification {
         def fileId = new ObjectId()
         def filesCollection = Mock(MongoCollection)
         def newFilename = 'newFilename'
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, Stub(MongoCollection), disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, Stub(MongoCollection))
 
         when:
         def futureResult = new FutureResultCallback()
@@ -957,7 +943,7 @@ class GridFSBucketSpecification extends Specification {
         def filesCollection = Mock(MongoCollection)
         def newFilename = 'newFilename'
         def exception =  new MongoException('failed')
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, Stub(MongoCollection), disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, Stub(MongoCollection))
 
         when:
         def futureResult = new FutureResultCallback()
@@ -979,7 +965,7 @@ class GridFSBucketSpecification extends Specification {
         given:
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection, disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
 
         when:
         def futureResult = new FutureResultCallback()
@@ -999,7 +985,7 @@ class GridFSBucketSpecification extends Specification {
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
         def exception =  new MongoException('failed')
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection, disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
 
         when:
         def futureResult = new FutureResultCallback()
@@ -1035,7 +1021,7 @@ class GridFSBucketSpecification extends Specification {
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
         def callback = Stub(SingleResultCallback)
-        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection, disableMD5)
+        def gridFSBucket = new GridFSBucketImpl('fs', 255, filesCollection, chunksCollection)
 
         when:
         gridFSBucket.delete(null, objectId, callback)

--- a/driver-async/src/test/unit/com/mongodb/async/client/gridfs/GridFSUploadStreamSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/gridfs/GridFSUploadStreamSpecification.groovy
@@ -20,8 +20,8 @@ import com.mongodb.MongoException
 import com.mongodb.MongoGridFSException
 import com.mongodb.async.FutureResultCallback
 import com.mongodb.async.SingleResultCallback
-import com.mongodb.async.client.MongoCollection
 import com.mongodb.async.client.ClientSession
+import com.mongodb.async.client.MongoCollection
 import org.bson.BsonObjectId
 import org.bson.BsonString
 import org.bson.Document
@@ -29,7 +29,6 @@ import org.bson.types.Binary
 import spock.lang.Specification
 
 import java.nio.ByteBuffer
-import java.security.MessageDigest
 import java.util.concurrent.CountDownLatch
 
 class GridFSUploadStreamSpecification extends Specification {
@@ -37,12 +36,11 @@ class GridFSUploadStreamSpecification extends Specification {
     def filename = 'filename'
     def metadata = new Document()
     def content = 'file content ' as byte[]
-    def disableMD5 = false
 
     def 'should return the file id'() {
         when:
-        def uploadStream = new GridFSUploadStreamImpl(clientSession, Stub(MongoCollection), Stub(MongoCollection), fileId, filename, 255,
-                disableMD5, metadata, NOOP_INDEXCHECK)
+        def uploadStream = new GridFSUploadStreamImpl(clientSession, Stub(MongoCollection), Stub(MongoCollection), fileId, filename, 255
+                , metadata, NOOP_INDEXCHECK)
 
         then:
         uploadStream.getId() == fileId
@@ -56,8 +54,8 @@ class GridFSUploadStreamSpecification extends Specification {
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
         def callback = Stub(SingleResultCallback)
-        def uploadStream = new GridFSUploadStreamImpl(clientSession, filesCollection, chunksCollection, fileId, filename, 2,
-                disableMD5, metadata, NOOP_INDEXCHECK)
+        def uploadStream = new GridFSUploadStreamImpl(clientSession, filesCollection, chunksCollection, fileId, filename, 2
+                , metadata, NOOP_INDEXCHECK)
 
         when:
         uploadStream.write(ByteBuffer.wrap(new byte[1]), callback)
@@ -84,8 +82,8 @@ class GridFSUploadStreamSpecification extends Specification {
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
         def callback = Stub(SingleResultCallback)
-        def uploadStream = new GridFSUploadStreamImpl(clientSession, filesCollection, chunksCollection, fileId, filename, 255,
-                disableMD5, null, NOOP_INDEXCHECK)
+        def uploadStream = new GridFSUploadStreamImpl(clientSession, filesCollection, chunksCollection, fileId, filename, 255
+                , null, NOOP_INDEXCHECK)
         def byteBuffer = ByteBuffer.wrap(new byte[10])
 
         when:
@@ -117,7 +115,7 @@ class GridFSUploadStreamSpecification extends Specification {
         def callback = Stub(SingleResultCallback)
         def metadata = new Document('contentType', 'text/txt')
         def uploadStream = new GridFSUploadStreamImpl(clientSession, filesCollection, chunksCollection, fileId, filename, 255,
-                md5Disabled, metadata, NOOP_INDEXCHECK)
+                metadata, NOOP_INDEXCHECK)
         def chunksData
         def fileData
 
@@ -157,11 +155,10 @@ class GridFSUploadStreamSpecification extends Specification {
         fileData.getFilename() == filename
         fileData.getLength() == content.length as Long
         fileData.getChunkSize() == 255
-        fileData.getMD5() == md5Disabled ? null : MessageDigest.getInstance('MD5').digest(content).encodeHex().toString()
         fileData.getMetadata() == metadata
 
         where:
-        [clientSession, md5Disabled] << [[null, Stub(ClientSession)], [true, false]].combinations()
+        clientSession << [null, Stub(ClientSession)]
     }
 
     def 'should not write an empty chunk'() {
@@ -169,8 +166,8 @@ class GridFSUploadStreamSpecification extends Specification {
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
         def callback = Stub(SingleResultCallback)
-        def uploadStream = new GridFSUploadStreamImpl(clientSession, filesCollection, chunksCollection, fileId, filename, 255,
-                disableMD5, metadata, NOOP_INDEXCHECK)
+        def uploadStream = new GridFSUploadStreamImpl(clientSession, filesCollection, chunksCollection, fileId, filename, 255
+                , metadata, NOOP_INDEXCHECK)
 
         when:
         uploadStream.close(callback)
@@ -191,8 +188,8 @@ class GridFSUploadStreamSpecification extends Specification {
         given:
         def chunksCollection = Mock(MongoCollection)
         def callback = Stub(SingleResultCallback)
-        def uploadStream = new GridFSUploadStreamImpl(clientSession, Stub(MongoCollection), chunksCollection, fileId, filename, 255,
-                disableMD5, metadata, NOOP_INDEXCHECK)
+        def uploadStream = new GridFSUploadStreamImpl(clientSession, Stub(MongoCollection), chunksCollection, fileId, filename, 255
+                , metadata, NOOP_INDEXCHECK)
 
         when:
         uploadStream.write(ByteBuffer.wrap(content), callback)
@@ -212,8 +209,8 @@ class GridFSUploadStreamSpecification extends Specification {
     def 'should close the stream on abort'() {
         given:
         def callback = Stub(SingleResultCallback)
-        def uploadStream = new GridFSUploadStreamImpl(clientSession, Stub(MongoCollection), Stub(MongoCollection), fileId, filename, 255,
-                disableMD5, metadata, NOOP_INDEXCHECK)
+        def uploadStream = new GridFSUploadStreamImpl(clientSession, Stub(MongoCollection), Stub(MongoCollection), fileId, filename, 255
+                , metadata, NOOP_INDEXCHECK)
         uploadStream.write(ByteBuffer.wrap(content), callback)
         uploadStream.abort(callback)
 
@@ -232,8 +229,8 @@ class GridFSUploadStreamSpecification extends Specification {
     def 'should throw an exception when trying to action post close'() {
         given:
         def callback = Stub(SingleResultCallback)
-        def uploadStream = new GridFSUploadStreamImpl(clientSession, Stub(MongoCollection), Stub(MongoCollection), fileId, filename, 255,
-                disableMD5, metadata, NOOP_INDEXCHECK)
+        def uploadStream = new GridFSUploadStreamImpl(clientSession, Stub(MongoCollection), Stub(MongoCollection), fileId, filename, 255
+                , metadata, NOOP_INDEXCHECK)
         uploadStream.close(callback)
 
         when:
@@ -269,8 +266,8 @@ class GridFSUploadStreamSpecification extends Specification {
         def fileId = new BsonString('myFile')
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
-        def uploadStream = new GridFSUploadStreamImpl(clientSession, filesCollection, chunksCollection, fileId, filename, 255,
-                disableMD5, metadata, NOOP_INDEXCHECK)
+        def uploadStream = new GridFSUploadStreamImpl(clientSession, filesCollection, chunksCollection, fileId, filename, 255
+                , metadata, NOOP_INDEXCHECK)
 
         when:
         uploadStream.getObjectId()
@@ -287,8 +284,8 @@ class GridFSUploadStreamSpecification extends Specification {
         def latchA = new CountDownLatch(1)
         def latchB = new CountDownLatch(1)
         def chunksCollection = Mock(MongoCollection)
-        def uploadStream = new GridFSUploadStreamImpl(clientSession, Stub(MongoCollection), chunksCollection, fileId, filename, 255,
-                disableMD5, metadata, NOOP_INDEXCHECK)
+        def uploadStream = new GridFSUploadStreamImpl(clientSession, Stub(MongoCollection), chunksCollection, fileId, filename, 255
+                , metadata, NOOP_INDEXCHECK)
 
         when:
         def futureResult = new FutureResultCallback()
@@ -334,8 +331,8 @@ class GridFSUploadStreamSpecification extends Specification {
         def latchA = new CountDownLatch(1)
         def latchB = new CountDownLatch(1)
         def chunksCollection = Mock(MongoCollection)
-        def uploadStream = new GridFSUploadStreamImpl(clientSession, Stub(MongoCollection), chunksCollection, fileId, filename, 255,
-                disableMD5, metadata, NOOP_INDEXCHECK)
+        def uploadStream = new GridFSUploadStreamImpl(clientSession, Stub(MongoCollection), chunksCollection, fileId, filename, 255
+                , metadata, NOOP_INDEXCHECK)
 
         when:
         def futureResult = new FutureResultCallback()
@@ -381,8 +378,8 @@ class GridFSUploadStreamSpecification extends Specification {
         def latchA = new CountDownLatch(1)
         def latchB = new CountDownLatch(1)
         def chunksCollection = Mock(MongoCollection)
-        def uploadStream = new GridFSUploadStreamImpl(clientSession, Stub(MongoCollection), chunksCollection, fileId, filename, 255,
-                disableMD5, metadata, NOOP_INDEXCHECK)
+        def uploadStream = new GridFSUploadStreamImpl(clientSession, Stub(MongoCollection), chunksCollection, fileId, filename, 255
+                , metadata, NOOP_INDEXCHECK)
 
         when:
         def futureResult = new FutureResultCallback()
@@ -427,8 +424,8 @@ class GridFSUploadStreamSpecification extends Specification {
         given:
         def chunksCollection = Mock(MongoCollection)
         def alternativeException = new MongoException('Alternative failure')
-        def uploadStream = new GridFSUploadStreamImpl(clientSession, Stub(MongoCollection), chunksCollection, fileId, filename, 255,
-                disableMD5, metadata, NOOP_INDEXCHECK)
+        def uploadStream = new GridFSUploadStreamImpl(clientSession, Stub(MongoCollection), chunksCollection, fileId, filename, 255
+                , metadata, NOOP_INDEXCHECK)
 
         when:
         def futureResult = new FutureResultCallback()
@@ -460,8 +457,8 @@ class GridFSUploadStreamSpecification extends Specification {
 
         when: 'The insert to the chunks collection fails'
         def futureResult = new FutureResultCallback()
-        def uploadStream = new GridFSUploadStreamImpl(clientSession, filesCollection, chunksCollection, fileId, filename, 255,
-                disableMD5, metadata, NOOP_INDEXCHECK)
+        def uploadStream = new GridFSUploadStreamImpl(clientSession, filesCollection, chunksCollection, fileId, filename, 255
+                , metadata, NOOP_INDEXCHECK)
         uploadStream.write(ByteBuffer.wrap(content), Stub(SingleResultCallback))
         uploadStream.close(futureResult)
 
@@ -481,8 +478,8 @@ class GridFSUploadStreamSpecification extends Specification {
 
         when: 'The insert to the files collection fails'
         futureResult = new FutureResultCallback()
-        uploadStream = new GridFSUploadStreamImpl(clientSession, filesCollection, chunksCollection, fileId, filename, 255,
-                disableMD5, metadata, NOOP_INDEXCHECK)
+        uploadStream = new GridFSUploadStreamImpl(clientSession, filesCollection, chunksCollection, fileId, filename, 255
+                , metadata, NOOP_INDEXCHECK)
         uploadStream.write(ByteBuffer.wrap(content), Stub(SingleResultCallback))
         uploadStream.close(futureResult)
 
@@ -511,8 +508,8 @@ class GridFSUploadStreamSpecification extends Specification {
         def filesCollection = Mock(MongoCollection)
         def chunksCollection = Mock(MongoCollection)
         def abortException = new MongoException('Alternative failure')
-        def uploadStream = new GridFSUploadStreamImpl(clientSession, filesCollection, chunksCollection, fileId, filename, 255,
-                disableMD5, metadata, NOOP_INDEXCHECK)
+        def uploadStream = new GridFSUploadStreamImpl(clientSession, filesCollection, chunksCollection, fileId, filename, 255
+                , metadata, NOOP_INDEXCHECK)
         def futureResult = new FutureResultCallback()
 
         when:
@@ -544,8 +541,8 @@ class GridFSUploadStreamSpecification extends Specification {
         def indexCheck = Mock(GridFSIndexCheck) {
             1 * checkAndCreateIndex(_) >> { it.last().onResult(null, indexException) }
         }
-        def uploadStream = new GridFSUploadStreamImpl(clientSession, filesCollection, chunksCollection, fileId, filename, 255,
-                disableMD5, metadata, indexCheck)
+        def uploadStream = new GridFSUploadStreamImpl(clientSession, filesCollection, chunksCollection, fileId, filename, 255
+                , metadata, indexCheck)
         def futureResult = new FutureResultCallback()
 
         when:


### PR DESCRIPTION
JAVA-3175