### PR TITLE
Throw exception if auto-encryption is enabled for async MongoClient

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/MongoClientSettings.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoClientSettings.java
@@ -95,6 +95,7 @@ public final class MongoClientSettings {
         }
 
         private Builder(final com.mongodb.MongoClientSettings settings) {
+            isTrue("auto-encryption settings is null", settings.getAutoEncryptionSettings() == null);
             notNull("settings", settings);
             wrappedBuilder = com.mongodb.MongoClientSettings.builder(settings);
             MongoCredential credential = settings.getCredential();

--- a/driver-async/src/test/functional/com/mongodb/async/client/MongoClientsSpecification.groovy
+++ b/driver-async/src/test/functional/com/mongodb/async/client/MongoClientsSpecification.groovy
@@ -16,6 +16,7 @@
 
 package com.mongodb.async.client
 
+import com.mongodb.AutoEncryptionSettings
 import com.mongodb.MongoCompressor
 import com.mongodb.MongoCredential
 import com.mongodb.MongoDriverInformation
@@ -251,5 +252,18 @@ class MongoClientsSpecification extends FunctionalSpecification {
             run(profileCollection.&drop)
         }
         client?.close()
+    }
+
+    def 'should throw if AutoEncryptionSettings is not null'() {
+        when:
+        MongoClients.create(com.mongodb.MongoClientSettings.builder()
+                .autoEncryptionSettings(AutoEncryptionSettings.builder()
+                        .keyVaultNamespace('test.keys')
+                        .kmsProviders([local: ['key': new byte[96]]])
+                        .build())
+                .build())
+
+        then:
+        thrown(IllegalStateException)
     }
 }


### PR DESCRIPTION
JAVA-3313

Until we actually implement it, don't want anyone to assume it's encrypting when it's not.