### PR TITLE
Suppress extraneous compiler warnings

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/OperationExecutor.java
+++ b/driver-async/src/main/com/mongodb/async/client/OperationExecutor.java
@@ -26,6 +26,7 @@ import com.mongodb.lang.Nullable;
 /**
  * An interface describing the execution of a read or a write operation.
  */
+@SuppressWarnings("overloads")
 interface OperationExecutor {
     /**
      * Execute the read operation with the given read preference.

--- a/driver-core/src/main/com/mongodb/client/model/Filters.java
+++ b/driver-core/src/main/com/mongodb/client/model/Filters.java
@@ -160,6 +160,8 @@ public final class Filters {
      * @return the filter
      * @mongodb.driver.manual reference/operator/query/in $in
      */
+    @SafeVarargs
+    @SuppressWarnings("varargs")
     public static <TItem> Bson in(final String fieldName, final TItem... values) {
         return in(fieldName, asList(values));
     }
@@ -186,6 +188,8 @@ public final class Filters {
      * @return the filter
      * @mongodb.driver.manual reference/operator/query/nin $nin
      */
+    @SafeVarargs
+    @SuppressWarnings("varargs")
     public static <TItem> Bson nin(final String fieldName, final TItem... values) {
         return nin(fieldName, asList(values));
     }
@@ -480,6 +484,8 @@ public final class Filters {
      * @return the filter
      * @mongodb.driver.manual reference/operator/query/all $all
      */
+    @SafeVarargs
+    @SuppressWarnings("varargs")
     public static <TItem> Bson all(final String fieldName, final TItem... values) {
         return all(fieldName, asList(values));
     }
@@ -918,7 +924,7 @@ public final class Filters {
         private final String fieldName;
         private final TItem value;
 
-        OperatorFilter(final String operatorName, final String fieldName, final TItem value) {
+        OperatorFilter(final String operatorName, final String fieldName, @Nullable final TItem value) {
             this.operatorName = notNull("operatorName", operatorName);
             this.fieldName = notNull("fieldName", fieldName);
             this.value = value;
@@ -1208,7 +1214,7 @@ public final class Filters {
         private final String fieldName;
         private final TItem value;
 
-        SimpleEncodingFilter(final String fieldName, final TItem value) {
+        SimpleEncodingFilter(final String fieldName, @Nullable final TItem value) {
             this.fieldName = notNull("fieldName", fieldName);
             this.value = value;
         }

--- a/driver-core/src/main/com/mongodb/client/model/geojson/Polygon.java
+++ b/driver-core/src/main/com/mongodb/client/model/geojson/Polygon.java
@@ -37,6 +37,7 @@ public final class Polygon extends Geometry {
      * @param exterior the exterior ring of the polygon
      * @param holes    optional interior rings of the polygon
      */
+    @SafeVarargs
     public Polygon(final List<Position> exterior, final List<Position>... holes) {
         this(new PolygonCoordinates(exterior, holes));
     }

--- a/driver-core/src/main/com/mongodb/client/model/geojson/PolygonCoordinates.java
+++ b/driver-core/src/main/com/mongodb/client/model/geojson/PolygonCoordinates.java
@@ -38,6 +38,7 @@ public final class PolygonCoordinates {
      * @param exterior the exterior ring of the polygon
      * @param holes    optional interior rings of the polygon
      */
+    @SafeVarargs
     public PolygonCoordinates(final List<Position> exterior, final List<Position>... holes) {
         notNull("exteriorRing", exterior);
         isTrueArgument("ring contains only non-null positions", !exterior.contains(null));

--- a/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/operation/CommandOperationHelper.java
@@ -59,6 +59,7 @@ import static com.mongodb.internal.operation.OperationHelper.withReleasableConne
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
+@SuppressWarnings("overloads")
 final class CommandOperationHelper {
 
     interface CommandTransformer<T, R> {

--- a/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
+++ b/driver-core/src/test/functional/com/mongodb/ClusterFixture.java
@@ -478,36 +478,44 @@ public final class ClusterFixture {
         }
     }
 
+    @SuppressWarnings("overloads")
     public static <T> T executeSync(final WriteOperation<T> op) {
         return executeSync(op, getBinding());
     }
 
+    @SuppressWarnings("overloads")
     public static <T> T executeSync(final WriteOperation<T> op, final ReadWriteBinding binding) {
         return op.execute(binding);
     }
 
+    @SuppressWarnings("overloads")
     public static <T> T executeSync(final ReadOperation<T> op) {
         return executeSync(op, getBinding());
     }
 
+    @SuppressWarnings("overloads")
     public static <T> T executeSync(final ReadOperation<T> op, final ReadWriteBinding binding) {
         return op.execute(binding);
     }
 
+    @SuppressWarnings("overloads")
     public static <T> T executeAsync(final AsyncWriteOperation<T> op) throws Throwable {
         return executeAsync(op, getAsyncBinding());
     }
 
+    @SuppressWarnings("overloads")
     public static <T> T executeAsync(final AsyncWriteOperation<T> op, final AsyncWriteBinding binding) throws Throwable {
         final FutureResultCallback<T> futureResultCallback = new FutureResultCallback<T>();
         op.executeAsync(binding, futureResultCallback);
         return futureResultCallback.get(TIMEOUT, SECONDS);
     }
 
+    @SuppressWarnings("overloads")
     public static <T> T executeAsync(final AsyncReadOperation<T> op) throws Throwable {
         return executeAsync(op, getAsyncBinding());
     }
 
+    @SuppressWarnings("overloads")
     public static <T> T executeAsync(final AsyncReadOperation<T> op, final AsyncReadBinding binding) throws Throwable {
         final FutureResultCallback<T> futureResultCallback = new FutureResultCallback<T>();
         op.executeAsync(binding, futureResultCallback);

--- a/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
@@ -200,11 +200,15 @@ public final class CollectionHelper<T> {
         insertDocuments(new DocumentCodec(registry), asList(documents));
     }
 
-    public <I> void insertDocuments(final Codec<I> iCodec, final I... documents) {
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    public final <I> void insertDocuments(final Codec<I> iCodec, final I... documents) {
         insertDocuments(iCodec, asList(documents));
     }
 
-    public <I> void insertDocuments(final Codec<I> iCodec, final WriteBinding binding, final I... documents) {
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    public final <I> void insertDocuments(final Codec<I> iCodec, final WriteBinding binding, final I... documents) {
         insertDocuments(iCodec, binding, asList(documents));
     }
 
@@ -286,12 +290,14 @@ public final class CollectionHelper<T> {
         return results;
     }
 
+    @SuppressWarnings("overloads")
     public List<T> find(final Bson filter, final Bson sort) {
         return find(filter != null ? filter.toBsonDocument(Document.class, registry) : null,
                     sort != null ? sort.toBsonDocument(Document.class, registry) : null,
                     codec);
     }
 
+    @SuppressWarnings("overloads")
     public List<T> find(final Bson filter, final Bson sort, final Bson projection) {
         return find(filter != null ? filter.toBsonDocument(Document.class, registry) : null,
                     sort != null ? sort.toBsonDocument(Document.class, registry) : null,
@@ -299,10 +305,12 @@ public final class CollectionHelper<T> {
                     codec);
     }
 
+    @SuppressWarnings("overloads")
     public <D> List<D> find(final BsonDocument filter, final Decoder<D> decoder) {
         return find(filter, null, decoder);
     }
 
+    @SuppressWarnings("overloads")
     public <D> List<D> find(final BsonDocument filter, final BsonDocument sort, final Decoder<D> decoder) {
         return find(filter, sort, null, decoder);
     }

--- a/driver-legacy/src/test/unit/com/mongodb/DBCollectionObjectFactoryTest.java
+++ b/driver-legacy/src/test/unit/com/mongodb/DBCollectionObjectFactoryTest.java
@@ -99,7 +99,10 @@ public class DBCollectionObjectFactoryTest {
         private static final long serialVersionUID = 5243874721805359328L;
     }
 
+    @SuppressWarnings("rawtypes")
     public static class MyDBObject extends HashMap<String, Object> implements DBObject {
+
+        private static final long serialVersionUID = -8540791504402368127L;
 
         @Override
         public void markAsPartialObject() {

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoIterableImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoIterableImpl.java
@@ -105,6 +105,7 @@ public abstract class MongoIterableImpl<TResult> implements MongoIterable<TResul
         return new MappingIterable<TResult, U>(this, mapper);
     }
 
+    @SuppressWarnings("overloads")
     private void forEach(final Block<? super TResult> block) {
         MongoCursor<TResult> cursor = iterator();
         try {

--- a/driver-sync/src/main/com/mongodb/client/internal/OperationExecutor.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/OperationExecutor.java
@@ -28,6 +28,7 @@ import com.mongodb.lang.Nullable;
  *
  * This class is not part of the public API and may be removed or changed at any time.
  */
+@SuppressWarnings("overloads")
 public interface OperationExecutor {
     /**
      * Execute the read operation with the given read preference.

--- a/driver-sync/src/test/functional/com/mongodb/client/TransactionProseTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/TransactionProseTest.java
@@ -93,7 +93,7 @@ public class TransactionProseTest {
             collection.insertOne(session, Document.parse("{ _id : 1 }"));
             session.commitTransaction();
 
-            Set<FindIterable> addresses = new HashSet<FindIterable>();
+            Set<FindIterable<Document>> addresses = new HashSet<>();
             int iterations = 50;
             while (iterations-- > 0) {
                 session.startTransaction();
@@ -121,7 +121,7 @@ public class TransactionProseTest {
             session.startTransaction();
             collection.insertOne(session, Document.parse("{ _id : 1 }"));
 
-            Set<FindIterable> addresses = new HashSet<FindIterable>();
+            Set<FindIterable<Document>> addresses = new HashSet<>();
             int iterations = 50;
             while (iterations-- > 0) {
                 addresses.add(collection.find(session, Document.parse("{}")));


### PR DESCRIPTION
* suppress warnings for "overloads" and "varargs" where appropriate
* Add SafeVarArgs annotation where appropriate

JAVA-3205

Compilation is clean now with this commit