### PR TITLE
JAVA-3395: Fix MongoCollection API mismatch between sync and reactive streams

### DIFF
--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoCollection.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoCollection.java
@@ -450,7 +450,7 @@ public interface MongoCollection<TDocument> {
      * @return a publisher containing the result of the aggregation operation
      * @mongodb.driver.manual aggregation/ Aggregation
      */
-    AggregatePublisher<Document> aggregate(List<? extends Bson> pipeline);
+    AggregatePublisher<TDocument> aggregate(List<? extends Bson> pipeline);
 
     /**
      * Aggregates documents according to the specified aggregation pipeline.
@@ -473,7 +473,7 @@ public interface MongoCollection<TDocument> {
      * @mongodb.server.release 3.6
      * @since 1.7
      */
-    AggregatePublisher<Document> aggregate(ClientSession clientSession, List<? extends Bson> pipeline);
+    AggregatePublisher<TDocument> aggregate(ClientSession clientSession, List<? extends Bson> pipeline);
 
     /**
      * Aggregates documents according to the specified aggregation pipeline.
@@ -591,7 +591,7 @@ public interface MongoCollection<TDocument> {
      * @return an publisher containing the result of the map-reduce operation
      * @mongodb.driver.manual reference/command/mapReduce/ map-reduce
      */
-    MapReducePublisher<Document> mapReduce(String mapFunction, String reduceFunction);
+    MapReducePublisher<TDocument> mapReduce(String mapFunction, String reduceFunction);
 
     /**
      * Aggregates documents according to the specified map-reduce function.
@@ -616,7 +616,7 @@ public interface MongoCollection<TDocument> {
      * @mongodb.server.release 3.6
      * @since 1.7
      */
-    MapReducePublisher<Document> mapReduce(ClientSession clientSession, String mapFunction, String reduceFunction);
+    MapReducePublisher<TDocument> mapReduce(ClientSession clientSession, String mapFunction, String reduceFunction);
 
     /**
      * Aggregates documents according to the specified map-reduce function.

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoCollectionImpl.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/internal/MongoCollectionImpl.java
@@ -249,8 +249,8 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
     }
 
     @Override
-    public AggregatePublisher<Document> aggregate(final List<? extends Bson> pipeline) {
-        return aggregate(pipeline, Document.class);
+    public AggregatePublisher<TDocument> aggregate(final List<? extends Bson> pipeline) {
+        return aggregate(pipeline, getDocumentClass());
     }
 
     @Override
@@ -259,8 +259,8 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
     }
 
     @Override
-    public AggregatePublisher<Document> aggregate(final ClientSession clientSession, final List<? extends Bson> pipeline) {
-        return aggregate(clientSession, pipeline, Document.class);
+    public AggregatePublisher<TDocument> aggregate(final ClientSession clientSession, final List<? extends Bson> pipeline) {
+        return aggregate(clientSession, pipeline, getDocumentClass());
     }
 
     @Override
@@ -311,8 +311,8 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
     }
 
     @Override
-    public MapReducePublisher<Document> mapReduce(final String mapFunction, final String reduceFunction) {
-        return mapReduce(mapFunction, reduceFunction, Document.class);
+    public MapReducePublisher<TDocument> mapReduce(final String mapFunction, final String reduceFunction) {
+        return mapReduce(mapFunction, reduceFunction, getDocumentClass());
     }
 
     @Override
@@ -322,9 +322,9 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
     }
 
     @Override
-    public MapReducePublisher<Document> mapReduce(final ClientSession clientSession, final String mapFunction,
+    public MapReducePublisher<TDocument> mapReduce(final ClientSession clientSession, final String mapFunction,
                                                   final String reduceFunction) {
-        return mapReduce(clientSession, mapFunction, reduceFunction, Document.class);
+        return mapReduce(clientSession, mapFunction, reduceFunction, getDocumentClass());
     }
 
     @Override

--- a/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/MongoCollectionImplSpecification.groovy
+++ b/driver-reactive-streams/src/test/unit/com/mongodb/reactivestreams/client/internal/MongoCollectionImplSpecification.groovy
@@ -368,6 +368,7 @@ class MongoCollectionImplSpecification extends Specification {
         def aggregatePublisher = collection.aggregate(pipeline)
 
         then:
+        1 * wrapped.getDocumentClass() >> Document
         1 * wrapped.aggregate(pipeline, Document) >> wrappedResult
         expect aggregatePublisher, isTheSameAs(new AggregatePublisherImpl(wrappedResult))
 
@@ -382,6 +383,7 @@ class MongoCollectionImplSpecification extends Specification {
         aggregatePublisher = collection.aggregate(clientSession, pipeline)
 
         then:
+        1 * wrapped.getDocumentClass() >> Document
         1 * wrapped.aggregate(wrappedClientSession, pipeline, Document) >> wrappedResult
         expect aggregatePublisher, isTheSameAs(new AggregatePublisherImpl(wrappedResult))
 
@@ -469,6 +471,7 @@ class MongoCollectionImplSpecification extends Specification {
         mapReducePublisher = collection.mapReduce('map', 'reduce')
 
         then:
+        1 * wrapped.getDocumentClass() >> Document
         1 * wrapped.mapReduce('map', 'reduce', Document) >> wrappedResult
         expect mapReducePublisher, isTheSameAs(new MapReducePublisherImpl(wrappedResult))
 
@@ -483,6 +486,7 @@ class MongoCollectionImplSpecification extends Specification {
         mapReducePublisher = collection.mapReduce(clientSession, 'map', 'reduce')
 
         then:
+        1 * wrapped.getDocumentClass() >> Document
         1 * wrapped.mapReduce(wrappedClientSession, 'map', 'reduce', Document) >> wrappedResult
         expect mapReducePublisher, isTheSameAs(new MapReducePublisherImpl(wrappedResult))
 


### PR DESCRIPTION
Evergreen patch: https://evergreen.mongodb.com/version/5d84f79a2a60ed61eeee2257