### PR TITLE
Deprecate ConnectionString#getThreadsAllowedToBlockForConnectionMultiplier

### DIFF
--- a/driver-core/src/main/com/mongodb/ConnectionString.java
+++ b/driver-core/src/main/com/mongodb/ConnectionString.java
@@ -128,7 +128,7 @@ import static java.util.Collections.unmodifiableList;
  * <li>{@code maxPoolSize=n}: The maximum number of connections in the connection pool.</li>
  * <li>{@code waitQueueMultiple=n} : this multiplier, multiplied with the maxPoolSize setting, gives the maximum number of
  * threads that may be waiting for a connection to become available from the pool.  All further threads will get an
- * exception right away.</li>
+ * exception right away. Note that this configuration option is deprecated and will be removed in the next major release.</li>
  * <li>{@code waitQueueTimeoutMS=ms}: The maximum wait time in milliseconds that a thread may wait for a connection to
  * become available.</li>
  * </ul>
@@ -1209,7 +1209,7 @@ public class ConnectionString {
     /**
      * Gets the multiplier for the number of threads allowed to block waiting for a connection specified in the connection string.
      * @return the multiplier for the number of threads allowed to block waiting for a connection
-     @deprecated in the next major release, wait queue size limitations will be removed
+     * @deprecated in the next major release, wait queue size limitations will be removed
      */
     @Deprecated
     @Nullable

--- a/driver-core/src/main/com/mongodb/ConnectionString.java
+++ b/driver-core/src/main/com/mongodb/ConnectionString.java
@@ -1209,7 +1209,9 @@ public class ConnectionString {
     /**
      * Gets the multiplier for the number of threads allowed to block waiting for a connection specified in the connection string.
      * @return the multiplier for the number of threads allowed to block waiting for a connection
+     @deprecated in the next major release, wait queue size limitations will be removed
      */
+    @Deprecated
     @Nullable
     public Integer getThreadsAllowedToBlockForConnectionMultiplier() {
         return threadsAllowedToBlockForConnectionMultiplier;

--- a/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClientOptions.java
@@ -271,7 +271,6 @@ public class MongoClientOptions {
      * <p>Default is 100.</p>
      *
      * @return the maximum size of the connection pool per host
-     * @see MongoClientOptions#getThreadsAllowedToBlockForConnectionMultiplier()
      */
     public int getConnectionsPerHost() {
         return maxConnectionsPerHost;
@@ -296,8 +295,10 @@ public class MongoClientOptions {
      *
      * <p>Default is 5.</p>
      *
+     * @deprecated in the next major release, wait queue size limitations will be removed
      * @return the multiplier
      */
+    @Deprecated
     public int getThreadsAllowedToBlockForConnectionMultiplier() {
         return threadsAllowedToBlockForConnectionMultiplier;
     }
@@ -1188,7 +1189,9 @@ public class MongoClientOptions {
          * @return {@code this}
          * @throws IllegalArgumentException if {@code threadsAllowedToBlockForConnectionMultiplier < 1}
          * @see MongoClientOptions#getThreadsAllowedToBlockForConnectionMultiplier()
+         * @deprecated in the next major release, wait queue size limitations will be removed
          */
+        @Deprecated
         public Builder threadsAllowedToBlockForConnectionMultiplier(final int threadsAllowedToBlockForConnectionMultiplier) {
             isTrueArgument("threadsAllowedToBlockForConnectionMultiplier must be > 0", threadsAllowedToBlockForConnectionMultiplier > 0);
             this.threadsAllowedToBlockForConnectionMultiplier = threadsAllowedToBlockForConnectionMultiplier;

--- a/driver-legacy/src/main/com/mongodb/MongoClientURI.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClientURI.java
@@ -108,7 +108,7 @@ import static com.mongodb.assertions.Assertions.notNull;
  * <li>{@code maxPoolSize=n}: The maximum number of connections in the connection pool.</li>
  * <li>{@code waitQueueMultiple=n} : this multiplier, multiplied with the maxPoolSize setting, gives the maximum number of
  * threads that may be waiting for a connection to become available from the pool.  All further threads will get an
- * exception right away.</li>
+ * exception right away.  Note that this configuration option is deprecated and will be removed in the next major release.</li>
  * <li>{@code waitQueueTimeoutMS=ms}: The maximum wait time in milliseconds that a thread may wait for a connection to
  * become available.</li>
  * </ul>


### PR DESCRIPTION
This was a final bit of cleanup for deprecation of all wait queue
limits.

JAVA-3460