### PR TITLE
Deprecation stragglers

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/MongoClients.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoClients.java
@@ -204,7 +204,7 @@ public final class MongoClients {
 
     private static MongoClient createWithAsynchronousSocketChannel(final MongoClientSettings settings,
                                                                    @Nullable final MongoDriverInformation mongoDriverInformation) {
-        StreamFactoryFactory streamFactoryFactory = new AsynchronousSocketChannelStreamFactoryFactory();
+        StreamFactoryFactory streamFactoryFactory = AsynchronousSocketChannelStreamFactoryFactory.builder().build();
         StreamFactory streamFactory = streamFactoryFactory.create(settings.getSocketSettings(), settings.getSslSettings());
         StreamFactory heartbeatStreamFactory = streamFactoryFactory.create(settings.getHeartbeatSocketSettings(),
                 settings.getSslSettings());

--- a/driver-async/src/test/unit/com/mongodb/async/client/MongoCollectionSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/MongoCollectionSpecification.groovy
@@ -33,7 +33,6 @@ import com.mongodb.bulk.BulkWriteUpsert
 import com.mongodb.bulk.WriteConcernError
 import com.mongodb.client.ImmutableDocument
 import com.mongodb.client.ImmutableDocumentCodecProvider
-import com.mongodb.internal.client.model.AggregationLevel
 import com.mongodb.client.model.BulkWriteOptions
 import com.mongodb.client.model.Collation
 import com.mongodb.client.model.CountOptions
@@ -64,18 +63,9 @@ import com.mongodb.internal.bulk.DeleteRequest
 import com.mongodb.internal.bulk.IndexRequest
 import com.mongodb.internal.bulk.InsertRequest
 import com.mongodb.internal.bulk.UpdateRequest
+import com.mongodb.internal.client.model.AggregationLevel
 import com.mongodb.internal.client.model.CountStrategy
 import com.mongodb.internal.client.model.changestream.ChangeStreamLevel
-import com.mongodb.operation.CountOperation
-import com.mongodb.operation.CreateIndexesOperation
-import com.mongodb.operation.DropCollectionOperation
-import com.mongodb.operation.DropIndexOperation
-import com.mongodb.operation.FindAndDeleteOperation
-import com.mongodb.operation.FindAndReplaceOperation
-import com.mongodb.operation.FindAndUpdateOperation
-import com.mongodb.operation.ListIndexesOperation
-import com.mongodb.operation.MixedBulkWriteOperation
-import com.mongodb.operation.RenameCollectionOperation
 import com.mongodb.internal.operation.CountOperation
 import com.mongodb.internal.operation.CreateIndexesOperation
 import com.mongodb.internal.operation.DropCollectionOperation
@@ -715,7 +705,7 @@ class MongoCollectionSpecification extends Specification {
     def 'deleteOne should translate BulkWriteException correctly'() {
         given:
         def bulkWriteException = new MongoBulkWriteException(acknowledged(0, 0, 1, null, []), [],
-                new WriteConcernError(100, '', new BsonDocument()),
+                new WriteConcernError(100, 'codeName', 'Message', new BsonDocument()),
                 new ServerAddress())
 
         def executor = new TestOperationExecutor([bulkWriteException])
@@ -829,7 +819,7 @@ class MongoCollectionSpecification extends Specification {
     def 'replaceOne should translate BulkWriteException correctly'() {
         given:
         def bulkWriteException = new MongoBulkWriteException(bulkWriteResult, [],
-                new WriteConcernError(100, '', new BsonDocument()), new ServerAddress())
+                new WriteConcernError(100, 'codeName', 'Message', new BsonDocument()), new ServerAddress())
 
         def executor = new TestOperationExecutor([bulkWriteException])
         def collection = new MongoCollectionImpl(namespace, Document, codecRegistry, readPreference, ACKNOWLEDGED,
@@ -965,7 +955,7 @@ class MongoCollectionSpecification extends Specification {
     def 'should translate MongoBulkWriteException to MongoWriteConcernException'() {
         given:
         def executor = new TestOperationExecutor([new MongoBulkWriteException(acknowledged(INSERT, 1, []), [],
-                new WriteConcernError(42, 'oops', new BsonDocument()),
+                new WriteConcernError(42, 'codeName', 'Message', new BsonDocument()),
                 new ServerAddress())])
         def collection = new MongoCollectionImpl(namespace, Document, codecRegistry, readPreference, ACKNOWLEDGED,
                 true, readConcern, executor)
@@ -975,7 +965,7 @@ class MongoCollectionSpecification extends Specification {
 
         then:
         def e = thrown(MongoWriteConcernException)
-        e.writeConcernError == new WriteConcernError(42, 'oops', new BsonDocument())
+        e.writeConcernError == new WriteConcernError(42, 'codeName', 'Message', new BsonDocument())
     }
 
     def 'should use FindOneAndDeleteOperation correctly'() {

--- a/driver-core/src/main/com/mongodb/ConnectionString.java
+++ b/driver-core/src/main/com/mongodb/ConnectionString.java
@@ -1096,21 +1096,6 @@ public class ConnectionString {
     }
 
     /**
-     * Returns true if writes should be retried if they fail due to a network error, and false otherwise
-     *
-     * <p>Starting with the 3.11.0 release, the default value is true</p>
-     *
-     * @return the retryWrites value, or true if unset
-     * @since 3.6
-     * @mongodb.server.release 3.6
-     * @deprecated Prefer {@link #getRetryWritesValue()}
-     */
-    @Deprecated
-    public boolean getRetryWrites() {
-        return retryWrites == null ? true : retryWrites;
-    }
-
-    /**
      * <p>Gets whether writes should be retried if they fail due to a network error</p>
      *
      * The name of this method differs from others in this class so as not to conflict with the now removed

--- a/driver-core/src/main/com/mongodb/bulk/WriteConcernError.java
+++ b/driver-core/src/main/com/mongodb/bulk/WriteConcernError.java
@@ -49,19 +49,6 @@ public class WriteConcernError {
     }
 
     /**
-     * Constructs a new instance.
-     *
-     * @param code    the error code
-     * @param message the error message
-     * @param details any details
-     * @deprecated
-     */
-    @Deprecated
-    public WriteConcernError(final int code, final String message, final BsonDocument details) {
-        this(code, "", message, details);
-    }
-
-    /**
      * Gets the code associated with this error.
      *
      * @return the code

--- a/driver-core/src/main/com/mongodb/client/model/ReplaceOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/ReplaceOptions.java
@@ -17,12 +17,6 @@
 package com.mongodb.client.model;
 
 import com.mongodb.lang.Nullable;
-import org.bson.conversions.Bson;
-
-import java.util.List;
-
-import static com.mongodb.assertions.Assertions.isTrue;
-import static com.mongodb.assertions.Assertions.notNull;
 
 /**
  * The options to apply when replacing documents.
@@ -36,26 +30,6 @@ public class ReplaceOptions {
     private boolean upsert;
     private Boolean bypassDocumentValidation;
     private Collation collation;
-
-    /**
-     * Creates replace options from updateOptions.
-     *
-     * @param updateOptions the updateOptions
-     * @return replace options
-     * @deprecated there is no replacement for this method
-     */
-    @Deprecated
-    public static ReplaceOptions createReplaceOptions(final UpdateOptions updateOptions) {
-        notNull("updateOptions", updateOptions);
-
-        List<? extends Bson> arrayFilters = updateOptions.getArrayFilters();
-        isTrue("ArrayFilters should be empty.",  arrayFilters == null || arrayFilters.isEmpty());
-
-        return new ReplaceOptions()
-                .bypassDocumentValidation(updateOptions.getBypassDocumentValidation())
-                .collation(updateOptions.getCollation())
-                .upsert(updateOptions.isUpsert());
-    }
 
     /**
      * Returns true if a new document should be inserted if there are no matches to the query filter.  The default is false.

--- a/driver-core/src/main/com/mongodb/connection/AsynchronousSocketChannelStreamFactoryFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/AsynchronousSocketChannelStreamFactoryFactory.java
@@ -24,19 +24,8 @@ import java.nio.channels.AsynchronousChannelGroup;
  * @see java.nio.channels.AsynchronousSocketChannel
  * @since 3.1
  */
-public class AsynchronousSocketChannelStreamFactoryFactory implements StreamFactoryFactory {
+public final class AsynchronousSocketChannelStreamFactoryFactory implements StreamFactoryFactory {
     private final AsynchronousChannelGroup group;
-
-    /**
-     * Construct an instance with the default {@code BufferProvider} and {@code AsynchronousChannelGroup}.
-     *
-     * @deprecated Use {@link AsynchronousSocketChannelStreamFactoryFactory#builder()} instead to construct the
-     * {@code AsynchronousSocketChannelStreamFactoryFactory}.
-     */
-    @Deprecated
-    public AsynchronousSocketChannelStreamFactoryFactory() {
-        this(builder());
-    }
 
     /**
      * Gets a builder for an instance of {@code AsynchronousSocketChannelStreamFactoryFactory}.

--- a/driver-core/src/main/com/mongodb/connection/netty/NettyStreamFactoryFactory.java
+++ b/driver-core/src/main/com/mongodb/connection/netty/NettyStreamFactoryFactory.java
@@ -33,33 +33,11 @@ import static com.mongodb.assertions.Assertions.notNull;
  *
  * @since 3.1
  */
-public class NettyStreamFactoryFactory implements StreamFactoryFactory {
+public final class NettyStreamFactoryFactory implements StreamFactoryFactory {
 
     private final EventLoopGroup eventLoopGroup;
     private final Class<? extends SocketChannel> socketChannelClass;
     private final ByteBufAllocator allocator;
-
-    /**
-     * Construct an instance with the default {@code EventLoopGroup} and {@code ByteBufAllocator}.
-     *
-     * @deprecated Use {@link NettyStreamFactoryFactory#builder()} instead to construct the {@code  NettyStreamFactoryFactory}.
-     */
-    @Deprecated
-    public NettyStreamFactoryFactory() {
-        this(builder());
-    }
-
-    /**
-     * Construct an instance with the given {@code EventLoopGroup} and {@code ByteBufAllocator}.
-     *
-     * @param eventLoopGroup the non-null event loop group
-     * @param allocator the non-null byte buf allocator
-     * @deprecated Use {@link NettyStreamFactoryFactory#builder()} instead to construct the {@code  NettyStreamFactoryFactory}.
-     */
-    @Deprecated
-    public NettyStreamFactoryFactory(final EventLoopGroup eventLoopGroup, final ByteBufAllocator allocator) {
-        this(builder().eventLoopGroup(eventLoopGroup).allocator(allocator));
-    }
 
     /**
      * Gets a builder for an instance of {@code NettyStreamFactoryFactory}.

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/BulkWriteBatchCombinerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/BulkWriteBatchCombinerSpecification.groovy
@@ -103,8 +103,8 @@ class BulkWriteBatchCombinerSpecification extends Specification {
     def 'should throw last write concern error'() {
         given:
         def combiner = new BulkWriteBatchCombiner(new ServerAddress(), true, ACKNOWLEDGED)
-        combiner.addWriteConcernErrorResult(new WriteConcernError(65, 'journal error', new BsonDocument()));
-        def writeConcernError = new WriteConcernError(75, 'wtimeout', new BsonDocument())
+        combiner.addWriteConcernErrorResult(new WriteConcernError(65, 'journalError', 'journal error', new BsonDocument()));
+        def writeConcernError = new WriteConcernError(75, 'wtimeout', 'wtimeout message', new BsonDocument())
         combiner.addWriteConcernErrorResult(writeConcernError)
 
         when:

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/WriteCommandHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/WriteCommandHelperSpecification.groovy
@@ -131,11 +131,12 @@ class WriteCommandHelperSpecification extends Specification {
 
     def 'should get write concern error from writeConcernError field'() {
         expect:
-        new WriteConcernError(75, 'wtimeout', new BsonDocument('wtimeout', new BsonString('0'))) ==
+        new WriteConcernError(75, 'wtimeout', 'wtimeout message', new BsonDocument('wtimeout', new BsonString('0'))) ==
         getBulkWriteException(INSERT, new BsonDocument('n', new BsonInt32(1))
                 .append('writeConcernError',
                         new BsonDocument('code', new BsonInt32(75))
-                                .append('errmsg', new BsonString('wtimeout'))
+                                .append('codeName', new BsonString('wtimeout'))
+                                .append('errmsg', new BsonString('wtimeout message'))
                                 .append('errInfo', new BsonDocument('wtimeout',
                                                                     new BsonString('0')))),
                               new ServerAddress())

--- a/driver-embedded-android/src/androidTest/java/com/mongodb/embedded/client/CrudTest.java
+++ b/driver-embedded-android/src/androidTest/java/com/mongodb/embedded/client/CrudTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 import static com.mongodb.embedded.client.Fixture.serverVersionGreaterThan;
 import static com.mongodb.embedded.client.Fixture.serverVersionLessThan;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
 
 // See https://github.com/mongodb/specifications/tree/master/source/crud/tests
 @RunWith(Parameterized.class)
@@ -77,6 +78,7 @@ public class CrudTest {
 
     @Test
     public void shouldPassAllOutcomes() {
+        assumeFalse(definition.getString("description").getValue().startsWith("Deprecated count"));
         BsonDocument outcome = helper.getOperationResults(definition.getDocument("operation"));
         BsonDocument expectedOutcome = definition.getDocument("outcome");
 

--- a/driver-embedded-android/src/androidTest/java/com/mongodb/embedded/client/JsonPoweredCrudTestHelper.java
+++ b/driver-embedded-android/src/androidTest/java/com/mongodb/embedded/client/JsonPoweredCrudTestHelper.java
@@ -81,6 +81,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
 
@@ -246,30 +247,6 @@ public class JsonPoweredCrudTestHelper {
         return toResult(iterable);
     }
 
-    @SuppressWarnings("deprecation")
-    BsonDocument getCountResult(final BsonDocument collectionOptions, final BsonDocument arguments,
-                                @Nullable final ClientSession clientSession) {
-        CountOptions options = new CountOptions();
-        if (arguments.containsKey("skip")) {
-            options.skip(arguments.getNumber("skip").intValue());
-        }
-        if (arguments.containsKey("limit")) {
-            options.limit(arguments.getNumber("limit").intValue());
-        }
-        if (arguments.containsKey("collation")) {
-            options.collation(getCollation(arguments.getDocument("collation")));
-        }
-
-        BsonDocument filter = arguments.getDocument("filter", new BsonDocument());
-        int count;
-        if (clientSession == null) {
-            count = (int) getCollection(collectionOptions).count(filter, options);
-        } else {
-            count = (int) getCollection(collectionOptions).count(clientSession, filter, options);
-        }
-        return toResult(count);
-    }
-
     BsonDocument getEstimatedDocumentCountResult(final BsonDocument collectionOptions, final BsonDocument arguments,
                                                  @Nullable final ClientSession clientSession) {
         if (!arguments.isEmpty()) {
@@ -341,8 +318,26 @@ public class JsonPoweredCrudTestHelper {
         if (arguments.containsKey("sort")) {
             iterable.sort(arguments.getDocument("sort"));
         }
-        if (arguments.containsKey("modifiers")) {
-            iterable.modifiers(arguments.getDocument("modifiers"));
+        if (arguments.containsKey("comment")) {
+            iterable.comment(arguments.getString("comment").getValue());
+        }
+        if (arguments.containsKey("hint")) {
+            iterable.hint(arguments.getDocument("hint"));
+        }
+        if (arguments.containsKey("max")) {
+            iterable.max(arguments.getDocument("max"));
+        }
+        if (arguments.containsKey("min")) {
+            iterable.min(arguments.getDocument("min"));
+        }
+        if (arguments.containsKey("maxTimeMS")) {
+            iterable.maxTime(arguments.getNumber("maxTimeMS").intValue(), TimeUnit.MILLISECONDS);
+        }
+        if (arguments.containsKey("showRecordId")) {
+            iterable.showRecordId(arguments.getBoolean("showRecordId").getValue());
+        }
+        if (arguments.containsKey("returnKey")) {
+            iterable.returnKey(arguments.getBoolean("returnKey").getValue());
         }
         if (arguments.containsKey("collation")) {
             iterable.collation(getCollation(arguments.getDocument("collation")));

--- a/driver-embedded/src/test/functional/com/mongodb/embedded/client/CrudTest.java
+++ b/driver-embedded/src/test/functional/com/mongodb/embedded/client/CrudTest.java
@@ -42,6 +42,7 @@ import static com.mongodb.embedded.client.Fixture.getMongoClient;
 import static com.mongodb.embedded.client.Fixture.serverVersionGreaterThan;
 import static com.mongodb.embedded.client.Fixture.serverVersionLessThan;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
 
 // See https://github.com/mongodb/specifications/tree/master/source/crud/tests
 @RunWith(Parameterized.class)
@@ -87,6 +88,7 @@ public class CrudTest extends DatabaseTestCase {
 
     @Test
     public void shouldPassAllOutcomes() {
+        assumeFalse(definition.getString("description").getValue().startsWith("Deprecated count"));
         BsonDocument outcome = helper.getOperationResults(definition.getDocument("operation"));
         BsonDocument expectedOutcome = definition.getDocument("outcome");
 

--- a/driver-legacy/src/test/functional/com/mongodb/DBCursorFunctionalSpecification.groovy
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCursorFunctionalSpecification.groovy
@@ -51,24 +51,6 @@ class DBCursorFunctionalSpecification extends FunctionalSpecification {
         1 * decoder.decode(_ as byte[], collection)
     }
 
-    @IgnoreIf({ serverVersionAtLeast(3, 0) })
-    def 'should use provided hints for queries'() {
-        given:
-        collection.createIndex(new BasicDBObject('a', 1))
-
-        when:
-        dbCursor = collection.find().hint(new BasicDBObject('a', 1))
-
-        then:
-        dbCursor.explain().get('cursor') == 'BtreeCursor a_1'
-
-        when:
-        dbCursor = collection.find().hint(new BasicDBObject('a', 1))
-
-        then:
-        dbCursor.explain().get('cursor') == 'BtreeCursor a_1'
-    }
-
     @IgnoreIf({ !serverVersionAtLeast(3, 0) })
     def 'should use provided hints for queries mongod > 3.0'() {
         given:

--- a/driver-legacy/src/test/functional/com/mongodb/DBCursorOldTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCursorOldTest.java
@@ -29,14 +29,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 
-import static com.mongodb.ClusterFixture.serverVersionAtLeast;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeThat;
 
 @SuppressWarnings("deprecation")
 public class DBCursorOldTest extends DatabaseTestCase {
@@ -255,34 +252,6 @@ public class DBCursorOldTest extends DatabaseTestCase {
                         .sort(new BasicDBObject("$natural", 1));
 
         cur.tryNext();
-    }
-
-    @Test
-    public void testExplain() {
-        assumeThat(serverVersionAtLeast(3, 0), is(false));
-        insertTestData(collection, 100);
-
-        DBObject q = BasicDBObjectBuilder.start().push("x").add("$gt", 50).get();
-
-        assertEquals(49, collection.find(q).count());
-        assertEquals(49, collection.find(q).itcount());
-        assertEquals(49, collection.find(q).toArray().size());
-        assertEquals(49, collection.find(q).itcount());
-        assertEquals(20, collection.find(q).limit(20).itcount());
-        assertEquals(20, collection.find(q).limit(-20).itcount());
-
-        collection.createIndex(new BasicDBObject("x", 1));
-
-        assertEquals(49, collection.find(q).count());
-        assertEquals(49, collection.find(q).toArray().size());
-        assertEquals(49, collection.find(q).itcount());
-        assertEquals(20, collection.find(q).limit(20).itcount());
-        assertEquals(20, collection.find(q).limit(-20).itcount());
-
-        assertEquals(49, collection.find(q).explain().get("n"));
-
-        assertEquals(20, collection.find(q).limit(20).explain().get("n"));
-        assertEquals(20, collection.find(q).limit(-20).explain().get("n"));
     }
 
     @Test

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoCollectionSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoCollectionSpecification.groovy
@@ -27,10 +27,11 @@ import com.mongodb.ServerAddress
 import com.mongodb.WriteConcern
 import com.mongodb.WriteConcernResult
 import com.mongodb.WriteError
+import com.mongodb.bulk.BulkWriteError
+import com.mongodb.bulk.WriteConcernError
 import com.mongodb.client.ClientSession
 import com.mongodb.client.ImmutableDocument
 import com.mongodb.client.ImmutableDocumentCodecProvider
-import com.mongodb.internal.client.model.AggregationLevel
 import com.mongodb.client.model.BulkWriteOptions
 import com.mongodb.client.model.Collation
 import com.mongodb.client.model.CountOptions
@@ -61,19 +62,9 @@ import com.mongodb.internal.bulk.DeleteRequest
 import com.mongodb.internal.bulk.IndexRequest
 import com.mongodb.internal.bulk.InsertRequest
 import com.mongodb.internal.bulk.UpdateRequest
+import com.mongodb.internal.client.model.AggregationLevel
 import com.mongodb.internal.client.model.CountStrategy
 import com.mongodb.internal.client.model.changestream.ChangeStreamLevel
-import com.mongodb.operation.BatchCursor
-import com.mongodb.operation.CountOperation
-import com.mongodb.operation.CreateIndexesOperation
-import com.mongodb.operation.DropCollectionOperation
-import com.mongodb.operation.DropIndexOperation
-import com.mongodb.operation.FindAndDeleteOperation
-import com.mongodb.operation.FindAndReplaceOperation
-import com.mongodb.operation.FindAndUpdateOperation
-import com.mongodb.operation.ListIndexesOperation
-import com.mongodb.operation.MixedBulkWriteOperation
-import com.mongodb.operation.RenameCollectionOperation
 import com.mongodb.internal.operation.BatchCursor
 import com.mongodb.internal.operation.CountOperation
 import com.mongodb.internal.operation.CreateIndexesOperation
@@ -713,7 +704,7 @@ class MongoCollectionSpecification extends Specification {
     def 'deleteOne should translate BulkWriteException correctly'() {
         given:
         def bulkWriteException = new MongoBulkWriteException(acknowledged(0, 0, 1, null, []), [],
-                                                             new com.mongodb.bulk.WriteConcernError(100, '', new BsonDocument()),
+                new WriteConcernError(100, 'codeName', 'Message', new BsonDocument()),
                                                              new ServerAddress())
 
         def executor = new TestOperationExecutor([bulkWriteException])
@@ -817,7 +808,7 @@ class MongoCollectionSpecification extends Specification {
     def 'replaceOne should translate BulkWriteException correctly'() {
         given:
         def bulkWriteException = new MongoBulkWriteException(bulkWriteResult, [],
-                                                             new com.mongodb.bulk.WriteConcernError(100, '', new BsonDocument()),
+                                                             new WriteConcernError(100, 'codeName', 'Message', new BsonDocument()),
                                                              new ServerAddress())
 
         def executor = new TestOperationExecutor([bulkWriteException])
@@ -947,7 +938,7 @@ class MongoCollectionSpecification extends Specification {
 
         where:
         executor << new TestOperationExecutor([new MongoBulkWriteException(acknowledged(INSERT, 1, []),
-                [new com.mongodb.bulk.BulkWriteError(11000, 'oops',
+                [new BulkWriteError(11000, 'oops',
                         new BsonDocument(), 0)],
                 null, new ServerAddress())])
     }
@@ -955,8 +946,7 @@ class MongoCollectionSpecification extends Specification {
     def 'should translate MongoBulkWriteException to MongoWriteConcernException'() {
         given:
         def executor = new TestOperationExecutor([new MongoBulkWriteException(acknowledged(INSERT, 1, []), [],
-                new com.mongodb.bulk.WriteConcernError(42, 'oops',
-                        new BsonDocument()),
+                new WriteConcernError(42, 'codeName', 'Message', new BsonDocument()),
                 new ServerAddress())])
         def collection = new MongoCollectionImpl(namespace, Document, codecRegistry, readPreference, ACKNOWLEDGED,
                 true, readConcern, executor)
@@ -966,7 +956,7 @@ class MongoCollectionSpecification extends Specification {
 
         then:
         def e = thrown(MongoWriteConcernException)
-        e.writeConcernError == new com.mongodb.bulk.WriteConcernError(42, 'oops', new BsonDocument())
+        e.writeConcernError == new WriteConcernError(42, 'codeName', 'Message', new BsonDocument())
     }
 
     def 'should use FindOneAndDeleteOperation correctly'() {


### PR DESCRIPTION
Searching for `@Deprecated` on the j3188 branch found a few stragglers that I left behind.  This should cover everything except driver-async deprecation, which we should hold off on until we pull reactive streams driver in.