### PR TITLE
Disable tests failing on MongoDB 4.2

### DIFF
--- a/driver-core/src/test/functional/com/mongodb/operation/AggregateOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/AggregateOperationSpecification.groovy
@@ -354,7 +354,7 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         def result = execute(operation, async)
 
         then:
-        result.containsKey('stages')
+        result.containsKey('stages') || result.containsKey('queryPlanner')
 
         where:
         async << [true, false]
@@ -377,7 +377,8 @@ class AggregateOperationSpecification extends OperationFunctionalSpecification {
         [async, options] << [[true, false], [defaultCollation, null, Collation.builder().build()]].combinations()
     }
 
-    @IgnoreIf({ !serverVersionAtLeast(3, 6) })
+    // Explain output keeps changing so only testing this in the range where the assertion still works
+    @IgnoreIf({ !serverVersionAtLeast(3, 6) || serverVersionAtLeast(4, 1) })
     def 'should apply $hint'() {
         given:
         def index = new BsonDocument('a', new BsonInt32(1))

--- a/driver-core/src/test/functional/com/mongodb/operation/CreateCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/CreateCollectionOperationSpecification.groovy
@@ -148,6 +148,7 @@ class CreateCollectionOperationSpecification extends OperationFunctionalSpecific
         async << [true, false]
     }
 
+    @IgnoreIf({ serverVersionAtLeast(4, 1) })
     def 'should set flags for use power of two sizes'() {
         given:
         assert !collectionNameExists(getCollectionName())


### PR DESCRIPTION
* Some tests are failing due to changes in the structure of the response
  to an explain command
* One is failing due to removal of flags from response to
  listCollections command

Patch build: https://evergreen.mongodb.com/version/5cafe6fae3c33148a7719f3a  (static check failure has been fixed)