### PR TITLE
Get server connectionId from isMaster if possible

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/DescriptionHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/DescriptionHelper.java
@@ -61,9 +61,15 @@ public final class DescriptionHelper {
     static ConnectionDescription createConnectionDescription(final ConnectionId connectionId,
                                                              final BsonDocument isMasterResult,
                                                              final BsonDocument buildInfoResult) {
-        return new ConnectionDescription(connectionId, getVersion(buildInfoResult), getMaxWireVersion(isMasterResult),
-                getServerType(isMasterResult), getMaxWriteBatchSize(isMasterResult), getMaxBsonObjectSize(isMasterResult),
-                getMaxMessageSizeBytes(isMasterResult), getCompressors(isMasterResult));
+        ConnectionDescription connectionDescription = new ConnectionDescription(connectionId, getVersion(buildInfoResult),
+                getMaxWireVersion(isMasterResult), getServerType(isMasterResult), getMaxWriteBatchSize(isMasterResult),
+                getMaxBsonObjectSize(isMasterResult), getMaxMessageSizeBytes(isMasterResult), getCompressors(isMasterResult));
+        if (isMasterResult.containsKey("connectionId")) {
+            ConnectionId newConnectionId =
+                    connectionDescription.getConnectionId().withServerValue(isMasterResult.getNumber("connectionId").intValue());
+            connectionDescription = connectionDescription.withConnectionId(newConnectionId);
+        }
+        return connectionDescription;
     }
 
     public static ServerDescription createServerDescription(final ServerAddress serverAddress, final BsonDocument isMasterResult,

--- a/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/InternalStreamConnectionInitializer.java
@@ -140,6 +140,10 @@ public class InternalStreamConnectionInitializer implements InternalConnectionIn
 
     private ConnectionDescription completeConnectionDescriptionInitialization(final InternalConnection internalConnection,
                                                                               final ConnectionDescription connectionDescription) {
+        if (connectionDescription.getConnectionId().getServerValue() != null) {
+            return connectionDescription;
+        }
+
         return applyGetLastErrorResult(executeCommandWithoutCheckingForFailure("admin",
                                                                                new BsonDocument("getlasterror", new BsonInt32(1)),
                                                                                internalConnection),
@@ -204,6 +208,11 @@ public class InternalStreamConnectionInitializer implements InternalConnectionIn
     private void completeConnectionDescriptionInitializationAsync(final InternalConnection internalConnection,
                                                                   final ConnectionDescription connectionDescription,
                                                                   final SingleResultCallback<ConnectionDescription> callback) {
+        if (connectionDescription.getConnectionId().getServerValue() != null) {
+            callback.onResult(connectionDescription, null);
+            return;
+        }
+
         executeCommandAsync("admin", new BsonDocument("getlasterror", new BsonInt32(1)),
                             internalConnection,
                             new SingleResultCallback<BsonDocument>() {

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/DescriptionHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/DescriptionHelperSpecification.groovy
@@ -82,6 +82,39 @@ class DescriptionHelperSpecification extends Specification {
                                           "ok" : 1
                                           }''')) ==
         new ConnectionDescription(connectionId, serverVersion, 6, ServerType.STANDALONE, 1000, 16777216, 48000000, [])
+
+        createConnectionDescription(connectionId,
+                parse('''{
+                                          ismaster : true,
+                                          maxBsonObjectSize : 16777216,
+                                          maxMessageSizeBytes : 48000000,
+                                          maxWriteBatchSize : 1000,
+                                          localTime : ISODate("2015-03-04T23:03:45.848Z"),
+                                          maxWireVersion : 6,
+                                          minWireVersion : 0,
+                                          connectionId : 1004
+                                          ok : 1
+                                          }'''),
+                parse('''{
+                                          "version" : "2.6.1",
+                                          "gitVersion" : "nogitversion",
+                                          "OpenSSLVersion" : "",
+                                          "loaderFlags" : "-fPIC -pthread -Wl,-bind_at_load -m64 -mmacosx-version-min=10.9",
+                                          "allocator" : "tcmalloc",
+                                          "versionArray" : [
+                                          3,
+                                          0,
+                                          0,
+                                          1
+                                          ],
+                                          "javascriptEngine" : "V8",
+                                          "bits" : 64,
+                                          "debug" : false,
+                                          "maxBsonObjectSize" : 16777216,
+                                          "ok" : 1
+                                          }''')) ==
+                new ConnectionDescription(connectionId, serverVersion, 6, ServerType.STANDALONE, 1000, 16777216, 48000000, [])
+                    .withConnectionId(connectionId.withServerValue(1004))
     }
 
     def 'connection description should reflect ismaster result with compressors'() {


### PR DESCRIPTION
As of MongoDB 4.2, the isMaster response includes the connectionId.
Formerly this value was only available in the response to the
getLastError command.  If the driver finds the connectionId in the
isMaster response, it will use it and then avoid executing the
getLastError command.

JAVA-3255