### PR TITLE
Re-enable deprecation warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ configure(javaMainProjects) {
         options.encoding = 'ISO-8859-1'
         options.fork = true
         options.debug = true
-        options.compilerArgs = ['-Xlint:all', '-Xlint:-options', '-Xlint:-deprecation']
+        options.compilerArgs = ['-Xlint:all']
     }
 }
 

--- a/driver-core/src/main/com/mongodb/internal/connection/AbstractMultiServerCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/AbstractMultiServerCluster.java
@@ -29,7 +29,7 @@ import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
 import com.mongodb.event.ClusterDescriptionChangedEvent;
 import com.mongodb.event.ServerDescriptionChangedEvent;
-import com.mongodb.event.ServerListenerAdapter;
+import com.mongodb.event.ServerListener;
 import org.bson.BsonDocument;
 import org.bson.types.ObjectId;
 
@@ -137,7 +137,7 @@ public abstract class AbstractMultiServerCluster extends BaseCluster {
     }
 
 
-    private final class DefaultServerStateListener extends ServerListenerAdapter {
+    private final class DefaultServerStateListener implements ServerListener {
         @Override
         public void serverDescriptionChanged(final ServerDescriptionChangedEvent event) {
             onChange(event);

--- a/driver-core/src/main/com/mongodb/internal/connection/SingleServerCluster.java
+++ b/driver-core/src/main/com/mongodb/internal/connection/SingleServerCluster.java
@@ -27,7 +27,7 @@ import com.mongodb.diagnostics.logging.Logger;
 import com.mongodb.diagnostics.logging.Loggers;
 import com.mongodb.event.ClusterDescriptionChangedEvent;
 import com.mongodb.event.ServerDescriptionChangedEvent;
-import com.mongodb.event.ServerListenerAdapter;
+import com.mongodb.event.ServerListener;
 
 import java.util.Collections;
 
@@ -79,7 +79,7 @@ public final class SingleServerCluster extends BaseCluster {
         }
     }
 
-    private class DefaultServerStateListener extends ServerListenerAdapter {
+    private class DefaultServerStateListener implements ServerListener {
         @Override
         public void serverDescriptionChanged(final ServerDescriptionChangedEvent event) {
             ServerDescription descriptionToPublish = event.getNewDescription();

--- a/driver-core/src/main/com/mongodb/internal/event/EventListenerHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/event/EventListenerHelper.java
@@ -20,14 +20,10 @@ import com.mongodb.connection.ClusterSettings;
 import com.mongodb.connection.ConnectionPoolSettings;
 import com.mongodb.connection.ServerSettings;
 import com.mongodb.event.ClusterListener;
-import com.mongodb.event.ClusterListenerAdapter;
 import com.mongodb.event.CommandListener;
 import com.mongodb.event.ConnectionPoolListener;
-import com.mongodb.event.ConnectionPoolListenerAdapter;
 import com.mongodb.event.ServerListener;
-import com.mongodb.event.ServerListenerAdapter;
 import com.mongodb.event.ServerMonitorListener;
-import com.mongodb.event.ServerMonitorListenerAdapter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -95,16 +91,16 @@ public final class EventListenerHelper {
         }
     }
 
-    public static final ServerListener NO_OP_SERVER_LISTENER = new ServerListenerAdapter() {
+    public static final ServerListener NO_OP_SERVER_LISTENER = new ServerListener() {
     };
 
-    public static final ServerMonitorListener NO_OP_SERVER_MONITOR_LISTENER = new ServerMonitorListenerAdapter() {
+    private static final ServerMonitorListener NO_OP_SERVER_MONITOR_LISTENER = new ServerMonitorListener() {
     };
 
-    public static final ClusterListener NO_OP_CLUSTER_LISTENER = new ClusterListenerAdapter() {
+    public static final ClusterListener NO_OP_CLUSTER_LISTENER = new ClusterListener() {
     };
 
-    public static final ConnectionPoolListener NO_OP_CONNECTION_POOL_LISTENER = new ConnectionPoolListenerAdapter() {
+    private static final ConnectionPoolListener NO_OP_CONNECTION_POOL_LISTENER = new ConnectionPoolListener() {
     };
 
     private EventListenerHelper() {

--- a/driver-core/src/main/com/mongodb/management/ConnectionPoolStatistics.java
+++ b/driver-core/src/main/com/mongodb/management/ConnectionPoolStatistics.java
@@ -21,7 +21,7 @@ import com.mongodb.connection.ConnectionPoolSettings;
 import com.mongodb.event.ConnectionAddedEvent;
 import com.mongodb.event.ConnectionCheckedInEvent;
 import com.mongodb.event.ConnectionCheckedOutEvent;
-import com.mongodb.event.ConnectionPoolListenerAdapter;
+import com.mongodb.event.ConnectionPoolListener;
 import com.mongodb.event.ConnectionPoolOpenedEvent;
 import com.mongodb.event.ConnectionPoolWaitQueueEnteredEvent;
 import com.mongodb.event.ConnectionPoolWaitQueueExitedEvent;
@@ -32,7 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * An MBean implementation for connection pool statistics.
  */
-final class ConnectionPoolStatistics extends ConnectionPoolListenerAdapter implements ConnectionPoolStatisticsMBean {
+final class ConnectionPoolStatistics implements ConnectionPoolListener, ConnectionPoolStatisticsMBean {
     private final ServerAddress serverAddress;
     private final ConnectionPoolSettings settings;
     private final AtomicInteger size = new AtomicInteger();

--- a/driver-core/src/test/functional/com/mongodb/internal/connection/QueueEventsConnectionPoolListener.java
+++ b/driver-core/src/test/functional/com/mongodb/internal/connection/QueueEventsConnectionPoolListener.java
@@ -16,13 +16,13 @@
 
 package com.mongodb.internal.connection;
 
-import com.mongodb.event.ConnectionPoolListenerAdapter;
+import com.mongodb.event.ConnectionPoolListener;
 import com.mongodb.event.ConnectionPoolWaitQueueEnteredEvent;
 import com.mongodb.event.ConnectionPoolWaitQueueExitedEvent;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-class QueueEventsConnectionPoolListener extends ConnectionPoolListenerAdapter {
+class QueueEventsConnectionPoolListener implements ConnectionPoolListener {
     private final AtomicInteger waitQueueSize = new AtomicInteger();
 
     @Override
@@ -35,7 +35,7 @@ class QueueEventsConnectionPoolListener extends ConnectionPoolListenerAdapter {
         waitQueueSize.decrementAndGet();
     }
 
-    public int getWaitQueueSize() {
+    int getWaitQueueSize() {
         return waitQueueSize.get();
     }
 }


### PR DESCRIPTION
* Replace use of deprecated event listener adapters (these were the only remaining usages of deprecated API elements that aren't already being suppressed)
* Remove -Xlint:-deprecation from build

https://jira.mongodb.org/browse/JAVA-3039
https://jira.mongodb.org/browse/JAVA-3129