### PR TITLE
Optimize check for empty update document

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/connection/BsonWriterAdapter.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BsonWriterAdapter.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.connection;
+
+import org.bson.BsonBinary;
+import org.bson.BsonDbPointer;
+import org.bson.BsonReader;
+import org.bson.BsonRegularExpression;
+import org.bson.BsonTimestamp;
+import org.bson.BsonWriter;
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
+
+import static org.bson.assertions.Assertions.notNull;
+
+public class BsonWriterAdapter implements BsonWriter {
+    private final BsonWriter bsonBinaryWriter;
+
+    BsonWriterAdapter(final BsonWriter bsonWriter) {
+        this.bsonBinaryWriter = notNull("bsonWriter", bsonWriter);
+    }
+
+    BsonWriter getBsonWriter() {
+        return bsonBinaryWriter;
+    }
+
+    @Override
+    public void writeStartDocument(final String name) {
+        bsonBinaryWriter.writeStartDocument(name);
+    }
+
+    @Override
+    public void writeStartDocument() {
+        bsonBinaryWriter.writeStartDocument();
+    }
+
+    @Override
+    public void writeEndDocument() {
+        bsonBinaryWriter.writeEndDocument();
+    }
+
+    @Override
+    public void writeStartArray(final String name) {
+        bsonBinaryWriter.writeStartArray(name);
+    }
+
+    @Override
+    public void writeStartArray() {
+        bsonBinaryWriter.writeStartArray();
+    }
+
+    @Override
+    public void writeEndArray() {
+        bsonBinaryWriter.writeEndArray();
+    }
+
+    @Override
+    public void writeBinaryData(final String name, final BsonBinary binary) {
+        bsonBinaryWriter.writeBinaryData(name, binary);
+    }
+
+    @Override
+    public void writeBinaryData(final BsonBinary binary) {
+        bsonBinaryWriter.writeBinaryData(binary);
+    }
+
+    @Override
+    public void writeBoolean(final String name, final boolean value) {
+        bsonBinaryWriter.writeBoolean(name, value);
+    }
+
+    @Override
+    public void writeBoolean(final boolean value) {
+        bsonBinaryWriter.writeBoolean(value);
+    }
+
+    @Override
+    public void writeDateTime(final String name, final long value) {
+        bsonBinaryWriter.writeDateTime(name, value);
+    }
+
+    @Override
+    public void writeDateTime(final long value) {
+        bsonBinaryWriter.writeDateTime(value);
+    }
+
+    @Override
+    public void writeDBPointer(final String name, final BsonDbPointer value) {
+        bsonBinaryWriter.writeDBPointer(name, value);
+    }
+
+    @Override
+    public void writeDBPointer(final BsonDbPointer value) {
+        bsonBinaryWriter.writeDBPointer(value);
+    }
+
+    @Override
+    public void writeDouble(final String name, final double value) {
+        bsonBinaryWriter.writeDouble(name, value);
+    }
+
+    @Override
+    public void writeDouble(final double value) {
+        bsonBinaryWriter.writeDouble(value);
+    }
+
+    @Override
+    public void writeInt32(final String name, final int value) {
+        bsonBinaryWriter.writeInt32(name, value);
+    }
+
+    @Override
+    public void writeInt32(final int value) {
+        bsonBinaryWriter.writeInt32(value);
+    }
+
+    @Override
+    public void writeInt64(final String name, final long value) {
+        bsonBinaryWriter.writeInt64(name, value);
+    }
+
+    @Override
+    public void writeInt64(final long value) {
+        bsonBinaryWriter.writeInt64(value);
+    }
+
+    @Override
+    public void writeDecimal128(final Decimal128 value) {
+        bsonBinaryWriter.writeDecimal128(value);
+    }
+
+    @Override
+    public void writeDecimal128(final String name, final Decimal128 value) {
+        bsonBinaryWriter.writeDecimal128(name, value);
+    }
+
+    @Override
+    public void writeJavaScript(final String name, final String code) {
+        bsonBinaryWriter.writeJavaScript(name, code);
+    }
+
+    @Override
+    public void writeJavaScript(final String code) {
+        bsonBinaryWriter.writeJavaScript(code);
+    }
+
+    @Override
+    public void writeJavaScriptWithScope(final String name, final String code) {
+        bsonBinaryWriter.writeJavaScriptWithScope(name, code);
+    }
+
+    @Override
+    public void writeJavaScriptWithScope(final String code) {
+        bsonBinaryWriter.writeJavaScriptWithScope(code);
+    }
+
+    @Override
+    public void writeMaxKey(final String name) {
+        bsonBinaryWriter.writeMaxKey(name);
+    }
+
+    @Override
+    public void writeMaxKey() {
+        bsonBinaryWriter.writeMaxKey();
+    }
+
+    @Override
+    public void writeMinKey(final String name) {
+        bsonBinaryWriter.writeMinKey(name);
+    }
+
+    @Override
+    public void writeMinKey() {
+        bsonBinaryWriter.writeMinKey();
+    }
+
+    @Override
+    public void writeName(final String name) {
+        bsonBinaryWriter.writeName(name);
+    }
+
+    @Override
+    public void writeNull(final String name) {
+        bsonBinaryWriter.writeNull(name);
+    }
+
+    @Override
+    public void writeNull() {
+        bsonBinaryWriter.writeNull();
+    }
+
+    @Override
+    public void writeObjectId(final String name, final ObjectId objectId) {
+        bsonBinaryWriter.writeObjectId(name, objectId);
+    }
+
+    @Override
+    public void writeObjectId(final ObjectId objectId) {
+        bsonBinaryWriter.writeObjectId(objectId);
+    }
+
+    @Override
+    public void writeRegularExpression(final String name, final BsonRegularExpression regularExpression) {
+        bsonBinaryWriter.writeRegularExpression(name, regularExpression);
+    }
+
+    @Override
+    public void writeRegularExpression(final BsonRegularExpression regularExpression) {
+        bsonBinaryWriter.writeRegularExpression(regularExpression);
+    }
+
+    @Override
+    public void writeString(final String name, final String value) {
+        bsonBinaryWriter.writeString(name, value);
+    }
+
+    @Override
+    public void writeString(final String value) {
+        bsonBinaryWriter.writeString(value);
+    }
+
+    @Override
+    public void writeSymbol(final String name, final String value) {
+        bsonBinaryWriter.writeSymbol(name, value);
+    }
+
+    @Override
+    public void writeSymbol(final String value) {
+        bsonBinaryWriter.writeSymbol(value);
+    }
+
+    @Override
+    public void writeTimestamp(final String name, final BsonTimestamp value) {
+        bsonBinaryWriter.writeTimestamp(name, value);
+    }
+
+    @Override
+    public void writeTimestamp(final BsonTimestamp value) {
+        bsonBinaryWriter.writeTimestamp(value);
+    }
+
+    @Override
+    public void writeUndefined(final String name) {
+        bsonBinaryWriter.writeUndefined(name);
+    }
+
+    @Override
+    public void writeUndefined() {
+        bsonBinaryWriter.writeUndefined();
+    }
+
+    @Override
+    public void pipe(final BsonReader reader) {
+        bsonBinaryWriter.pipe(reader);
+    }
+
+    @Override
+    public void flush() {
+        bsonBinaryWriter.flush();
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/connection/BsonWriterDecorator.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/BsonWriterDecorator.java
@@ -27,249 +27,249 @@ import org.bson.types.ObjectId;
 
 import static org.bson.assertions.Assertions.notNull;
 
-public class BsonWriterAdapter implements BsonWriter {
-    private final BsonWriter bsonBinaryWriter;
+public class BsonWriterDecorator implements BsonWriter {
+    private final BsonWriter bsonWriter;
 
-    BsonWriterAdapter(final BsonWriter bsonWriter) {
-        this.bsonBinaryWriter = notNull("bsonWriter", bsonWriter);
+    BsonWriterDecorator(final BsonWriter bsonWriter) {
+        this.bsonWriter = notNull("bsonWriter", bsonWriter);
     }
 
     BsonWriter getBsonWriter() {
-        return bsonBinaryWriter;
+        return bsonWriter;
     }
 
     @Override
     public void writeStartDocument(final String name) {
-        bsonBinaryWriter.writeStartDocument(name);
+        bsonWriter.writeStartDocument(name);
     }
 
     @Override
     public void writeStartDocument() {
-        bsonBinaryWriter.writeStartDocument();
+        bsonWriter.writeStartDocument();
     }
 
     @Override
     public void writeEndDocument() {
-        bsonBinaryWriter.writeEndDocument();
+        bsonWriter.writeEndDocument();
     }
 
     @Override
     public void writeStartArray(final String name) {
-        bsonBinaryWriter.writeStartArray(name);
+        bsonWriter.writeStartArray(name);
     }
 
     @Override
     public void writeStartArray() {
-        bsonBinaryWriter.writeStartArray();
+        bsonWriter.writeStartArray();
     }
 
     @Override
     public void writeEndArray() {
-        bsonBinaryWriter.writeEndArray();
+        bsonWriter.writeEndArray();
     }
 
     @Override
     public void writeBinaryData(final String name, final BsonBinary binary) {
-        bsonBinaryWriter.writeBinaryData(name, binary);
+        bsonWriter.writeBinaryData(name, binary);
     }
 
     @Override
     public void writeBinaryData(final BsonBinary binary) {
-        bsonBinaryWriter.writeBinaryData(binary);
+        bsonWriter.writeBinaryData(binary);
     }
 
     @Override
     public void writeBoolean(final String name, final boolean value) {
-        bsonBinaryWriter.writeBoolean(name, value);
+        bsonWriter.writeBoolean(name, value);
     }
 
     @Override
     public void writeBoolean(final boolean value) {
-        bsonBinaryWriter.writeBoolean(value);
+        bsonWriter.writeBoolean(value);
     }
 
     @Override
     public void writeDateTime(final String name, final long value) {
-        bsonBinaryWriter.writeDateTime(name, value);
+        bsonWriter.writeDateTime(name, value);
     }
 
     @Override
     public void writeDateTime(final long value) {
-        bsonBinaryWriter.writeDateTime(value);
+        bsonWriter.writeDateTime(value);
     }
 
     @Override
     public void writeDBPointer(final String name, final BsonDbPointer value) {
-        bsonBinaryWriter.writeDBPointer(name, value);
+        bsonWriter.writeDBPointer(name, value);
     }
 
     @Override
     public void writeDBPointer(final BsonDbPointer value) {
-        bsonBinaryWriter.writeDBPointer(value);
+        bsonWriter.writeDBPointer(value);
     }
 
     @Override
     public void writeDouble(final String name, final double value) {
-        bsonBinaryWriter.writeDouble(name, value);
+        bsonWriter.writeDouble(name, value);
     }
 
     @Override
     public void writeDouble(final double value) {
-        bsonBinaryWriter.writeDouble(value);
+        bsonWriter.writeDouble(value);
     }
 
     @Override
     public void writeInt32(final String name, final int value) {
-        bsonBinaryWriter.writeInt32(name, value);
+        bsonWriter.writeInt32(name, value);
     }
 
     @Override
     public void writeInt32(final int value) {
-        bsonBinaryWriter.writeInt32(value);
+        bsonWriter.writeInt32(value);
     }
 
     @Override
     public void writeInt64(final String name, final long value) {
-        bsonBinaryWriter.writeInt64(name, value);
+        bsonWriter.writeInt64(name, value);
     }
 
     @Override
     public void writeInt64(final long value) {
-        bsonBinaryWriter.writeInt64(value);
+        bsonWriter.writeInt64(value);
     }
 
     @Override
     public void writeDecimal128(final Decimal128 value) {
-        bsonBinaryWriter.writeDecimal128(value);
+        bsonWriter.writeDecimal128(value);
     }
 
     @Override
     public void writeDecimal128(final String name, final Decimal128 value) {
-        bsonBinaryWriter.writeDecimal128(name, value);
+        bsonWriter.writeDecimal128(name, value);
     }
 
     @Override
     public void writeJavaScript(final String name, final String code) {
-        bsonBinaryWriter.writeJavaScript(name, code);
+        bsonWriter.writeJavaScript(name, code);
     }
 
     @Override
     public void writeJavaScript(final String code) {
-        bsonBinaryWriter.writeJavaScript(code);
+        bsonWriter.writeJavaScript(code);
     }
 
     @Override
     public void writeJavaScriptWithScope(final String name, final String code) {
-        bsonBinaryWriter.writeJavaScriptWithScope(name, code);
+        bsonWriter.writeJavaScriptWithScope(name, code);
     }
 
     @Override
     public void writeJavaScriptWithScope(final String code) {
-        bsonBinaryWriter.writeJavaScriptWithScope(code);
+        bsonWriter.writeJavaScriptWithScope(code);
     }
 
     @Override
     public void writeMaxKey(final String name) {
-        bsonBinaryWriter.writeMaxKey(name);
+        bsonWriter.writeMaxKey(name);
     }
 
     @Override
     public void writeMaxKey() {
-        bsonBinaryWriter.writeMaxKey();
+        bsonWriter.writeMaxKey();
     }
 
     @Override
     public void writeMinKey(final String name) {
-        bsonBinaryWriter.writeMinKey(name);
+        bsonWriter.writeMinKey(name);
     }
 
     @Override
     public void writeMinKey() {
-        bsonBinaryWriter.writeMinKey();
+        bsonWriter.writeMinKey();
     }
 
     @Override
     public void writeName(final String name) {
-        bsonBinaryWriter.writeName(name);
+        bsonWriter.writeName(name);
     }
 
     @Override
     public void writeNull(final String name) {
-        bsonBinaryWriter.writeNull(name);
+        bsonWriter.writeNull(name);
     }
 
     @Override
     public void writeNull() {
-        bsonBinaryWriter.writeNull();
+        bsonWriter.writeNull();
     }
 
     @Override
     public void writeObjectId(final String name, final ObjectId objectId) {
-        bsonBinaryWriter.writeObjectId(name, objectId);
+        bsonWriter.writeObjectId(name, objectId);
     }
 
     @Override
     public void writeObjectId(final ObjectId objectId) {
-        bsonBinaryWriter.writeObjectId(objectId);
+        bsonWriter.writeObjectId(objectId);
     }
 
     @Override
     public void writeRegularExpression(final String name, final BsonRegularExpression regularExpression) {
-        bsonBinaryWriter.writeRegularExpression(name, regularExpression);
+        bsonWriter.writeRegularExpression(name, regularExpression);
     }
 
     @Override
     public void writeRegularExpression(final BsonRegularExpression regularExpression) {
-        bsonBinaryWriter.writeRegularExpression(regularExpression);
+        bsonWriter.writeRegularExpression(regularExpression);
     }
 
     @Override
     public void writeString(final String name, final String value) {
-        bsonBinaryWriter.writeString(name, value);
+        bsonWriter.writeString(name, value);
     }
 
     @Override
     public void writeString(final String value) {
-        bsonBinaryWriter.writeString(value);
+        bsonWriter.writeString(value);
     }
 
     @Override
     public void writeSymbol(final String name, final String value) {
-        bsonBinaryWriter.writeSymbol(name, value);
+        bsonWriter.writeSymbol(name, value);
     }
 
     @Override
     public void writeSymbol(final String value) {
-        bsonBinaryWriter.writeSymbol(value);
+        bsonWriter.writeSymbol(value);
     }
 
     @Override
     public void writeTimestamp(final String name, final BsonTimestamp value) {
-        bsonBinaryWriter.writeTimestamp(name, value);
+        bsonWriter.writeTimestamp(name, value);
     }
 
     @Override
     public void writeTimestamp(final BsonTimestamp value) {
-        bsonBinaryWriter.writeTimestamp(value);
+        bsonWriter.writeTimestamp(value);
     }
 
     @Override
     public void writeUndefined(final String name) {
-        bsonBinaryWriter.writeUndefined(name);
+        bsonWriter.writeUndefined(name);
     }
 
     @Override
     public void writeUndefined() {
-        bsonBinaryWriter.writeUndefined();
+        bsonWriter.writeUndefined();
     }
 
     @Override
     public void pipe(final BsonReader reader) {
-        bsonBinaryWriter.pipe(reader);
+        bsonWriter.pipe(reader);
     }
 
     @Override
     public void flush() {
-        bsonBinaryWriter.flush();
+        bsonWriter.flush();
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/connection/FieldTrackingBsonWriter.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/FieldTrackingBsonWriter.java
@@ -29,7 +29,7 @@ import org.bson.types.ObjectId;
 // It's an imperfect check because we can't tell if the pipe method ended up writing any fields.
 // For the purposes of the check, it's better to assume that pipe does end up writing a field, in order to avoid
 // incorrectly reporting an error any time pipe is used
-public class FieldTrackingBsonWriter extends BsonWriterAdapter {
+public class FieldTrackingBsonWriter extends BsonWriterDecorator {
 
     private boolean hasWrittenField;
     private boolean topLevelDocumentWritten;

--- a/driver-core/src/main/com/mongodb/internal/connection/FieldTrackingBsonWriter.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/FieldTrackingBsonWriter.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.internal.connection;
+
+import org.bson.BsonBinary;
+import org.bson.BsonDbPointer;
+import org.bson.BsonReader;
+import org.bson.BsonRegularExpression;
+import org.bson.BsonTimestamp;
+import org.bson.BsonWriter;
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
+
+// Helper class to help determine when an update document contains any fields
+// It's an imperfect check because we can't tell if the pipe method ended up writing any fields.
+// For the purposes of the check, it's better to assume that pipe does end up writing a field, in order to avoid
+// incorrectly reporting an error any time pipe is used
+public class FieldTrackingBsonWriter extends BsonWriterAdapter {
+
+    private boolean hasWrittenField;
+    private boolean topLevelDocumentWritten;
+
+    public FieldTrackingBsonWriter(final BsonWriter bsonWriter) {
+        super(bsonWriter);
+    }
+
+    public boolean hasWrittenField() {
+        return hasWrittenField;
+    }
+
+    @Override
+    public void writeStartDocument(final String name) {
+        if (topLevelDocumentWritten) {
+            hasWrittenField = true;
+        }
+        super.writeStartDocument(name);
+    }
+
+    @Override
+    public void writeStartDocument() {
+        if (topLevelDocumentWritten) {
+            hasWrittenField = true;
+        }
+        topLevelDocumentWritten = true;
+        super.writeStartDocument();
+    }
+
+    @Override
+    public void writeStartArray(final String name) {
+        hasWrittenField = true;
+        super.writeStartArray(name);
+    }
+
+    @Override
+    public void writeStartArray() {
+        hasWrittenField = true;
+        super.writeStartArray();
+    }
+
+    @Override
+    public void writeBinaryData(final String name, final BsonBinary binary) {
+        hasWrittenField = true;
+        super.writeBinaryData(name, binary);
+    }
+
+    @Override
+    public void writeBinaryData(final BsonBinary binary) {
+        hasWrittenField = true;
+        super.writeBinaryData(binary);
+    }
+
+    @Override
+    public void writeBoolean(final String name, final boolean value) {
+        hasWrittenField = true;
+        super.writeBoolean(name, value);
+    }
+
+    @Override
+    public void writeBoolean(final boolean value) {
+        hasWrittenField = true;
+        super.writeBoolean(value);
+    }
+
+    @Override
+    public void writeDateTime(final String name, final long value) {
+        hasWrittenField = true;
+        super.writeDateTime(name, value);
+    }
+
+    @Override
+    public void writeDateTime(final long value) {
+        hasWrittenField = true;
+        super.writeDateTime(value);
+    }
+
+    @Override
+    public void writeDBPointer(final String name, final BsonDbPointer value) {
+        hasWrittenField = true;
+        super.writeDBPointer(name, value);
+    }
+
+    @Override
+    public void writeDBPointer(final BsonDbPointer value) {
+        hasWrittenField = true;
+        super.writeDBPointer(value);
+    }
+
+    @Override
+    public void writeDouble(final String name, final double value) {
+        hasWrittenField = true;
+        super.writeDouble(name, value);
+    }
+
+    @Override
+    public void writeDouble(final double value) {
+        hasWrittenField = true;
+        super.writeDouble(value);
+    }
+
+    @Override
+    public void writeInt32(final String name, final int value) {
+        hasWrittenField = true;
+        super.writeInt32(name, value);
+    }
+
+    @Override
+    public void writeInt32(final int value) {
+        hasWrittenField = true;
+        super.writeInt32(value);
+    }
+
+    @Override
+    public void writeInt64(final String name, final long value) {
+        super.writeInt64(name, value);
+        hasWrittenField = true;
+    }
+
+    @Override
+    public void writeInt64(final long value) {
+        hasWrittenField = true;
+        super.writeInt64(value);
+    }
+
+    @Override
+    public void writeDecimal128(final Decimal128 value) {
+        hasWrittenField = true;
+        super.writeDecimal128(value);
+    }
+
+    @Override
+    public void writeDecimal128(final String name, final Decimal128 value) {
+        hasWrittenField = true;
+        super.writeDecimal128(name, value);
+    }
+
+    @Override
+    public void writeJavaScript(final String name, final String code) {
+        hasWrittenField = true;
+        super.writeJavaScript(name, code);
+    }
+
+    @Override
+    public void writeJavaScript(final String code) {
+        hasWrittenField = true;
+        super.writeJavaScript(code);
+    }
+
+    @Override
+    public void writeJavaScriptWithScope(final String name, final String code) {
+        super.writeJavaScriptWithScope(name, code);
+        hasWrittenField = true;
+    }
+
+    @Override
+    public void writeJavaScriptWithScope(final String code) {
+        hasWrittenField = true;
+        super.writeJavaScriptWithScope(code);
+    }
+
+    @Override
+    public void writeMaxKey(final String name) {
+        hasWrittenField = true;
+        super.writeMaxKey(name);
+    }
+
+    @Override
+    public void writeMaxKey() {
+        hasWrittenField = true;
+        super.writeMaxKey();
+    }
+
+    @Override
+    public void writeMinKey(final String name) {
+        hasWrittenField = true;
+        super.writeMinKey(name);
+    }
+
+    @Override
+    public void writeMinKey() {
+        hasWrittenField = true;
+        super.writeMinKey();
+    }
+
+    @Override
+    public void writeNull(final String name) {
+        hasWrittenField = true;
+        super.writeNull(name);
+    }
+
+    @Override
+    public void writeNull() {
+        hasWrittenField = true;
+        super.writeNull();
+    }
+
+    @Override
+    public void writeObjectId(final String name, final ObjectId objectId) {
+        hasWrittenField = true;
+        super.writeObjectId(name, objectId);
+    }
+
+    @Override
+    public void writeObjectId(final ObjectId objectId) {
+        hasWrittenField = true;
+        super.writeObjectId(objectId);
+    }
+
+    @Override
+    public void writeRegularExpression(final String name, final BsonRegularExpression regularExpression) {
+        hasWrittenField = true;
+        super.writeRegularExpression(name, regularExpression);
+    }
+
+    @Override
+    public void writeRegularExpression(final BsonRegularExpression regularExpression) {
+        hasWrittenField = true;
+        super.writeRegularExpression(regularExpression);
+    }
+
+    @Override
+    public void writeString(final String name, final String value) {
+        hasWrittenField = true;
+        super.writeString(name, value);
+    }
+
+    @Override
+    public void writeString(final String value) {
+        hasWrittenField = true;
+        super.writeString(value);
+    }
+
+    @Override
+    public void writeSymbol(final String name, final String value) {
+        hasWrittenField = true;
+        super.writeSymbol(name, value);
+    }
+
+    @Override
+    public void writeSymbol(final String value) {
+        hasWrittenField = true;
+        super.writeSymbol(value);
+    }
+
+    @Override
+    public void writeTimestamp(final String name, final BsonTimestamp value) {
+        hasWrittenField = true;
+        super.writeTimestamp(name, value);
+    }
+
+    @Override
+    public void writeTimestamp(final BsonTimestamp value) {
+        hasWrittenField = true;
+        super.writeTimestamp(value);
+    }
+
+    @Override
+    public void writeUndefined(final String name) {
+        hasWrittenField = true;
+        super.writeUndefined(name);
+    }
+
+    @Override
+    public void writeUndefined() {
+        hasWrittenField = true;
+        super.writeUndefined();
+    }
+
+    @Override
+    public void pipe(final BsonReader reader) {
+        // this is a faulty assumption, as we may end up piping an empty document.  But if we don't increment here, we may undercount,
+        // which in this context is worse since we'll thrown an exception when we should not.
+        hasWrittenField = true;
+        super.pipe(reader);
+    }
+}

--- a/driver-core/src/main/com/mongodb/internal/connection/LevelCountingBsonWriter.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/LevelCountingBsonWriter.java
@@ -17,10 +17,9 @@
 package com.mongodb.internal.connection;
 
 import org.bson.BsonBinaryWriter;
-import org.bson.BsonWriter;
 
 
-abstract class LevelCountingBsonWriter extends BsonWriterAdapter implements BsonWriter {
+abstract class LevelCountingBsonWriter extends BsonWriterDecorator {
     private int level = -1;
 
     LevelCountingBsonWriter(final BsonBinaryWriter bsonBinaryWriter) {

--- a/driver-core/src/main/com/mongodb/internal/connection/LevelCountingBsonWriter.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/LevelCountingBsonWriter.java
@@ -16,270 +16,40 @@
 
 package com.mongodb.internal.connection;
 
-import org.bson.BsonBinary;
 import org.bson.BsonBinaryWriter;
-import org.bson.BsonDbPointer;
-import org.bson.BsonReader;
-import org.bson.BsonRegularExpression;
-import org.bson.BsonTimestamp;
 import org.bson.BsonWriter;
-import org.bson.types.Decimal128;
-import org.bson.types.ObjectId;
-
-import static org.bson.assertions.Assertions.notNull;
 
 
-abstract class LevelCountingBsonWriter implements BsonWriter {
-    private final BsonBinaryWriter bsonBinaryWriter;
+abstract class LevelCountingBsonWriter extends BsonWriterAdapter implements BsonWriter {
     private int level = -1;
 
     LevelCountingBsonWriter(final BsonBinaryWriter bsonBinaryWriter) {
-        this.bsonBinaryWriter = notNull("bsonBinaryWriter", bsonBinaryWriter);
+        super(bsonBinaryWriter);
     }
 
-    public int getCurrentLevel() {
+    BsonBinaryWriter getBsonBinaryWriter() {
+        return (BsonBinaryWriter) super.getBsonWriter();
+    }
+
+    int getCurrentLevel() {
         return level;
-    }
-
-    public BsonBinaryWriter getBsonBinaryWriter() {
-        return bsonBinaryWriter;
     }
 
     @Override
     public void writeStartDocument(final String name) {
         level++;
-        bsonBinaryWriter.writeStartDocument(name);
+        super.writeStartDocument(name);
     }
 
     @Override
     public void writeStartDocument() {
         level++;
-        bsonBinaryWriter.writeStartDocument();
+        super.writeStartDocument();
     }
 
     @Override
     public void writeEndDocument() {
         level--;
-        bsonBinaryWriter.writeEndDocument();
-    }
-
-    @Override
-    public void writeStartArray(final String name) {
-        bsonBinaryWriter.writeStartArray(name);
-    }
-
-    @Override
-    public void writeStartArray() {
-        bsonBinaryWriter.writeStartArray();
-    }
-
-    @Override
-    public void writeEndArray() {
-        bsonBinaryWriter.writeEndArray();
-    }
-
-    @Override
-    public void writeBinaryData(final String name, final BsonBinary binary) {
-        bsonBinaryWriter.writeBinaryData(name, binary);
-    }
-
-    @Override
-    public void writeBinaryData(final BsonBinary binary) {
-        bsonBinaryWriter.writeBinaryData(binary);
-    }
-
-    @Override
-    public void writeBoolean(final String name, final boolean value) {
-        bsonBinaryWriter.writeBoolean(name, value);
-    }
-
-    @Override
-    public void writeBoolean(final boolean value) {
-        bsonBinaryWriter.writeBoolean(value);
-    }
-
-    @Override
-    public void writeDateTime(final String name, final long value) {
-        bsonBinaryWriter.writeDateTime(name, value);
-    }
-
-    @Override
-    public void writeDateTime(final long value) {
-        bsonBinaryWriter.writeDateTime(value);
-    }
-
-    @Override
-    public void writeDBPointer(final String name, final BsonDbPointer value) {
-        bsonBinaryWriter.writeDBPointer(name, value);
-    }
-
-    @Override
-    public void writeDBPointer(final BsonDbPointer value) {
-        bsonBinaryWriter.writeDBPointer(value);
-    }
-
-    @Override
-    public void writeDouble(final String name, final double value) {
-        bsonBinaryWriter.writeDouble(name, value);
-    }
-
-    @Override
-    public void writeDouble(final double value) {
-        bsonBinaryWriter.writeDouble(value);
-    }
-
-    @Override
-    public void writeInt32(final String name, final int value) {
-        bsonBinaryWriter.writeInt32(name, value);
-    }
-
-    @Override
-    public void writeInt32(final int value) {
-        bsonBinaryWriter.writeInt32(value);
-    }
-
-    @Override
-    public void writeInt64(final String name, final long value) {
-        bsonBinaryWriter.writeInt64(name, value);
-    }
-
-    @Override
-    public void writeInt64(final long value) {
-        bsonBinaryWriter.writeInt64(value);
-    }
-
-    @Override
-    public void writeDecimal128(final Decimal128 value) {
-        bsonBinaryWriter.writeDecimal128(value);
-    }
-
-    @Override
-    public void writeDecimal128(final String name, final Decimal128 value) {
-        bsonBinaryWriter.writeDecimal128(name, value);
-    }
-
-    @Override
-    public void writeJavaScript(final String name, final String code) {
-        bsonBinaryWriter.writeJavaScript(name, code);
-    }
-
-    @Override
-    public void writeJavaScript(final String code) {
-        bsonBinaryWriter.writeJavaScript(code);
-    }
-
-    @Override
-    public void writeJavaScriptWithScope(final String name, final String code) {
-        bsonBinaryWriter.writeJavaScriptWithScope(name, code);
-    }
-
-    @Override
-    public void writeJavaScriptWithScope(final String code) {
-        bsonBinaryWriter.writeJavaScriptWithScope(code);
-    }
-
-    @Override
-    public void writeMaxKey(final String name) {
-        bsonBinaryWriter.writeMaxKey(name);
-    }
-
-    @Override
-    public void writeMaxKey() {
-        bsonBinaryWriter.writeMaxKey();
-    }
-
-    @Override
-    public void writeMinKey(final String name) {
-        bsonBinaryWriter.writeMinKey(name);
-    }
-
-    @Override
-    public void writeMinKey() {
-        bsonBinaryWriter.writeMinKey();
-    }
-
-    @Override
-    public void writeName(final String name) {
-        bsonBinaryWriter.writeName(name);
-    }
-
-    @Override
-    public void writeNull(final String name) {
-        bsonBinaryWriter.writeNull(name);
-    }
-
-    @Override
-    public void writeNull() {
-        bsonBinaryWriter.writeNull();
-    }
-
-    @Override
-    public void writeObjectId(final String name, final ObjectId objectId) {
-        bsonBinaryWriter.writeObjectId(name, objectId);
-    }
-
-    @Override
-    public void writeObjectId(final ObjectId objectId) {
-        bsonBinaryWriter.writeObjectId(objectId);
-    }
-
-    @Override
-    public void writeRegularExpression(final String name, final BsonRegularExpression regularExpression) {
-        bsonBinaryWriter.writeRegularExpression(name, regularExpression);
-    }
-
-    @Override
-    public void writeRegularExpression(final BsonRegularExpression regularExpression) {
-        bsonBinaryWriter.writeRegularExpression(regularExpression);
-    }
-
-    @Override
-    public void writeString(final String name, final String value) {
-        bsonBinaryWriter.writeString(name, value);
-    }
-
-    @Override
-    public void writeString(final String value) {
-        bsonBinaryWriter.writeString(value);
-    }
-
-    @Override
-    public void writeSymbol(final String name, final String value) {
-        bsonBinaryWriter.writeSymbol(name, value);
-    }
-
-    @Override
-    public void writeSymbol(final String value) {
-        bsonBinaryWriter.writeSymbol(value);
-    }
-
-    @Override
-    public void writeTimestamp(final String name, final BsonTimestamp value) {
-        bsonBinaryWriter.writeTimestamp(name, value);
-    }
-
-    @Override
-    public void writeTimestamp(final BsonTimestamp value) {
-        bsonBinaryWriter.writeTimestamp(value);
-    }
-
-    @Override
-    public void writeUndefined(final String name) {
-        bsonBinaryWriter.writeUndefined(name);
-    }
-
-    @Override
-    public void writeUndefined() {
-        bsonBinaryWriter.writeUndefined();
-    }
-
-    @Override
-    public void pipe(final BsonReader reader) {
-        bsonBinaryWriter.pipe(reader);
-    }
-
-    @Override
-    public void flush() {
-        bsonBinaryWriter.flush();
+        super.writeEndDocument();
     }
 }

--- a/driver-core/src/test/functional/com/mongodb/operation/MixedBulkWriteOperationSpecification.groovy
+++ b/driver-core/src/test/functional/com/mongodb/operation/MixedBulkWriteOperationSpecification.groovy
@@ -303,6 +303,23 @@ class MixedBulkWriteOperationSpecification extends OperationFunctionalSpecificat
         [async, ordered] << [[true, false], [true, false]].combinations()
     }
 
+    def 'when replacing with an empty document, update should not throw IllegalArgumentException'() {
+        given:
+        def id = new ObjectId()
+        def operation = new MixedBulkWriteOperation(getNamespace(),
+                [new UpdateRequest(new BsonDocument('_id', new BsonObjectId(id)), new BsonDocument(), REPLACE)],
+                true, ACKNOWLEDGED, false)
+
+        when:
+        execute(operation, async)
+
+        then:
+        noExceptionThrown()
+
+        where:
+        [async, ordered] << [[true, false], [true, false]].combinations()
+    }
+
     def 'when updating with an invalid document, update should throw IllegalArgumentException'() {
         given:
         def id = new ObjectId()


### PR DESCRIPTION
The CRUD specification requires that an update contains at least one
field, in order to check for application bugs.  Because once the command
makes it to the server it can't be distinguished from a replace (where
an empty document is legal).

The current method of checking for an empty document is to call
BsonDocument#isEmpty.  But that has the unfortunate affect of hydrating
a BsonDocumentWrapper into a full BsonDocument.  We really want to avoid
that hit.  To do so, we need another way of checking for an empty
document.  We use the technique of wrapping the BsonWriter with a
FieldTracking BsonWriter, which tracks whether at least one field
is written.  BulkWriteBatch then checks that and throws if it's not.

This also fixes a bug in which that check was done for both update and
replace requests.  An empty replace document, while rare, is legal.

JAVA-3328