### PR TITLE
Support $merge aggregation stage

### DIFF
--- a/docs/reference/content/builders/aggregation.md
+++ b/docs/reference/content/builders/aggregation.md
@@ -216,6 +216,27 @@ This example writes the pipeline to the `authors` collection:
 out("authors")
 ```
 
+### Merge
+
+The [`$merge`]({{< docsref "reference/operator/aggregation/merge/" >}}) pipeline stage merges all documents into the specified
+collection.  It must be the last stage in any aggregate pipeline:
+
+This example merges the pipeline into the `authors` collection using the default options:
+
+```java
+merge("authors")
+```
+
+This example merges the pipeline into the `authors` collection using some non-default options:
+
+```java
+merge(new MongoNamespace("reporting", customers"),
+    new MergeOptions().uniqueIdentifier(Arrays.asList("date", "customerId"))
+                      .whenMatched(MergeOptions.WhenMatched.REPLACE)
+                      .whenNotMatched(MergeOptions.WhenNotMatched.INSERT))
+```
+
+
 ### GraphLookup
 
 The [`$graphLookup`]({{< docsref "reference/operator/aggregation/graphLookup/" >}}) pipeline stage performs a recursive search on a specified collection to match field A of one document to some field B of the other documents. For the matching documents, the stage repeats the search to match field A from the matching documents to the field B of the remaining documents until no new documents are encountered or until a specified depth. To each output document, `$graphLookup` adds a new array field that contains the traversal results of the search for that document.

--- a/driver-async/src/main/com/mongodb/async/client/AggregateIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/AggregateIterable.java
@@ -81,10 +81,10 @@ public interface AggregateIterable<TResult> extends MongoIterable<TResult> {
     AggregateIterable<TResult> useCursor(@Nullable Boolean useCursor);
 
     /**
-     * Aggregates documents according to the specified aggregation pipeline, which must end with a $out stage.
+     * Aggregates documents according to the specified aggregation pipeline, which must end with a $out or $merge stage.
      *
      * @param callback the callback, which is called when the aggregation completes
-     * @throws IllegalStateException if the pipeline does not end with a $out stage
+     * @throws IllegalStateException if the pipeline does not end with a $out or $merge stage
      * @mongodb.driver.manual aggregation/ Aggregation
      */
     void toCollection(SingleResultCallback<Void> callback);
@@ -101,7 +101,7 @@ public interface AggregateIterable<TResult> extends MongoIterable<TResult> {
     /**
      * Sets the bypass document level validation flag.
      *
-     * <p>Note: This only applies when an $out stage is specified</p>.
+     * <p>Note: This only applies when a $out or $merge stage is specified</p>.
      *
      * @param bypassDocumentValidation If true, allows the write to opt-out of document level validation.
      * @return this

--- a/driver-async/src/main/com/mongodb/async/client/MapReduceIterable.java
+++ b/driver-async/src/main/com/mongodb/async/client/MapReduceIterable.java
@@ -167,8 +167,6 @@ public interface MapReduceIterable<TResult> extends MongoIterable<TResult> {
     /**
      * Sets the bypass document level validation flag.
      *
-     * <p>Note: This only applies when an $out stage is specified</p>.
-     *
      * @param bypassDocumentValidation If true, allows the write to opt-out of document level validation.
      * @return this
      * @since 3.2

--- a/driver-async/src/main/com/mongodb/async/client/MongoCollection.java
+++ b/driver-async/src/main/com/mongodb/async/client/MongoCollection.java
@@ -539,7 +539,7 @@ public interface MongoCollection<TDocument> {
     <TResult> FindIterable<TResult> find(ClientSession clientSession, Bson filter, Class<TResult> resultClass);
 
     /**
-     * Aggregates documents according to the specified aggregation pipeline.  If the pipeline ends with a $out stage, the returned
+     * Aggregates documents according to the specified aggregation pipeline.  If the pipeline ends with a $out or $merge stage, the returned
      * iterable will be a query of the collection that the aggregation was written to.  Note that in this case the pipeline will be
      * executed even if the iterable is never iterated.
      *
@@ -550,7 +550,7 @@ public interface MongoCollection<TDocument> {
     AggregateIterable<TDocument> aggregate(List<? extends Bson> pipeline);
 
     /**
-     * Aggregates documents according to the specified aggregation pipeline.  If the pipeline ends with a $out stage, the returned
+     * Aggregates documents according to the specified aggregation pipeline.  If the pipeline ends with a $out or $merge stage, the returned
      * iterable will be a query of the collection that the aggregation was written to.  Note that in this case the pipeline will be
      * executed even if the iterable is never iterated.
      *
@@ -563,7 +563,7 @@ public interface MongoCollection<TDocument> {
     <TResult> AggregateIterable<TResult> aggregate(List<? extends Bson> pipeline, Class<TResult> resultClass);
 
     /**
-     * Aggregates documents according to the specified aggregation pipeline.  If the pipeline ends with a $out stage, the returned
+     * Aggregates documents according to the specified aggregation pipeline.  If the pipeline ends with a $out or $merge stage, the returned
      * iterable will be a query of the collection that the aggregation was written to.  Note that in this case the pipeline will be
      * executed even if the iterable is never iterated.
      *
@@ -577,7 +577,7 @@ public interface MongoCollection<TDocument> {
     AggregateIterable<TDocument> aggregate(ClientSession clientSession, List<? extends Bson> pipeline);
 
     /**
-     * Aggregates documents according to the specified aggregation pipeline.  If the pipeline ends with a $out stage, the returned
+     * Aggregates documents according to the specified aggregation pipeline.  If the pipeline ends with a $out or $merge stage, the returned
      * iterable will be a query of the collection that the aggregation was written to.  Note that in this case the pipeline will be
      * executed even if the iterable is never iterated.
      *

--- a/driver-core/src/main/com/mongodb/client/model/MergeOptions.java
+++ b/driver-core/src/main/com/mongodb/client/model/MergeOptions.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client.model;
+
+import org.bson.conversions.Bson;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Options to control the behavior of the $merge aggregation stage
+ *
+ * @mongodb.driver.manual reference/operator/aggregation/merge/  $merge stage
+ * @mongodb.server.release 4.2
+ * @see Aggregates#merge(String, MergeOptions)
+ * @see Aggregates#merge(com.mongodb.MongoNamespace, MergeOptions)
+ * @since 3.11
+ */
+public final class MergeOptions {
+
+    /**
+     * The behavior of $merge if a result document and an existing document in the collection have the same value for the specified on
+     * field(s).
+     */
+    public enum WhenMatched {
+        /**
+         *  Replace the existing document in the output collection with the matching results document.
+         */
+        REPLACE,
+
+        /**
+         *  Keep the existing document in the output collection.
+         */
+        KEEP_EXISTING,
+
+        /**
+         * Merge the matching documents
+         */
+        MERGE,
+
+        /**
+         * An aggregation pipeline to update the document in the collection.
+         *
+         * @see #whenMatchedPipeline(List)
+         */
+        PIPELINE,
+
+        /**
+         * Stop and fail the aggregation operation. Any changes to the output collection from previous documents are not reverted.
+         */
+        FAIL,
+    }
+
+    /**
+     * The behavior of $merge if a result document does not match an existing document in the out collection.
+     */
+    public enum WhenNotMatched {
+        /**
+         * Insert the document into the output collection.
+         */
+        INSERT,
+
+        /**
+         * Discard the document; i.e. $merge does not insert the document into the output collection.
+         */
+        DISCARD,
+
+        /**
+         * Stop and fail the aggregation operation. Any changes to the output collection from previous documents are not reverted.
+         */
+        FAIL
+    }
+
+    private List<String> uniqueIdentifier;
+    private WhenMatched whenMatched;
+    private List<Variable<?>> variables;
+    private List<Bson> whenMatchedPipeline;
+    private WhenNotMatched whenNotMatched;
+
+    /**
+     * Gets the fields that act as a unique identifier for a document. The identifier determine if a results document matches an
+     * already existing document in the output collection.
+     *
+     * @return the unique identifier
+     */
+    public List<String> getUniqueIdentifier() {
+        return uniqueIdentifier;
+    }
+
+    /**
+     * Sets the field that act as a unique identifier for a document. The identifier determine if a results document matches an
+     * already existing document in the output collection.
+     *
+     * @param uniqueIdentifier the unique identifier
+     * @return this
+     */
+    public MergeOptions uniqueIdentifier(final String uniqueIdentifier) {
+        this.uniqueIdentifier = Collections.singletonList(uniqueIdentifier);
+        return this;
+    }
+
+    /**
+     * Sets the field that act as a unique identifier for a document. The identifier determine if a results document matches an
+     * already existing document in the output collection.
+     *
+     * @param uniqueIdentifier the unique identifier
+     * @return this
+     */
+    public MergeOptions uniqueIdentifier(final List<String> uniqueIdentifier) {
+        this.uniqueIdentifier = uniqueIdentifier;
+        return this;
+    }
+
+    /**
+     * Gets the behavior of $merge if a result document and an existing document in the collection have the same value for the specified
+     * on field(s).
+     *
+     * @return when matched
+     */
+    public WhenMatched getWhenMatched() {
+        return whenMatched;
+    }
+
+    /**
+     * Sets the behavior of $merge if a result document and an existing document in the collection have the same value for the specified
+     * on field(s).
+     *
+     * @param whenMatched when matched
+     * @return this
+     */
+    public MergeOptions whenMatched(final WhenMatched whenMatched) {
+        this.whenMatched = whenMatched;
+        return this;
+    }
+
+    /**
+     * Gets the variables accessible for use in the whenMatched pipeline
+     * @return the variables
+     */
+    public List<Variable<?>> getVariables() {
+        return variables;
+    }
+
+    /**
+     * Sets the variables accessible for use in the whenMatched pipeline.
+     *
+     * @param variables the variables
+     * @return this
+     */
+    public MergeOptions variables(final List<Variable<?>> variables) {
+        this.variables = variables;
+        return this;
+    }
+
+    /**
+     * Gets aggregation pipeline to update the document in the collection.
+     *
+     * @return when matched pipeline
+     * @see WhenMatched#PIPELINE
+     */
+    public List<Bson> getWhenMatchedPipeline() {
+        return whenMatchedPipeline;
+    }
+
+    /**
+     * Sets aggregation pipeline to update the document in the collection.
+     *
+     * @param whenMatchedPipeline when matched pipeline
+     * @return this
+     * @see WhenMatched#PIPELINE
+     */
+    public MergeOptions whenMatchedPipeline(final List<Bson> whenMatchedPipeline) {
+        this.whenMatchedPipeline = whenMatchedPipeline;
+        return this;
+    }
+
+    /**
+     * Gets the behavior of $merge if a result document does not match an existing document in the out collection.
+     *
+     * @return when not matched
+     */
+    public WhenNotMatched getWhenNotMatched() {
+        return whenNotMatched;
+    }
+
+    /**
+     * Sets the behavior of $merge if a result document does not match an existing document in the out collection.
+     *
+     * @param whenNotMatched when not matched
+     * @return this
+     */
+    public MergeOptions whenNotMatched(final WhenNotMatched whenNotMatched) {
+        this.whenNotMatched = whenNotMatched;
+        return this;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        MergeOptions that = (MergeOptions) o;
+
+        if (uniqueIdentifier != null ? !uniqueIdentifier.equals(that.uniqueIdentifier) : that.uniqueIdentifier != null) {
+            return false;
+        }
+        if (whenMatched != that.whenMatched) {
+            return false;
+        }
+        if (variables != null ? !variables.equals(that.variables) : that.variables != null) {
+            return false;
+        }
+        if (whenMatchedPipeline != null ? !whenMatchedPipeline.equals(that.whenMatchedPipeline) : that.whenMatchedPipeline != null) {
+            return false;
+        }
+        if (whenNotMatched != that.whenNotMatched) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = uniqueIdentifier != null ? uniqueIdentifier.hashCode() : 0;
+        result = 31 * result + (whenMatched != null ? whenMatched.hashCode() : 0);
+        result = 31 * result + (variables != null ? variables.hashCode() : 0);
+        result = 31 * result + (whenMatchedPipeline != null ? whenMatchedPipeline.hashCode() : 0);
+        result = 31 * result + (whenNotMatched != null ? whenNotMatched.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "MergeOptions{"
+                + "uniqueIdentifier=" + uniqueIdentifier
+                + ", whenMatched=" + whenMatched
+                + ", variables=" + variables
+                + ", whenMatchedPipeline=" + whenMatchedPipeline
+                + ", whenNotMatched=" + whenNotMatched
+                + '}';
+    }
+}

--- a/driver-core/src/main/com/mongodb/operation/AggregateToCollectionOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/AggregateToCollectionOperation.java
@@ -120,8 +120,6 @@ public class AggregateToCollectionOperation implements AsyncWriteOperation<Void>
         this.aggregationLevel = notNull("aggregationLevel", aggregationLevel);
 
         isTrueArgument("pipeline is not empty", !pipeline.isEmpty());
-        isTrueArgument("last stage of pipeline contains an output collection",
-                pipeline.get(pipeline.size() - 1).get("$out") != null);
     }
 
     /**
@@ -208,7 +206,7 @@ public class AggregateToCollectionOperation implements AsyncWriteOperation<Void>
     /**
      * Sets the bypass document level validation flag.
      *
-     * <p>Note: This only applies when an $out stage is specified</p>.
+     * <p>Note: This only applies when an $out or $merge stage is specified</p>.
      *
      * @param bypassDocumentValidation If true, allows the write to opt-out of document level validation.
      * @return this

--- a/driver-core/src/main/com/mongodb/operation/FindAndReplaceOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/FindAndReplaceOperation.java
@@ -36,11 +36,11 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
 import static com.mongodb.operation.CommandOperationHelper.CommandCreator;
 import static com.mongodb.operation.DocumentHelper.putIfNotNull;
 import static com.mongodb.operation.DocumentHelper.putIfNotZero;
 import static com.mongodb.operation.DocumentHelper.putIfTrue;
-import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
 import static com.mongodb.operation.OperationHelper.validateCollation;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -260,8 +260,6 @@ public class FindAndReplaceOperation<T> extends BaseFindAndModifyOperation<T> {
 
     /**
      * Sets the bypass document level validation flag.
-     *
-     * <p>Note: This only applies when an $out stage is specified</p>.
      *
      * @param bypassDocumentValidation If true, allows the write to opt-out of document level validation.
      * @return this

--- a/driver-core/src/main/com/mongodb/operation/FindAndUpdateOperation.java
+++ b/driver-core/src/main/com/mongodb/operation/FindAndUpdateOperation.java
@@ -38,11 +38,11 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.mongodb.assertions.Assertions.notNull;
+import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
 import static com.mongodb.operation.CommandOperationHelper.CommandCreator;
 import static com.mongodb.operation.DocumentHelper.putIfNotNull;
 import static com.mongodb.operation.DocumentHelper.putIfNotZero;
 import static com.mongodb.operation.DocumentHelper.putIfTrue;
-import static com.mongodb.internal.operation.ServerVersionHelper.serverIsAtLeastVersionThreeDotTwo;
 import static com.mongodb.operation.OperationHelper.validateCollation;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -263,8 +263,6 @@ public class FindAndUpdateOperation<T> extends BaseFindAndModifyOperation<T> {
 
     /**
      * Sets the bypass document level validation flag.
-     *
-     * <p>Note: This only applies when an $out stage is specified</p>.
      *
      * @param bypassDocumentValidation If true, allows the write to opt-out of document level validation.
      * @return this

--- a/driver-core/src/test/functional/com/mongodb/client/model/AggregatesFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/AggregatesFunctionalSpecification.groovy
@@ -206,6 +206,7 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         def outCollectionName = getCollectionName() + '.out'
         getCollectionHelper(new MongoNamespace(getDatabaseName(), outCollectionName))
                 .createUniqueIndex(new Document('x', 1))
+        getCollectionHelper(new MongoNamespace('db1', outCollectionName)).create()
 
         when:
         aggregate([merge(outCollectionName)])

--- a/driver-core/src/test/functional/com/mongodb/client/model/AggregatesFunctionalSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/client/model/AggregatesFunctionalSpecification.groovy
@@ -16,6 +16,7 @@
 
 package com.mongodb.client.model
 
+import com.mongodb.MongoCommandException
 import com.mongodb.MongoNamespace
 import com.mongodb.OperationFunctionalSpecification
 import org.bson.BsonDocument
@@ -45,6 +46,7 @@ import static com.mongodb.client.model.Aggregates.group
 import static com.mongodb.client.model.Aggregates.limit
 import static com.mongodb.client.model.Aggregates.lookup
 import static com.mongodb.client.model.Aggregates.match
+import static com.mongodb.client.model.Aggregates.merge
 import static com.mongodb.client.model.Aggregates.out
 import static com.mongodb.client.model.Aggregates.project
 import static com.mongodb.client.model.Aggregates.replaceRoot
@@ -195,6 +197,91 @@ class AggregatesFunctionalSpecification extends OperationFunctionalSpecification
         aggregate([out(outCollectionName)])
 
         then:
+        getCollectionHelper(new MongoNamespace(getDatabaseName(), outCollectionName)).find() == [a, b, c]
+    }
+
+    @IgnoreIf({ !serverVersionAtLeast(4, 2) })
+    def '$merge'() {
+        given:
+        def outCollectionName = getCollectionName() + '.out'
+        getCollectionHelper(new MongoNamespace(getDatabaseName(), outCollectionName))
+                .createUniqueIndex(new Document('x', 1))
+
+        when:
+        aggregate([merge(outCollectionName)])
+
+        then:
+        getCollectionHelper(new MongoNamespace(getDatabaseName(), outCollectionName)).find() == [a, b, c]
+
+        when:
+        aggregate([merge(new MongoNamespace('db1', outCollectionName))])
+
+        then:
+        getCollectionHelper(new MongoNamespace('db1', outCollectionName)).find() == [a, b, c]
+
+        when:
+        aggregate([merge(outCollectionName, new MergeOptions()
+                .uniqueIdentifier('x')
+                .whenMatched(MergeOptions.WhenMatched.REPLACE)
+                .whenNotMatched(MergeOptions.WhenNotMatched.FAIL))])
+
+        then:
+        getCollectionHelper(new MongoNamespace(getDatabaseName(), outCollectionName)).find() == [a, b, c]
+
+        when:
+        aggregate([merge(outCollectionName, new MergeOptions()
+                .uniqueIdentifier('x')
+                .whenMatched(MergeOptions.WhenMatched.KEEP_EXISTING))])
+
+        then:
+        getCollectionHelper(new MongoNamespace(getDatabaseName(), outCollectionName)).find() == [a, b, c]
+
+        when:
+        aggregate([merge(outCollectionName, new MergeOptions()
+                .uniqueIdentifier('x')
+                .whenMatched(MergeOptions.WhenMatched.MERGE))])
+
+        then:
+        getCollectionHelper(new MongoNamespace(getDatabaseName(), outCollectionName)).find() == [a, b, c]
+
+        when:
+        aggregate([merge(outCollectionName, new MergeOptions()
+                .uniqueIdentifier('x')
+                .whenMatched(MergeOptions.WhenMatched.FAIL))])
+
+        then:
+        thrown(MongoCommandException)
+
+        when:
+        aggregate([merge(outCollectionName, new MergeOptions()
+                .uniqueIdentifier('x')
+                .whenMatched(MergeOptions.WhenMatched.REPLACE)
+                .whenNotMatched(MergeOptions.WhenNotMatched.DISCARD))])
+
+        then:
+        getCollectionHelper(new MongoNamespace(getDatabaseName(), outCollectionName)).find() == [a, b, c]
+
+        when:
+        aggregate([merge(outCollectionName, new MergeOptions()
+                .uniqueIdentifier('x')
+                .whenMatched(MergeOptions.WhenMatched.REPLACE)
+                .whenNotMatched(MergeOptions.WhenNotMatched.INSERT))])
+
+        then:
+        getCollectionHelper(new MongoNamespace(getDatabaseName(), outCollectionName)).find() == [a, b, c]
+
+        when:
+        aggregate([merge(outCollectionName, new MergeOptions()
+                .uniqueIdentifier('x')
+                .whenMatched(MergeOptions.WhenMatched.PIPELINE)
+                .variables([new Variable<Integer>('b', 1)])
+                .whenMatchedPipeline([addFields([new Field<String>('b', '$$b')])])
+                .whenNotMatched(MergeOptions.WhenNotMatched.FAIL))])
+
+        then:
+        a.append('b', 1)
+        b.append('b', 1)
+        c.append('b', 1)
         getCollectionHelper(new MongoNamespace(getDatabaseName(), outCollectionName)).find() == [a, b, c]
     }
 

--- a/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
+++ b/driver-core/src/test/functional/com/mongodb/client/test/CollectionHelper.java
@@ -351,6 +351,11 @@ public final class CollectionHelper<T> {
         new CreateIndexesOperation(namespace, asList(new IndexRequest(wrap(key))), WriteConcern.ACKNOWLEDGED).execute(getBinding());
     }
 
+    public void createUniqueIndex(final Document key) {
+        new CreateIndexesOperation(namespace, asList(new IndexRequest(wrap(key)).unique(true)), WriteConcern.ACKNOWLEDGED)
+                .execute(getBinding());
+    }
+
     public void createIndex(final Document key, final String defaultLanguage) {
         new CreateIndexesOperation(namespace, asList(new IndexRequest(wrap(key)).defaultLanguage(defaultLanguage)),
                                           WriteConcern.ACKNOWLEDGED).execute(getBinding());

--- a/driver-core/src/test/functional/com/mongodb/operation/AggregateToCollectionOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/AggregateToCollectionOperationSpecification.groovy
@@ -107,20 +107,26 @@ class AggregateToCollectionOperationSpecification extends OperationFunctionalSpe
         thrown(IllegalArgumentException)
     }
 
-    def 'should not accept a pipeline without the last stage specifying an output-collection'() {
-        when:
-        new AggregateToCollectionOperation(getNamespace(), [new BsonDocument('$match', new BsonDocument('job', new BsonString('plumber')))])
-
-
-        then:
-        thrown(IllegalArgumentException)
-    }
-
     def 'should be able to output to a collection'() {
         when:
         AggregateToCollectionOperation operation =
                 new AggregateToCollectionOperation(getNamespace(),
                                                    [new BsonDocument('$out', new BsonString(aggregateCollectionNamespace.collectionName))])
+        execute(operation, async);
+
+        then:
+        getCollectionHelper(aggregateCollectionNamespace).count() == 3
+
+        where:
+        async << [true, false]
+    }
+
+    @IgnoreIf({ !serverVersionAtLeast(4, 2) })
+    def 'should be able to merge into a collection'() {
+        when:
+        AggregateToCollectionOperation operation =
+                new AggregateToCollectionOperation(getNamespace(),
+                        [new BsonDocument('$merge', new BsonDocument('into', new BsonString(aggregateCollectionNamespace.collectionName)))])
         execute(operation, async);
 
         then:

--- a/driver-sync/src/main/com/mongodb/client/AggregateIterable.java
+++ b/driver-sync/src/main/com/mongodb/client/AggregateIterable.java
@@ -32,10 +32,11 @@ import java.util.concurrent.TimeUnit;
 public interface AggregateIterable<TResult> extends MongoIterable<TResult> {
 
     /**
-     * Aggregates documents according to the specified aggregation pipeline, which must end with a $out stage.
+     * Aggregates documents according to the specified aggregation pipeline, which must end with a $out or $merge stage.
      *
-     * @throws IllegalStateException if the pipeline does not end with a $out stage
+     * @throws IllegalStateException if the pipeline does not end with a $out or $merge stage
      * @mongodb.driver.manual reference/operator/aggregation/out/ $out stage
+     * @mongodb.driver.manual reference/operator/aggregation/merge/ $merge stage
      * @since 3.4
      */
     void toCollection();
@@ -99,7 +100,7 @@ public interface AggregateIterable<TResult> extends MongoIterable<TResult> {
     /**
      * Sets the bypass document level validation flag.
      *
-     * <p>Note: This only applies when an $out stage is specified</p>.
+     * <p>Note: This only applies when an $out or $merge stage is specified</p>.
      *
      * @param bypassDocumentValidation If true, allows the write to opt-out of document level validation.
      * @return this


### PR DESCRIPTION
* Recognize pipelines that end with $merge and treat them as writes
* Recognize the various flavors of the "into" field so that the correct
  find command can be constructed when attempting to iterate an
  aggregation ending with a $merge stage.

JAVA-3317

Note: This doesn't implement the spec tests yet, since support for CRUD v2 is not yet in the driver but has been done as part of the array updates POC.  Once that is merged we can pull in the spec tests for this.  I think it's sufficiently tested as is with the MongoCollection unit tests and the AggregateToCollectionOperation integration tests