### PR TITLE
Deprecate isModifiedCountAvailable methods

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/MongoCollectionImpl.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoCollectionImpl.java
@@ -32,7 +32,6 @@ import com.mongodb.bulk.WriteRequest;
 import com.mongodb.client.model.AggregationLevel;
 import com.mongodb.client.model.BulkWriteOptions;
 import com.mongodb.client.model.CountOptions;
-import com.mongodb.internal.client.model.CountStrategy;
 import com.mongodb.client.model.CreateIndexOptions;
 import com.mongodb.client.model.DeleteOptions;
 import com.mongodb.client.model.DropIndexOptions;
@@ -51,6 +50,7 @@ import com.mongodb.client.model.WriteModel;
 import com.mongodb.client.model.changestream.ChangeStreamLevel;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
+import com.mongodb.internal.client.model.CountStrategy;
 import com.mongodb.internal.operation.AsyncOperations;
 import com.mongodb.internal.operation.IndexHelper;
 import com.mongodb.lang.Nullable;
@@ -1065,9 +1065,8 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private UpdateResult toUpdateResult(final com.mongodb.bulk.BulkWriteResult result) {
         if (result.wasAcknowledged()) {
-            Long modifiedCount = result.isModifiedCountAvailable() ? (long) result.getModifiedCount() : null;
             BsonValue upsertedId = result.getUpserts().isEmpty() ? null : result.getUpserts().get(0).getId();
-            return UpdateResult.acknowledged(result.getMatchedCount(), modifiedCount, upsertedId);
+            return UpdateResult.acknowledged(result.getMatchedCount(), (long) result.getModifiedCount(), upsertedId);
         } else {
             return UpdateResult.unacknowledged();
         }

--- a/driver-async/src/test/functional/com/mongodb/async/client/JsonPoweredCrudTestHelper.java
+++ b/driver-async/src/test/functional/com/mongodb/async/client/JsonPoweredCrudTestHelper.java
@@ -152,9 +152,7 @@ public class JsonPoweredCrudTestHelper {
 
     BsonDocument toResult(final UpdateResult updateResult) {
         BsonDocument resultDoc = new BsonDocument("matchedCount", new BsonInt32((int) updateResult.getMatchedCount()));
-        if (updateResult.isModifiedCountAvailable()) {
-            resultDoc.append("modifiedCount", new BsonInt32((int) updateResult.getModifiedCount()));
-        }
+        resultDoc.append("modifiedCount", new BsonInt32((int) updateResult.getModifiedCount()));
         // If the upsertedId is an ObjectId that means it came from the server and can't be verified.
         // This check is to handle the "ReplaceOne with upsert when no documents match without an id specified" test
         // in replaceOne-pre_2.6
@@ -186,9 +184,7 @@ public class JsonPoweredCrudTestHelper {
             resultDoc.append("insertedCount", new BsonInt32(insertedIds.size()));
 
             resultDoc.append("matchedCount", new BsonInt32(bulkWriteResult.getMatchedCount()));
-            if (bulkWriteResult.isModifiedCountAvailable()) {
-                resultDoc.append("modifiedCount", new BsonInt32(bulkWriteResult.getModifiedCount()));
-            }
+            resultDoc.append("modifiedCount", new BsonInt32(bulkWriteResult.getModifiedCount()));
             resultDoc.append("upsertedCount", bulkWriteResult.getUpserts() == null
                     ? new BsonInt32(0) : new BsonInt32(bulkWriteResult.getUpserts().size()));
             BsonDocument upserts = new BsonDocument();

--- a/driver-async/src/test/unit/com/mongodb/async/client/MongoCollectionSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/MongoCollectionSpecification.groovy
@@ -41,7 +41,6 @@ import com.mongodb.client.model.AggregationLevel
 import com.mongodb.client.model.BulkWriteOptions
 import com.mongodb.client.model.Collation
 import com.mongodb.client.model.CountOptions
-import com.mongodb.internal.client.model.CountStrategy
 import com.mongodb.client.model.CreateIndexOptions
 import com.mongodb.client.model.DeleteManyModel
 import com.mongodb.client.model.DeleteOneModel
@@ -66,6 +65,7 @@ import com.mongodb.client.model.changestream.ChangeStreamLevel
 import com.mongodb.client.result.DeleteResult
 import com.mongodb.client.result.UpdateResult
 import com.mongodb.client.test.Worker
+import com.mongodb.internal.client.model.CountStrategy
 import com.mongodb.operation.CountOperation
 import com.mongodb.operation.CreateIndexesOperation
 import com.mongodb.operation.DropCollectionOperation
@@ -850,7 +850,7 @@ class MongoCollectionSpecification extends Specification {
         where:
         [bypassDocumentValidation, modifiedCount, upsertedId, writeConcern, session, retryWrites] << [
                 [null, true, false],
-                [null, 1],
+                [1],
                 [null, new BsonInt32(42)],
                 [ACKNOWLEDGED, UNACKNOWLEDGED],
                 [null, Stub(ClientSession)],

--- a/driver-core/src/main/com/mongodb/bulk/BulkWriteResult.java
+++ b/driver-core/src/main/com/mongodb/bulk/BulkWriteResult.java
@@ -63,14 +63,18 @@ public abstract class BulkWriteResult {
     public abstract int getDeletedCount();
 
     /**
-     * Returns true if the server was able to provide a count of modified documents.  If this method returns false (which can happen if the
-     * server is not at least version 2.6) then the {@code getModifiedCount} method will throw {@code UnsupportedOperationException}.
+     * Returns true if the server was able to provide a count of modified documents.
      *
+     * <p>
+     * This method now always returns true, as modified count is available since MongoDB 2.6.
+     * </p>
      * @return true if modifiedCount is available
      * @throws java.lang.UnsupportedOperationException if the write was unacknowledged.
      * @see com.mongodb.WriteConcern#UNACKNOWLEDGED
      * @see #getModifiedCount()
+     * @deprecated no longer needed since all supported server versions support modified count
      */
+    @Deprecated
     public abstract boolean isModifiedCountAvailable();
 
     /**
@@ -78,13 +82,8 @@ public abstract class BulkWriteResult {
      * documents that were actually changed; for example, if you set the value of some field , and the field already has that value, that
      * will not count as a modification.
      *
-     * <p> If the server is not able to provide a count of modified documents (which can happen if the server is not at least version 2.6),
-     * then this method will throw an {@code UnsupportedOperationException} </p>
-     *
      * @return the number of documents modified by the write operation
-     * @throws java.lang.UnsupportedOperationException if the write was unacknowledged or if no modified count is available.
      * @see com.mongodb.WriteConcern#UNACKNOWLEDGED
-     * @see #isModifiedCountAvailable()
      */
     public abstract int getModifiedCount();
 
@@ -133,7 +132,7 @@ public abstract class BulkWriteResult {
      * @param insertedCount the number of documents inserted by the write operation
      * @param matchedCount  the number of documents matched by the write operation
      * @param removedCount  the number of documents removed by the write operation
-     * @param modifiedCount the number of documents modified, which may be null if the server was not able to provide the count
+     * @param modifiedCount the number of documents modified, which may not be null
      * @param upserts       the list of upserts
      * @return an acknowledged BulkWriteResult
      */
@@ -161,17 +160,13 @@ public abstract class BulkWriteResult {
             }
 
             @Override
+            @Deprecated
             public boolean isModifiedCountAvailable() {
-                return modifiedCount != null;
+                return true;
             }
 
             @Override
             public int getModifiedCount() {
-                if (modifiedCount == null) {
-                    throw new UnsupportedOperationException("The modifiedCount is not available because at least one of the servers that "
-                                                            + "was updated was not able to provide this information (the server is must be "
-                                                            + "at least version 2.6");
-                }
                 return modifiedCount;
             }
 
@@ -195,9 +190,6 @@ public abstract class BulkWriteResult {
                     return false;
                 }
                 if (insertedCount != that.getInsertedCount()) {
-                    return false;
-                }
-                if (isModifiedCountAvailable() != that.isModifiedCountAvailable()) {
                     return false;
                 }
                 if (modifiedCount != null && !modifiedCount.equals(that.getModifiedCount())) {
@@ -267,6 +259,7 @@ public abstract class BulkWriteResult {
             }
 
             @Override
+            @Deprecated
             public boolean isModifiedCountAvailable() {
                 throw getUnacknowledgedWriteException();
             }

--- a/driver-core/src/main/com/mongodb/client/result/UpdateResult.java
+++ b/driver-core/src/main/com/mongodb/client/result/UpdateResult.java
@@ -45,10 +45,12 @@ public abstract class UpdateResult {
     /**
      * Gets a value indicating whether the modified count is available.
      * <p>
-     * The modified count is only available when all servers have been upgraded to 2.6 or above.
+     * This method now always returns true, as modified count is available since MongoDB 2.6.
      * </p>
      * @return true if the modified count is available
+     * @deprecated no longer needed since all supported server versions support modified count
      */
+    @Deprecated
     public abstract boolean isModifiedCountAvailable();
 
     /**
@@ -93,7 +95,7 @@ public abstract class UpdateResult {
         private final Long modifiedCount;
         private final BsonValue upsertedId;
 
-        AcknowledgedUpdateResult(final long matchedCount, @Nullable final Long modifiedCount, @Nullable final BsonValue upsertedId) {
+        AcknowledgedUpdateResult(final long matchedCount, final Long modifiedCount, @Nullable final BsonValue upsertedId) {
             this.matchedCount = matchedCount;
             this.modifiedCount = modifiedCount;
             this.upsertedId = upsertedId;
@@ -110,16 +112,13 @@ public abstract class UpdateResult {
         }
 
         @Override
+        @Deprecated
         public boolean isModifiedCountAvailable() {
-            return modifiedCount != null;
+            return true;
         }
 
         @Override
         public long getModifiedCount() {
-            if (modifiedCount == null) {
-                throw new UnsupportedOperationException("Modified count is only available when connected to MongoDB 2.6 servers or "
-                                                        + "above.");
-            }
             return modifiedCount;
         }
 
@@ -183,6 +182,7 @@ public abstract class UpdateResult {
         }
 
         @Override
+        @Deprecated
         public boolean isModifiedCountAvailable() {
             return false;
         }

--- a/driver-core/src/main/com/mongodb/connection/BulkWriteBatchCombiner.java
+++ b/driver-core/src/main/com/mongodb/connection/BulkWriteBatchCombiner.java
@@ -46,7 +46,7 @@ public class BulkWriteBatchCombiner {
     private int insertedCount;
     private int matchedCount;
     private int deletedCount;
-    private Integer modifiedCount = 0;
+    private int modifiedCount = 0;
     private final Set<BulkWriteUpsert> writeUpserts = new TreeSet<BulkWriteUpsert>(new Comparator<BulkWriteUpsert>() {
         @Override
         public int compare(final BulkWriteUpsert o1, final BulkWriteUpsert o2) {
@@ -84,11 +84,7 @@ public class BulkWriteBatchCombiner {
         insertedCount += result.getInsertedCount();
         matchedCount += result.getMatchedCount();
         deletedCount += result.getDeletedCount();
-        if (result.isModifiedCountAvailable() && modifiedCount != null) {
-            modifiedCount += result.getModifiedCount();
-        } else {
-            modifiedCount = null;
-        }
+        modifiedCount += result.getModifiedCount();
         mergeUpserts(result.getUpserts(), indexMap);
     }
 

--- a/driver-core/src/main/com/mongodb/operation/BulkWriteBatch.java
+++ b/driver-core/src/main/com/mongodb/operation/BulkWriteBatch.java
@@ -45,7 +45,6 @@ import org.bson.BsonDocument;
 import org.bson.BsonDocumentWrapper;
 import org.bson.BsonInt32;
 import org.bson.BsonInt64;
-import org.bson.BsonNumber;
 import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.bson.BsonWriter;
@@ -296,9 +295,7 @@ final class BulkWriteBatch {
     }
 
     private Integer getModifiedCount(final BsonDocument result) {
-        BsonNumber modifiedCount = result.getNumber("nModified",
-                (batchType == UPDATE || batchType == REPLACE) ? null : new BsonInt32(0));
-        return modifiedCount == null ? null : modifiedCount.intValue();
+        return result.getNumber("nModified", new BsonInt32(0)).intValue();
     }
 
     private boolean hasError(final BsonDocument result) {

--- a/driver-core/src/test/functional/com/mongodb/operation/MixedBulkWriteOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/MixedBulkWriteOperationSpecification.groovy
@@ -973,9 +973,7 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         result.getInsertedCount() == 2
         result.getDeletedCount() == 2
         result.getMatchedCount() == 4
-        if (result.isModifiedCountAvailable()) {
-            result.getModifiedCount() == 4
-        }
+        result.getModifiedCount() == 4
         result.getUpserts().isEmpty()
 
         then:

--- a/driver-core/src/test/unit/com/mongodb/connection/BulkWriteBatchCombinerSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/connection/BulkWriteBatchCombinerSpecification.groovy
@@ -57,18 +57,6 @@ class BulkWriteBatchCombinerSpecification extends Specification {
         result == BulkWriteResult.acknowledged(INSERT, 1, 0, [])
     }
 
-    def 'should handle null modifiedCount'() {
-        def combiner = new BulkWriteBatchCombiner(new ServerAddress(), true, ACKNOWLEDGED)
-        combiner.addResult(BulkWriteResult.acknowledged(UPDATE, 1, null, []), new IndexMap.RangeBased().add(0, 0))
-        combiner.addResult(BulkWriteResult.acknowledged(INSERT, 1, 0, []), new IndexMap.RangeBased().add(0, 0))
-
-        when:
-        def result = combiner.getResult()
-
-        then:
-        result == BulkWriteResult.acknowledged(1, 1, 0, null, [])
-    }
-
     def 'should sort upserts'() {
         given:
         def combiner = new BulkWriteBatchCombiner(new ServerAddress(), true, ACKNOWLEDGED)

--- a/driver-core/src/test/unit/com/mongodb/internal/connection/WriteCommandHelperSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/WriteCommandHelperSpecification.groovy
@@ -30,7 +30,6 @@ import spock.lang.Specification
 
 import static com.mongodb.bulk.WriteRequest.Type.DELETE
 import static com.mongodb.bulk.WriteRequest.Type.INSERT
-import static com.mongodb.bulk.WriteRequest.Type.REPLACE
 import static com.mongodb.bulk.WriteRequest.Type.UPDATE
 import static com.mongodb.internal.connection.WriteCommandResultHelper.getBulkWriteException
 import static com.mongodb.internal.connection.WriteCommandResultHelper.getBulkWriteResult
@@ -55,17 +54,6 @@ class WriteCommandHelperSpecification extends Specification {
                                                            .append('_id',
                                                                    new BsonString('id2'))])))
                 .getUpserts()
-    }
-
-
-    def 'should not have modified count for update with no nModified field in the result'() {
-        expect:
-        !getBulkWriteResult(UPDATE, new BsonDocument('n', new BsonInt32(1))).isModifiedCountAvailable()
-    }
-
-    def 'should not have modified count for replace with no nModified field in the result'() {
-        expect:
-        !getBulkWriteResult(REPLACE, new BsonDocument('n', new BsonInt32(1))).isModifiedCountAvailable()
     }
 
     def 'should have modified count of 0 for insert with no nModified field in the result'() {

--- a/driver-core/src/test/unit/com/mongodb/operation/BulkWriteBatchSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/operation/BulkWriteBatchSpecification.groovy
@@ -250,7 +250,7 @@ class BulkWriteBatchSpecification extends Specification {
 
         then:
         !bulkWriteBatch.hasErrors()
-        bulkWriteBatch.getResult() == BulkWriteResult.acknowledged(0, 0, 0, null, [new BulkWriteUpsert(0, new BsonInt32(2))])
+        bulkWriteBatch.getResult() == BulkWriteResult.acknowledged(0, 0, 0, 0, [new BulkWriteUpsert(0, new BsonInt32(2))])
         bulkWriteBatch.shouldProcessBatch()
     }
 

--- a/driver-embedded-android/src/androidTest/java/com/mongodb/embedded/client/JsonPoweredCrudTestHelper.java
+++ b/driver-embedded-android/src/androidTest/java/com/mongodb/embedded/client/JsonPoweredCrudTestHelper.java
@@ -18,7 +18,6 @@ package com.mongodb.embedded.client;
 
 import android.content.res.AssetManager;
 import android.support.test.InstrumentationRegistry;
-
 import com.mongodb.MongoBulkWriteException;
 import com.mongodb.MongoException;
 import com.mongodb.ReadConcern;
@@ -59,7 +58,6 @@ import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.WriteModel;
 import com.mongodb.client.result.UpdateResult;
 import com.mongodb.lang.Nullable;
-
 import org.bson.BsonArray;
 import org.bson.BsonBoolean;
 import org.bson.BsonDocument;
@@ -138,9 +136,7 @@ public class JsonPoweredCrudTestHelper {
 
     BsonDocument toResult(final UpdateResult updateResult) {
         BsonDocument resultDoc = new BsonDocument("matchedCount", new BsonInt32((int) updateResult.getMatchedCount()));
-        if (updateResult.isModifiedCountAvailable()) {
-            resultDoc.append("modifiedCount", new BsonInt32((int) updateResult.getModifiedCount()));
-        }
+        resultDoc.append("modifiedCount", new BsonInt32((int) updateResult.getModifiedCount()));
         if (updateResult.getUpsertedId() != null) {
             resultDoc.append("upsertedId", updateResult.getUpsertedId());
         }
@@ -169,9 +165,7 @@ public class JsonPoweredCrudTestHelper {
             resultDoc.append("insertedCount", new BsonInt32(insertedIds.size()));
 
             resultDoc.append("matchedCount", new BsonInt32(bulkWriteResult.getMatchedCount()));
-            if (bulkWriteResult.isModifiedCountAvailable()) {
-                resultDoc.append("modifiedCount", new BsonInt32(bulkWriteResult.getModifiedCount()));
-            }
+            resultDoc.append("modifiedCount", new BsonInt32(bulkWriteResult.getModifiedCount()));
             resultDoc.append("upsertedCount", bulkWriteResult.getUpserts() == null
                     ? new BsonInt32(0) : new BsonInt32(bulkWriteResult.getUpserts().size()));
             BsonDocument upserts = new BsonDocument();

--- a/driver-legacy/src/main/com/mongodb/AcknowledgedBulkWriteResult.java
+++ b/driver-legacy/src/main/com/mongodb/AcknowledgedBulkWriteResult.java
@@ -16,8 +16,6 @@
 
 package com.mongodb;
 
-import com.mongodb.lang.Nullable;
-
 import java.util.Collections;
 import java.util.List;
 
@@ -27,15 +25,15 @@ class AcknowledgedBulkWriteResult extends BulkWriteResult {
     private int insertedCount;
     private int matchedCount;
     private int removedCount;
-    private Integer modifiedCount;
+    private int modifiedCount;
     private final List<BulkWriteUpsert> upserts;
 
     AcknowledgedBulkWriteResult(final int insertedCount, final int matchedCount, final int removedCount,
-                                @Nullable final Integer modifiedCount, final List<BulkWriteUpsert> upserts) {
+                                final Integer modifiedCount, final List<BulkWriteUpsert> upserts) {
         this.insertedCount = insertedCount;
         this.matchedCount = matchedCount;
         this.removedCount = removedCount;
-        this.modifiedCount = modifiedCount;
+        this.modifiedCount = notNull("modifiedCount", modifiedCount);
         this.upserts = Collections.unmodifiableList(notNull("upserts", upserts));
     }
 
@@ -60,16 +58,13 @@ class AcknowledgedBulkWriteResult extends BulkWriteResult {
     }
 
     @Override
+    @Deprecated
     public boolean isModifiedCountAvailable() {
-        return modifiedCount != null;
+        return true;
     }
 
     @Override
     public int getModifiedCount() {
-        if (modifiedCount == null) {
-            throw new UnsupportedOperationException("The modifiedCount is not available because at least one of the servers "
-                    + "updated was not able to provide this information (the server must be at least version 2.6 or higher.");
-        }
         return modifiedCount;
     }
 
@@ -98,7 +93,7 @@ class AcknowledgedBulkWriteResult extends BulkWriteResult {
         if (removedCount != that.removedCount) {
             return false;
         }
-        if (modifiedCount != null ? !modifiedCount.equals(that.modifiedCount) : that.modifiedCount != null) {
+        if (modifiedCount != that.modifiedCount) {
             return false;
         }
         if (!upserts.equals(that.upserts)) {
@@ -113,7 +108,7 @@ class AcknowledgedBulkWriteResult extends BulkWriteResult {
         int result = insertedCount;
         result = 31 * result + matchedCount;
         result = 31 * result + removedCount;
-        result = 31 * result + (modifiedCount != null ? modifiedCount.hashCode() : 0);
+        result = 31 * result + modifiedCount;
         result = 31 * result + upserts.hashCode();
         return result;
     }

--- a/driver-legacy/src/main/com/mongodb/BulkWriteHelper.java
+++ b/driver-legacy/src/main/com/mongodb/BulkWriteHelper.java
@@ -29,9 +29,8 @@ final class BulkWriteHelper {
     static BulkWriteResult translateBulkWriteResult(final com.mongodb.bulk.BulkWriteResult bulkWriteResult,
                                                     final Decoder<DBObject> decoder) {
         if (bulkWriteResult.wasAcknowledged()) {
-            Integer modifiedCount = (bulkWriteResult.isModifiedCountAvailable()) ? bulkWriteResult.getModifiedCount() : null;
             return new AcknowledgedBulkWriteResult(bulkWriteResult.getInsertedCount(), bulkWriteResult.getMatchedCount(),
-                                                   bulkWriteResult.getDeletedCount(), modifiedCount,
+                                                   bulkWriteResult.getDeletedCount(), bulkWriteResult.getModifiedCount(),
                                                    translateBulkWriteUpserts(bulkWriteResult.getUpserts(), decoder));
         } else {
             return new UnacknowledgedBulkWriteResult();

--- a/driver-legacy/src/main/com/mongodb/BulkWriteResult.java
+++ b/driver-legacy/src/main/com/mongodb/BulkWriteResult.java
@@ -67,14 +67,19 @@ public abstract class BulkWriteResult {
     public abstract int getRemovedCount();
 
     /**
-     * Returns true if the server was able to provide a count of modified documents.  If this method returns false (which can happen if the
-     * server is not at least version 2.6) then the {@code getModifiedCount} method will throw {@code UnsupportedOperationException}.
+     * Returns true if the server was able to provide a count of modified documents.
+     *
+     * <p>
+     * This method now always returns true, as modified count is available since MongoDB 2.6.
+     * </p>
      *
      * @return true if modifiedCount is available
      * @throws java.lang.UnsupportedOperationException if the write was unacknowledged.
      * @see WriteConcern#UNACKNOWLEDGED
      * @see #getModifiedCount()
+     * @deprecated no longer needed since all supported server versions support modified count
      */
+    @Deprecated
     public abstract boolean isModifiedCountAvailable();
 
     /**
@@ -82,13 +87,8 @@ public abstract class BulkWriteResult {
      * count documents that were actually changed; for example, if you set the value of some field , and the field already has that value,
      * that will not count as a modification.</p>
      *
-     * <p>If the server is not able to provide a count of modified documents (which can happen if the server is not at least version 2.6),
-     * then this method will throw an {@code UnsupportedOperationException} </p>
-     *
      * @return the number of documents modified by the write operation
-     * @throws java.lang.UnsupportedOperationException if the write was unacknowledged or if no modified count is available
      * @see WriteConcern#UNACKNOWLEDGED
-     * @see #isModifiedCountAvailable()
      */
     public abstract int getModifiedCount();
 

--- a/driver-legacy/src/main/com/mongodb/UnacknowledgedBulkWriteResult.java
+++ b/driver-legacy/src/main/com/mongodb/UnacknowledgedBulkWriteResult.java
@@ -44,6 +44,7 @@ class UnacknowledgedBulkWriteResult extends BulkWriteResult {
     }
 
     @Override
+    @Deprecated
     public boolean isModifiedCountAvailable() {
         throw getUnacknowledgedWriteException();
     }

--- a/driver-legacy/src/test/functional/com/mongodb/DBCollectionTest.java
+++ b/driver-legacy/src/test/functional/com/mongodb/DBCollectionTest.java
@@ -721,9 +721,7 @@ public class DBCollectionTest extends DatabaseTestCase {
         assertEquals(1, result.getInsertedCount());
         assertEquals(4, result.getMatchedCount());
         assertEquals(3, result.getRemovedCount());
-        if (result.isModifiedCountAvailable()) {
-            assertEquals(4, result.getModifiedCount());
-        }
+        assertEquals(4, result.getModifiedCount());
         assertEquals(Arrays.asList(new BulkWriteUpsert(1, upsertOneId),
                                    new BulkWriteUpsert(2, upsertTwoId)),
                      result.getUpserts());

--- a/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/MongoCollectionImpl.java
@@ -989,9 +989,8 @@ class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument> {
 
     private UpdateResult toUpdateResult(final com.mongodb.bulk.BulkWriteResult result) {
         if (result.wasAcknowledged()) {
-            Long modifiedCount = result.isModifiedCountAvailable() ? (long) result.getModifiedCount() : null;
             BsonValue upsertedId = result.getUpserts().isEmpty() ? null : result.getUpserts().get(0).getId();
-            return UpdateResult.acknowledged(result.getMatchedCount(), modifiedCount, upsertedId);
+            return UpdateResult.acknowledged(result.getMatchedCount(), (long) result.getModifiedCount(), upsertedId);
         } else {
             return UpdateResult.unacknowledged();
         }

--- a/driver-sync/src/test/functional/com/mongodb/client/JsonPoweredCrudTestHelper.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/JsonPoweredCrudTestHelper.java
@@ -138,9 +138,7 @@ public class JsonPoweredCrudTestHelper {
 
     BsonDocument toResult(final UpdateResult updateResult) {
         BsonDocument resultDoc = new BsonDocument("matchedCount", new BsonInt32((int) updateResult.getMatchedCount()));
-        if (updateResult.isModifiedCountAvailable()) {
-            resultDoc.append("modifiedCount", new BsonInt32((int) updateResult.getModifiedCount()));
-        }
+        resultDoc.append("modifiedCount", new BsonInt32((int) updateResult.getModifiedCount()));
         if (updateResult.getUpsertedId() != null) {
             resultDoc.append("upsertedId", updateResult.getUpsertedId());
         }
@@ -169,9 +167,7 @@ public class JsonPoweredCrudTestHelper {
             resultDoc.append("insertedCount", new BsonInt32(insertedIds.size()));
 
             resultDoc.append("matchedCount", new BsonInt32(bulkWriteResult.getMatchedCount()));
-            if (bulkWriteResult.isModifiedCountAvailable()) {
-                resultDoc.append("modifiedCount", new BsonInt32(bulkWriteResult.getModifiedCount()));
-            }
+            resultDoc.append("modifiedCount", new BsonInt32(bulkWriteResult.getModifiedCount()));
             resultDoc.append("upsertedCount", bulkWriteResult.getUpserts() == null
                     ? new BsonInt32(0) : new BsonInt32(bulkWriteResult.getUpserts().size()));
             BsonDocument upserts = new BsonDocument();

--- a/driver-sync/src/test/unit/com/mongodb/client/internal/MongoCollectionSpecification.groovy
+++ b/driver-sync/src/test/unit/com/mongodb/client/internal/MongoCollectionSpecification.groovy
@@ -848,7 +848,7 @@ class MongoCollectionSpecification extends Specification {
         where:
         [bypassDocumentValidation, modifiedCount, upsertedId, writeConcern, session, retryWrites] << [
                 [null, true, false],
-                [null, 1],
+                [1],
                 [null, new BsonInt32(42)],
                 [ACKNOWLEDGED, UNACKNOWLEDGED],
                 [null, Stub(ClientSession)],


### PR DESCRIPTION
Additionally, remove usage of this method and simplify code to assume
that the modifiedCount is available on all supported server versions.

https://jira.mongodb.org/browse/JAVA-3262

Patch build: https://evergreen.mongodb.com/patch/5caf8b98e3c33148a76e078c