### PR TITLE
Simplify mongocryptd process-starting logic

### DIFF
--- a/driver-async/src/main/com/mongodb/async/client/internal/CommandMarker.java
+++ b/driver-async/src/main/com/mongodb/async/client/internal/CommandMarker.java
@@ -30,7 +30,6 @@ import com.mongodb.connection.ClusterSettings;
 import org.bson.RawBsonDocument;
 
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -85,20 +84,16 @@ class CommandMarker implements Closeable {
                 if (t == null) {
                     wrappedCallback.onResult(result, null);
                 } else if (t instanceof MongoTimeoutException && processBuilder != null) {
-                    try {
-                        startProcessAndContinue(new SingleResultCallback<Void>() {
-                            @Override
-                            public void onResult(final Void result, final Throwable t) {
-                                if (t != null) {
-                                    callback.onResult(null, t);
-                                } else {
-                                    runCommand(databaseName, command, wrappedCallback);
-                                }
+                    startProcessAndContinue(new SingleResultCallback<Void>() {
+                        @Override
+                        public void onResult(final Void result, final Throwable t) {
+                            if (t != null) {
+                                callback.onResult(null, t);
+                            } else {
+                                runCommand(databaseName, command, wrappedCallback);
                             }
-                        });
-                    } catch (Throwable t1) {
-                        wrappedCallback.onResult(null, t);
-                    }
+                        }
+                    });
                 } else {
                     wrappedCallback.onResult(null, t);
                 }
@@ -131,8 +126,8 @@ class CommandMarker implements Closeable {
     private void startProcess() {
         try {
             processBuilder.start();
-        } catch (IOException e) {
-            throw new MongoClientException("Exception starting mongocryptd process. Is `mongocryptd` on the system path?", e);
+        } catch (Throwable t) {
+            throw new MongoClientException("Exception starting mongocryptd process. Is `mongocryptd` on the system path?", t);
         }
     }
 }

--- a/driver-async/src/main/com/mongodb/async/client/internal/CommandMarker.java
+++ b/driver-async/src/main/com/mongodb/async/client/internal/CommandMarker.java
@@ -30,6 +30,7 @@ import com.mongodb.connection.ClusterSettings;
 import org.bson.RawBsonDocument;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -39,7 +40,6 @@ import static com.mongodb.internal.capi.MongoCryptOptionsHelper.createMongocrypt
 class CommandMarker implements Closeable {
     private MongoClient client;
     private final ProcessBuilder processBuilder;
-    private boolean active;
 
     CommandMarker(final Map<String, Object> options) {
         String connectionString;
@@ -48,6 +48,13 @@ class CommandMarker implements Closeable {
             connectionString = (String) options.get("mongocryptdURI");
         } else {
             connectionString = "mongodb://localhost:27020";
+        }
+
+        if (!options.containsKey("mongocryptdBypassSpawn") || !((Boolean) options.get("mongocryptdBypassSpawn"))) {
+            processBuilder = new ProcessBuilder(createMongocryptdSpawnArgs(options));
+            startProcess();
+        } else {
+            processBuilder = null;
         }
 
         client = MongoClients.create(MongoClientSettings.builder()
@@ -59,13 +66,6 @@ class CommandMarker implements Closeable {
                     }
                 })
                 .build());
-        active = false;
-
-        if (!options.containsKey("mongocryptdBypassSpawn") || !((Boolean) options.get("mongocryptdBypassSpawn"))) {
-            processBuilder = new ProcessBuilder(createMongocryptdSpawnArgs(options));
-        } else {
-            processBuilder = null;
-        }
     }
 
     void mark(final String databaseName, final RawBsonDocument command, final SingleResultCallback<RawBsonDocument> callback) {
@@ -79,13 +79,18 @@ class CommandMarker implements Closeable {
                 }
             }
         };
-        executeCommand(databaseName, command, new SingleResultCallback<RawBsonDocument>() {
+        runCommand(databaseName, command, new SingleResultCallback<RawBsonDocument>() {
             @Override
             public void onResult(final RawBsonDocument result, final Throwable t) {
                 if (t == null) {
                     wrappedCallback.onResult(result, null);
                 } else if (t instanceof MongoTimeoutException && processBuilder != null) {
-                    executeCommand(databaseName, command, wrappedCallback);
+                    try {
+                        startProcess();
+                        runCommand(databaseName, command, wrappedCallback);
+                    } catch (Throwable t1) {
+                        wrappedCallback.onResult(null, t);
+                    }
                 } else {
                     wrappedCallback.onResult(null, t);
                 }
@@ -98,38 +103,19 @@ class CommandMarker implements Closeable {
         client.close();
     }
 
-    private void executeCommand(final String databaseName, final RawBsonDocument markableCommand,
-                                final SingleResultCallback<RawBsonDocument> callback) {
-        spawnIfNecessary(new SingleResultCallback<Void>(){
-            @Override
-            public void onResult(final Void result, final Throwable t) {
-                if (t != null) {
-                    callback.onResult(null, t);
-                } else {
-                    client.getDatabase(databaseName)
-                            .withReadConcern(ReadConcern.DEFAULT)
-                            .withReadPreference(ReadPreference.primary())
-                            .runCommand(markableCommand, RawBsonDocument.class, callback);
-                }
-            }
-        });
+    private void runCommand(final String databaseName, final RawBsonDocument command,
+                            final SingleResultCallback<RawBsonDocument> callback) {
+        client.getDatabase(databaseName)
+                .withReadConcern(ReadConcern.DEFAULT)
+                .withReadPreference(ReadPreference.primary())
+                .runCommand(command, RawBsonDocument.class, callback);
     }
 
-    private synchronized void spawnIfNecessary(final SingleResultCallback<Void> callback) {
+    private void startProcess() {
         try {
-            if (processBuilder != null) {
-                synchronized (this) {
-                    if (!active) {
-                        processBuilder.start();
-                        active = true;
-                    }
-                }
-            }
-            callback.onResult(null, null);
-        } catch (Throwable t) {
-            callback.onResult(null,
-                    new MongoClientException("Exception starting mongocryptd process. Is `mongocryptd` on the system path?", t));
+            processBuilder.start();
+        } catch (IOException e) {
+            throw new MongoClientException("Exception starting mongocryptd process. Is `mongocryptd` on the system path?", e);
         }
     }
-
 }


### PR DESCRIPTION
* Attempt to start mongocryptd on MongoClient construction
* Attempt to re-start mongocryptd on a MongoTimeoutException

This fixes a bug where mongocryptd was not being restarted on
MongoTimeoutException.

JAVA-3071
