### PR TITLE
Handle null results for reactive applications

### DIFF
--- a/driver-async/src/test/unit/com/mongodb/async/client/MongoIterableSubscriptionSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/MongoIterableSubscriptionSpecification.groovy
@@ -68,7 +68,7 @@ class MongoIterableSubscriptionSpecification extends Specification {
 
         then:
         observer.assertNoErrors()
-        observer.assertReceivedOnNext([1, 2, 3, 4])
+        observer.assertReceivedOnNext([1, 2, 3, null])
         observer.assertTerminalEvent()
     }
 
@@ -85,7 +85,7 @@ class MongoIterableSubscriptionSpecification extends Specification {
 
         then:
         observer.assertNoErrors()
-        observer.assertReceivedOnNext([1, 2, 3, 4])
+        observer.assertReceivedOnNext([1, 2, 3, null])
         observer.assertTerminalEvent()
 
         cleanup:
@@ -293,7 +293,7 @@ class MongoIterableSubscriptionSpecification extends Specification {
         then: // check that the observer is finished
         observer.assertSubscribed()
         observer.assertNoErrors()
-        observer.assertReceivedOnNext([1, 2, 3, 4])
+        observer.assertReceivedOnNext([1, 2, 3, null])
         observer.assertTerminalEvent()
 
         when: // unsubscribe
@@ -466,7 +466,7 @@ class MongoIterableSubscriptionSpecification extends Specification {
 
     def getCursor() {
         Mock(AsyncBatchCursor) {
-            def cursorResults = [[1, 2], [3, 4]]
+            def cursorResults = [[1, 2], [3, null]]
             next(_) >> {
                 it[0].onResult(cursorResults.isEmpty() ? null : cursorResults.remove(0), null)
             }

--- a/driver-async/src/test/unit/com/mongodb/async/client/SingleResultCallbackSubscriptionSpecification.groovy
+++ b/driver-async/src/test/unit/com/mongodb/async/client/SingleResultCallbackSubscriptionSpecification.groovy
@@ -250,7 +250,7 @@ class SingleResultCallbackSubscriptionSpecification extends Specification {
         observer.assertTerminalEvent()
     }
 
-    def 'should be able to handle Void callbacks'() {
+    def 'should be able to handle null single result'() {
         given:
         def observer = new TestObserver()
         observe(new Block<SingleResultCallback<Void>>(){
@@ -265,7 +265,7 @@ class SingleResultCallbackSubscriptionSpecification extends Specification {
 
         then:
         observer.assertNoErrors()
-        observer.assertReceivedOnNext([])
+        observer.assertReceivedOnNext([null])
         observer.assertTerminalEvent()
     }
 


### PR DESCRIPTION
In some situations (e.g. a distinct command) a null result is expected.
AbstractSubscription now handles this use case.

Wrapping drivers (Reactive Streams, Scala) use a special
SUCCESS result to handle void returns, so this change should not present
a problem for those drivers.

https://jira.mongodb.org/browse/JAVA-3279