### PR TITLE
Remove org.mongodb.test.mongocryptdSpawnPath support from tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,7 +137,6 @@ configure(javaCodeCheckedProjects) {
                 'org.mongodb.async.type': System.getProperty('org.mongodb.async.type', 'nio2'),
                 'org.mongodb.test.awsAccessKeyId': System.getProperty('org.mongodb.test.awsAccessKeyId'),
                 'org.mongodb.test.awsSecretAccessKey': System.getProperty('org.mongodb.test.awsSecretAccessKey'),
-                'org.mongodb.test.mongocryptdSpawnPath': System.getProperty('org.mongodb.test.mongocryptdSpawnPath'),
                 'jna.library.path': System.getProperty('jna.library.path')
         )
 

--- a/driver-async/src/test/functional/com/mongodb/async/client/ClientSideEncryptionTest.java
+++ b/driver-async/src/test/functional/com/mongodb/async/client/ClientSideEncryptionTest.java
@@ -206,10 +206,6 @@ public class ClientSideEncryptionTest {
             }
         }
 
-        if (System.getProperty("org.mongodb.test.mongocryptdSpawnPath") != null) {
-            extraOptions.put("mongocryptdSpawnPath", System.getProperty("org.mongodb.test.mongocryptdSpawnPath"));
-        }
-
         Map<String, Map<String, Object>> kmsProvidersMap = new HashMap<String, Map<String, Object>>();
 
         for (String kmsProviderKey : kmsProviders.keySet()) {

--- a/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideEncryptionTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/AbstractClientSideEncryptionTest.java
@@ -194,10 +194,6 @@ public abstract class AbstractClientSideEncryptionTest {
             }
         }
 
-        if (System.getProperty("org.mongodb.test.mongocryptdSpawnPath") != null) {
-            extraOptions.put("mongocryptdSpawnPath", System.getProperty("org.mongodb.test.mongocryptdSpawnPath"));
-        }
-
         Map<String, Map<String, Object>> kmsProvidersMap = new HashMap<String, Map<String, Object>>();
 
         for (String kmsProviderKey : kmsProviders.keySet()) {


### PR DESCRIPTION
The system property was getting through Gradle into the tests as the empty string rather than null.  But since we don't use this property on Evergreen anyway, and I've never actually used it locally (it's always just on my path due to use of `m`, I decided to just remove it until such time as it's necessary.

https://evergreen.mongodb.com/version/5d4aebe49ccd4e5c061160f8

JAVA-3071