### PR TITLE
Throw MongoClientException for sharded cluster transactions

### DIFF
--- a/driver-async/src/test/functional/com/mongodb/async/client/TransactionFailureTest.java
+++ b/driver-async/src/test/functional/com/mongodb/async/client/TransactionFailureTest.java
@@ -33,12 +33,23 @@ public class TransactionFailureTest extends DatabaseTestCase {
 
     @Before
     public void setUp() {
-        assumeTrue(canRunTests());
         super.setUp();
     }
 
     @Test(expected = MongoClientException.class)
-    public void testTransactionFails() throws InterruptedException {
+    public void testTransactionFailsOn40Cluster() throws InterruptedException {
+        assumeTrue(serverVersionLessThan("4.0"));
+        doTransaction();
+    }
+
+    @Test(expected = MongoClientException.class)
+    public void testTransactionFailsOnShardedCluster() throws InterruptedException {
+        assumeTrue(isSharded());
+        doTransaction();
+    }
+
+
+    private void doTransaction() throws InterruptedException {
         final ClientSession clientSession = createSession();
 
         try {
@@ -60,11 +71,5 @@ public class TransactionFailureTest extends DatabaseTestCase {
                 client.startSession(options, getCallback());
             }
         }.get();
-    }
-
-
-    private boolean canRunTests() {
-        return serverVersionLessThan("4.0")
-                || (serverVersionLessThan("4.1.0") && isSharded());
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/CommandMessage.java
@@ -50,7 +50,6 @@ import static com.mongodb.connection.ClusterConnectionMode.SINGLE;
 import static com.mongodb.connection.ServerType.SHARD_ROUTER;
 import static com.mongodb.internal.connection.BsonWriterHelper.writePayload;
 import static com.mongodb.internal.connection.ReadConcernHelper.getReadConcernDocument;
-import static com.mongodb.internal.operation.ServerVersionHelper.FOUR_DOT_TWO_WIRE_VERSION;
 import static com.mongodb.internal.operation.ServerVersionHelper.FOUR_DOT_ZERO_WIRE_VERSION;
 import static com.mongodb.internal.operation.ServerVersionHelper.THREE_DOT_SIX_WIRE_VERSION;
 
@@ -265,9 +264,10 @@ public final class CommandMessage extends RequestMessage {
 
     private void checkServerVersionForTransactionSupport() {
         int wireVersion = getSettings().getMaxWireVersion();
-        if (wireVersion < FOUR_DOT_ZERO_WIRE_VERSION
-                || (wireVersion < FOUR_DOT_TWO_WIRE_VERSION && getSettings().getServerType() == SHARD_ROUTER)) {
+        if (wireVersion < FOUR_DOT_ZERO_WIRE_VERSION) {
             throw new MongoClientException("Transactions are not supported by the MongoDB cluster to which this client is connected.");
+        } else if (getSettings().getServerType() == SHARD_ROUTER) {
+            throw new MongoClientException("This version of the driver does not support transactions on a sharded cluster.");
         }
     }
 

--- a/driver-sync/src/test/functional/com/mongodb/client/TransactionFailureTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/TransactionFailureTest.java
@@ -31,12 +31,22 @@ public class TransactionFailureTest extends DatabaseTestCase {
 
     @Before
     public void setUp() {
-        assumeTrue(canRunTests());
         super.setUp();
     }
 
     @Test(expected = MongoClientException.class)
-    public void testTransactionFails() {
+    public void testTransactionFailsOn40Cluster() {
+        assumeTrue(serverVersionLessThan("4.0"));
+        doTransaction();
+    }
+
+    @Test(expected = MongoClientException.class)
+    public void testTransactionFailsOnShardedCluster() {
+        assumeTrue(isSharded());
+        doTransaction();
+    }
+
+    private void doTransaction() {
         ClientSession clientSession = client.startSession();
         try {
             clientSession.startTransaction();
@@ -44,10 +54,5 @@ public class TransactionFailureTest extends DatabaseTestCase {
         } finally {
             clientSession.close();
         }
-    }
-
-    private boolean canRunTests() {
-        return serverVersionLessThan("4.0")
-                || (serverVersionLessThan("4.1.0") && isSharded());
     }
 }


### PR DESCRIPTION
This fix is only intended for the 3.10.x branch.  The idea is to prevent users from using a version 
of the driver that doesn't fully support sharded txns from being used to run txns on a sharded cluster.

https://jira.mongodb.org/browse/JAVA-3240
https://evergreen.mongodb.com/version/5ca38488e3c33143e187a4bb
