### PR TITLE
Ensure tag sets with the same tags compare equally

### DIFF
--- a/driver-core/src/main/com/mongodb/TagSet.java
+++ b/driver-core/src/main/com/mongodb/TagSet.java
@@ -20,6 +20,7 @@ import com.mongodb.annotations.Immutable;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -73,7 +74,14 @@ public final class TagSet implements Iterable<Tag> {
                 throw new IllegalArgumentException("Duplicate tag names not allowed in a tag set: " + tag.getName());
             }
         }
-        this.wrapped = Collections.unmodifiableList(new ArrayList<Tag>(tagList));
+        ArrayList<Tag> copy = new ArrayList<Tag>(tagList);
+        Collections.sort(copy, new Comparator<Tag>() {
+            @Override
+            public int compare(final Tag o1, final Tag o2) {
+                return o1.getName().compareTo(o2.getName());
+            }
+        });
+        this.wrapped = Collections.unmodifiableList(copy);
     }
 
     @Override

--- a/driver-core/src/test/unit/com/mongodb/TagSetSpecification.groovy
+++ b/driver-core/src/test/unit/com/mongodb/TagSetSpecification.groovy
@@ -84,4 +84,17 @@ class TagSetSpecification extends Specification {
         thrown(IllegalArgumentException)
     }
 
+    def 'should alphabetically order tags'() {
+        when:
+        def pTag = new Tag('p', '1')
+        def dcTag = new Tag('dc', 'ny')
+        def tagSet = new TagSet([pTag, dcTag])
+        def iter = tagSet.iterator()
+
+        then:
+        iter.next() == dcTag
+        iter.next() == pTag
+        !iter.hasNext()
+        tagSet == new TagSet([dcTag, pTag])
+    }
 }


### PR DESCRIPTION
Order does not matter with a tag set, so they now sorted by name to
ensure that equivalent tag sets compare as equal

This addresses https://jira.mongodb.org/browse/JAVA-3283