### PR TITLE
Deprecate SessionContext

### DIFF
--- a/driver-core/src/main/com/mongodb/session/SessionContext.java
+++ b/driver-core/src/main/com/mongodb/session/SessionContext.java
@@ -24,7 +24,9 @@ import org.bson.BsonTimestamp;
  * The session context.
  *
  * @since 3.6
+ * @deprecated there is no replacement for this class
  */
+@Deprecated
 public interface SessionContext {
 
     /**


### PR DESCRIPTION
There is no need for this class in the public API, as all its users
are either internal or deprecated themselves.

JAVA-3509