### PR TITLE
Remove premature optimization

### DIFF
--- a/driver-sync/src/main/com/mongodb/client/internal/Crypt.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Crypt.java
@@ -298,12 +298,11 @@ class Crypt implements Closeable {
     private void decryptKey(final MongoKeyDecryptor keyDecryptor) {
         InputStream inputStream = keyManagementService.stream(keyDecryptor.getHostName(), keyDecryptor.getMessage());
         try {
-            byte[] bytes = new byte[4096];
-
             int bytesNeeded = keyDecryptor.bytesNeeded();
 
             while (bytesNeeded > 0) {
-                int bytesRead = inputStream.read(bytes, 0, bytesNeeded);
+                byte[] bytes = new byte[bytesNeeded];
+                int bytesRead = inputStream.read(bytes, 0, bytes.length);
                 keyDecryptor.feed(ByteBuffer.wrap(bytes, 0, bytesRead));
                 bytesNeeded = keyDecryptor.bytesNeeded();
             }


### PR DESCRIPTION
Remove code that avoids extra allocations but that could lead to an
exception if bytesNeeded > hard-coded array length

JAVA-3071