### PR TITLE
Update value of driver name in client metadata to reflect new structure

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/async/client/MongoClients.java
+++ b/driver-core/src/main/com/mongodb/internal/async/client/MongoClients.java
@@ -149,11 +149,9 @@ public final class MongoClients {
                                          @Nullable final MongoDriverInformation mongoDriverInformation,
                                          final StreamFactory streamFactory, final StreamFactory heartbeatStreamFactory) {
         notNull("settings", settings);
-        MongoDriverInformation.Builder builder = mongoDriverInformation == null ? MongoDriverInformation.builder()
-                : MongoDriverInformation.builder(mongoDriverInformation);
         return new DefaultClusterFactory().createCluster(settings.getClusterSettings(), settings.getServerSettings(),
                 settings.getConnectionPoolSettings(), streamFactory, heartbeatStreamFactory, settings.getCredential(),
-                getCommandListener(settings.getCommandListeners()), settings.getApplicationName(), builder.driverName("async").build(),
+                getCommandListener(settings.getCommandListeners()), settings.getApplicationName(), mongoDriverInformation,
                 settings.getCompressorList());
     }
 

--- a/driver-legacy/src/examples/tour/Decimal128LegacyAPIQuickTour.java
+++ b/driver-legacy/src/examples/tour/Decimal128LegacyAPIQuickTour.java
@@ -37,7 +37,7 @@ public class Decimal128LegacyAPIQuickTour {
      *
      * @param args takes an optional single argument for the connection string
      */
-    public static void main(final String[] args) {
+    public static void main(final String[] args) {      
         MongoClient mongoClient;
 
         if (args.length == 0) {

--- a/driver-legacy/src/examples/tour/Decimal128LegacyAPIQuickTour.java
+++ b/driver-legacy/src/examples/tour/Decimal128LegacyAPIQuickTour.java
@@ -37,7 +37,7 @@ public class Decimal128LegacyAPIQuickTour {
      *
      * @param args takes an optional single argument for the connection string
      */
-    public static void main(final String[] args) {      
+    public static void main(final String[] args) {
         MongoClient mongoClient;
 
         if (args.length == 0) {

--- a/driver-legacy/src/main/com/mongodb/MongoClient.java
+++ b/driver-legacy/src/main/com/mongodb/MongoClient.java
@@ -732,8 +732,13 @@ public class MongoClient implements Closeable {
                 credential,
                 getCommandListener(options.getCommandListeners()),
                 options.getApplicationName(),
-                mongoDriverInformation,
+                wrapMongoDriverInformation(mongoDriverInformation),
                 options.getCompressorList());
+    }
+
+    private static MongoDriverInformation wrapMongoDriverInformation(@Nullable final MongoDriverInformation mongoDriverInformation) {
+        return (mongoDriverInformation == null ? MongoDriverInformation.builder() : MongoDriverInformation.builder(mongoDriverInformation))
+                .driverName("legacy").build();
     }
 
     private static ClusterSettings getClusterSettings(final ClusterSettings.Builder builder, final MongoClientOptions options) {

--- a/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoClients.java
+++ b/driver-reactive-streams/src/main/com/mongodb/reactivestreams/client/MongoClients.java
@@ -69,7 +69,8 @@ public final class MongoClients {
      * @since 1.3
      */
     public static MongoClient create(final ConnectionString connectionString, final MongoDriverInformation mongoDriverInformation) {
-        return create(com.mongodb.internal.async.client.MongoClients.create(connectionString, mongoDriverInformation));
+        return create(com.mongodb.internal.async.client.MongoClients.create(connectionString,
+                wrapMongoDriverInformation(mongoDriverInformation)));
     }
 
     /**
@@ -94,7 +95,7 @@ public final class MongoClients {
      * @since 1.8
      */
     public static MongoClient create(final MongoClientSettings settings, final MongoDriverInformation mongoDriverInformation) {
-        return create(com.mongodb.internal.async.client.MongoClients.create(settings, mongoDriverInformation));
+        return create(com.mongodb.internal.async.client.MongoClients.create(settings, wrapMongoDriverInformation(mongoDriverInformation)));
     }
 
     /**
@@ -110,6 +111,11 @@ public final class MongoClients {
 
     private static MongoClient create(final com.mongodb.internal.async.client.MongoClient asyncMongoClient) {
         return new MongoClientImpl(asyncMongoClient);
+    }
+
+    private static MongoDriverInformation wrapMongoDriverInformation(final MongoDriverInformation mongoDriverInformation) {
+        return (mongoDriverInformation == null ? MongoDriverInformation.builder() : MongoDriverInformation.builder(mongoDriverInformation))
+                .driverName("reactive-streams").build();
     }
 
     private MongoClients() {

--- a/driver-scala/src/main/scala/org/mongodb/scala/MongoClient.scala
+++ b/driver-scala/src/main/scala/org/mongodb/scala/MongoClient.scala
@@ -96,7 +96,7 @@ object MongoClient {
       case Some(info) => MongoDriverInformation.builder(info)
       case None       => MongoDriverInformation.builder()
     }
-    builder.driverName("mongo-scala-driver").driverPlatform(s"Scala/${scala.util.Properties.versionString}")
+    builder.driverName("scala").driverPlatform(s"Scala/${scala.util.Properties.versionString}")
     MongoClient(MongoClients.create(clientSettings, builder.build()))
   }
 


### PR DESCRIPTION
* mongo-java-driver|sync: for com.mongodb.MongoClient
* mongo-java-driver|legacy: for com.mongodb.client.MongoClient
* mongo-java-driver|reactive-streams: for com.mongodb.reactivestreams.client.MongoClient
* mongo-java-driver|reactive-streams|scala for org.mongodb.scala.MongoClient

https://jira.mongodb.org/browse/JAVA-3488