### PR TITLE
UUID specification implementation updates

### DIFF
--- a/bson/src/main/org/bson/LazyBSONObject.java
+++ b/bson/src/main/org/bson/LazyBSONObject.java
@@ -177,7 +177,7 @@ public class LazyBSONObject implements BSONObject {
             case BINARY:
                 byte binarySubType = reader.peekBinarySubType();
                 if (BsonBinarySubType.isUuid(binarySubType) && reader.peekBinarySize() == 16) {
-                    return new UuidCodec().decode(reader, DecoderContext.builder().build());
+                    return new UuidCodec(UuidRepresentation.JAVA_LEGACY).decode(reader, DecoderContext.builder().build());
                 }
                 BsonBinary binary = reader.readBinaryData();
                 if (binarySubType == BINARY.getValue() || binarySubType == OLD_BINARY.getValue()) {

--- a/bson/src/test/unit/org/bson/codecs/IterableCodecSpecification.groovy
+++ b/bson/src/test/unit/org/bson/codecs/IterableCodecSpecification.groovy
@@ -16,13 +16,21 @@
 
 package org.bson.codecs
 
+
 import org.bson.BsonDocument
 import org.bson.BsonDocumentReader
 import org.bson.BsonDocumentWriter
 import org.bson.types.Binary
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import static org.bson.BsonDocument.parse
+import static org.bson.UuidRepresentation.C_SHARP_LEGACY
+import static org.bson.UuidRepresentation.JAVA_LEGACY
+import static org.bson.UuidRepresentation.PYTHON_LEGACY
+import static org.bson.UuidRepresentation.STANDARD
+import static org.bson.UuidRepresentation.UNSPECIFIED
+import static org.bson.codecs.configuration.CodecRegistries.fromCodecs
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders
 
 class IterableCodecSpecification extends Specification {
@@ -122,4 +130,55 @@ class IterableCodecSpecification extends Specification {
         '{"array": [{ "$binary" : "CAcGBQQDAgEQDw4NDAsKCQ==", "$type" : "3" }]}' | [UUID.fromString('01020304-0506-0708-090a-0b0c0d0e0f10')]
     }
 
+    @SuppressWarnings(['LineLength'])
+    @Unroll
+    def 'should decode binary subtype 3 for UUID'() {
+        given:
+        def reader = new BsonDocumentReader(parse(document))
+        def codec = new IterableCodec(fromCodecs(new UuidCodec(representation), new BinaryCodec()), new BsonTypeClassMap())
+                .withUuidRepresentation(representation)
+
+        when:
+        reader.readStartDocument()
+        reader.readName('array')
+        def iterable = codec.decode(reader, DecoderContext.builder().build())
+        reader.readEndDocument()
+
+        then:
+        value == iterable
+
+        where:
+        representation | value                                                     | document
+        JAVA_LEGACY    | [UUID.fromString('08070605-0403-0201-100f-0e0d0c0b0a09')] | '{"array": [{ "$binary" : "AQIDBAUGBwgJCgsMDQ4PEA==", "$type" : "3" }]}'
+        C_SHARP_LEGACY | [UUID.fromString('04030201-0605-0807-090a-0b0c0d0e0f10')] | '{"array": [{ "$binary" : "AQIDBAUGBwgJCgsMDQ4PEA==", "$type" : "3" }]}'
+        PYTHON_LEGACY  | [UUID.fromString('01020304-0506-0708-090a-0b0c0d0e0f10')] | '{"array": [{ "$binary" : "AQIDBAUGBwgJCgsMDQ4PEA==", "$type" : "3" }]}'
+        STANDARD       | [new Binary((byte) 3, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] as byte[])] | '{"array": [{ "$binary" : "AQIDBAUGBwgJCgsMDQ4PEA==", "$type" : "3" }]}'
+        UNSPECIFIED    | [new Binary((byte) 3, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] as byte[])] | '{"array": [{ "$binary" : "AQIDBAUGBwgJCgsMDQ4PEA==", "$type" : "3" }]}'
+    }
+
+    @SuppressWarnings(['LineLength'])
+    @Unroll
+    def 'should decode binary subtype 4 for UUID'() {
+        given:
+        def reader = new BsonDocumentReader(parse(document))
+        def codec = new IterableCodec(fromCodecs(new UuidCodec(representation), new BinaryCodec()), new BsonTypeClassMap())
+                .withUuidRepresentation(representation)
+
+        when:
+        reader.readStartDocument()
+        reader.readName('array')
+        def iterable = codec.decode(reader, DecoderContext.builder().build())
+        reader.readEndDocument()
+
+        then:
+        value == iterable
+
+        where:
+        representation | value                                                     | document
+        STANDARD       | [UUID.fromString('01020304-0506-0708-090a-0b0c0d0e0f10')] | '{"array": [{ "$binary" : "AQIDBAUGBwgJCgsMDQ4PEA==", "$type" : "4" }]}'
+        JAVA_LEGACY    | [UUID.fromString('01020304-0506-0708-090a-0b0c0d0e0f10')] | '{"array": [{ "$binary" : "AQIDBAUGBwgJCgsMDQ4PEA==", "$type" : "4" }]}'
+        C_SHARP_LEGACY | [new Binary((byte) 4, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] as byte[])] | '{"array": [{ "$binary" : "AQIDBAUGBwgJCgsMDQ4PEA==", "$type" : "4" }]}'
+        PYTHON_LEGACY  | [new Binary((byte) 4, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] as byte[])] | '{"array": [{ "$binary" : "AQIDBAUGBwgJCgsMDQ4PEA==", "$type" : "4" }]}'
+        UNSPECIFIED    | [new Binary((byte) 4, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] as byte[])] | '{"array": [{ "$binary" : "AQIDBAUGBwgJCgsMDQ4PEA==", "$type" : "4" }]}'
+    }
 }

--- a/bson/src/test/unit/org/bson/codecs/MapCodecSpecification.groovy
+++ b/bson/src/test/unit/org/bson/codecs/MapCodecSpecification.groovy
@@ -42,6 +42,7 @@ import org.bson.types.ObjectId
 import org.bson.types.Symbol
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Unroll
 
 import java.nio.ByteBuffer
 import java.util.concurrent.atomic.AtomicBoolean
@@ -49,6 +50,12 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 
 import static java.util.Arrays.asList
+import static org.bson.UuidRepresentation.C_SHARP_LEGACY
+import static org.bson.UuidRepresentation.JAVA_LEGACY
+import static org.bson.UuidRepresentation.PYTHON_LEGACY
+import static org.bson.UuidRepresentation.STANDARD
+import static org.bson.UuidRepresentation.UNSPECIFIED
+import static org.bson.codecs.configuration.CodecRegistries.fromCodecs
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders
 
 class MapCodecSpecification extends Specification {
@@ -139,22 +146,48 @@ class MapCodecSpecification extends Specification {
     }
 
     @SuppressWarnings(['LineLength'])
-    def 'should decode binary subtypes for UUID'() {
+    @Unroll
+    def 'should decode binary subtype 3 for UUID'() {
         given:
         def reader = new BsonBinaryReader(ByteBuffer.wrap(bytes as byte[]))
 
         when:
-        def document = new MapCodec().decode(reader, DecoderContext.builder().build())
+        def map = new MapCodec(fromCodecs(new UuidCodec(representation), new BinaryCodec()))
+                .withUuidRepresentation(representation)
+                .decode(reader, DecoderContext.builder().build())
 
         then:
-        value == document.get('f')
+        value == map.get('f')
 
         where:
-        value                                                   | bytes
-        new Binary((byte) 0x03, (byte[]) [115, 116, 11])        | [16, 0, 0, 0, 5, 102, 0, 3, 0, 0, 0, 3, 115, 116, 11, 0]
-        new Binary((byte) 0x04, (byte[]) [115, 116, 11])        | [16, 0, 0, 0, 5, 102, 0, 3, 0, 0, 0, 4, 115, 116, 11, 0]
-        UUID.fromString('08070605-0403-0201-100f-0e0d0c0b0a09') | [29, 0, 0, 0, 5, 102, 0, 16, 0, 0, 0, 3, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0]
-        UUID.fromString('01020304-0506-0708-090a-0b0c0d0e0f10') | [29, 0, 0, 0, 5, 102, 0, 16, 0, 0, 0, 4, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0]
+        representation | value                                                   | bytes
+        JAVA_LEGACY    | UUID.fromString('08070605-0403-0201-100f-0e0d0c0b0a09') | [29, 0, 0, 0, 5, 102, 0, 16, 0, 0, 0, 3, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0]
+        C_SHARP_LEGACY | UUID.fromString('04030201-0605-0807-090a-0b0c0d0e0f10') | [29, 0, 0, 0, 5, 102, 0, 16, 0, 0, 0, 3, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0]
+        PYTHON_LEGACY  | UUID.fromString('01020304-0506-0708-090a-0b0c0d0e0f10') | [29, 0, 0, 0, 5, 102, 0, 16, 0, 0, 0, 3, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0]
+        STANDARD       | new Binary((byte) 3, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] as byte[]) | [29, 0, 0, 0, 5, 102, 0, 16, 0, 0, 0, 3, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0]
+        UNSPECIFIED    | new Binary((byte) 3, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] as byte[]) | [29, 0, 0, 0, 5, 102, 0, 16, 0, 0, 0, 3, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0]
+    }
+
+    @SuppressWarnings(['LineLength'])
+    @Unroll
+    def 'should decode binary subtype 4 for UUID'() {
+        given:
+        def reader = new BsonBinaryReader(ByteBuffer.wrap(bytes as byte[]))
+
+        when:
+        def map = new MapCodec().withUuidRepresentation(representation)
+                .decode(reader, DecoderContext.builder().build())
+
+        then:
+        value == map.get('f')
+
+        where:
+        representation | value                                                   | bytes
+        STANDARD       | UUID.fromString('01020304-0506-0708-090a-0b0c0d0e0f10') | [29, 0, 0, 0, 5, 102, 0, 16, 0, 0, 0, 4, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0]
+        JAVA_LEGACY    | UUID.fromString('01020304-0506-0708-090a-0b0c0d0e0f10') | [29, 0, 0, 0, 5, 102, 0, 16, 0, 0, 0, 4, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0]
+        C_SHARP_LEGACY | new Binary((byte) 4, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] as byte[]) | [29, 0, 0, 0, 5, 102, 0, 16, 0, 0, 0, 4, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0]
+        PYTHON_LEGACY  | new Binary((byte) 4, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] as byte[]) | [29, 0, 0, 0, 5, 102, 0, 16, 0, 0, 0, 4, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0]
+        UNSPECIFIED    | new Binary((byte) 4, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] as byte[]) | [29, 0, 0, 0, 5, 102, 0, 16, 0, 0, 0, 4, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0]
     }
 
     def 'should apply transformer to decoded values'() {

--- a/driver-legacy/src/main/com/mongodb/DBCollection.java
+++ b/driver-legacy/src/main/com/mongodb/DBCollection.java
@@ -2447,10 +2447,11 @@ public class DBCollection {
         return retVal;
     }
 
-    DBObjectCodec getDefaultDBObjectCodec() {
-        return new DBObjectCodec(MongoClient.getDefaultCodecRegistry(),
+    Codec<DBObject> getDefaultDBObjectCodec() {
+        return new DBObjectCodec(getDB().getMongoClient().getCodecRegistry(),
                                  DBObjectCodec.getDefaultBsonTypeClassMap(),
-                                 getObjectFactory());
+                                 getObjectFactory())
+                .withUuidRepresentation(getDB().getMongoClient().getMongoClientOptions().getUuidRepresentation());
     }
 
     private <T> T convertOptionsToType(final DBObject options, final String field, final Class<T> clazz) {

--- a/driver-legacy/src/main/com/mongodb/GroupCommand.java
+++ b/driver-legacy/src/main/com/mongodb/GroupCommand.java
@@ -21,6 +21,7 @@ import com.mongodb.lang.Nullable;
 import com.mongodb.operation.GroupOperation;
 import org.bson.BsonDocumentWrapper;
 import org.bson.BsonJavaScript;
+import org.bson.codecs.Codec;
 
 import static com.mongodb.assertions.Assertions.notNull;
 
@@ -149,7 +150,7 @@ public class GroupCommand {
         return new BasicDBObject("group", args);
     }
 
-    GroupOperation<DBObject> toOperation(final MongoNamespace namespace, final DBObjectCodec codec, final boolean retryReads) {
+    GroupOperation<DBObject> toOperation(final MongoNamespace namespace, final Codec<DBObject> codec, final boolean retryReads) {
         if (initial == null) {
             throw new IllegalArgumentException("Group command requires an initial document for the aggregate result");
         }

--- a/driver-legacy/src/test/unit/com/mongodb/DBSpecification.groovy
+++ b/driver-legacy/src/test/unit/com/mongodb/DBSpecification.groovy
@@ -16,6 +16,7 @@
 
 package com.mongodb
 
+
 import com.mongodb.client.internal.TestOperationExecutor
 import com.mongodb.client.model.Collation
 import com.mongodb.client.model.CollationAlternate
@@ -70,7 +71,7 @@ class DBSpecification extends Specification {
 
     def 'should execute CreateCollectionOperation'() {
         given:
-        def mongo = Stub(Mongo)
+        def mongo = Stub(MongoClient)
         mongo.mongoClientOptions >> MongoClientOptions.builder().build()
         def executor = new TestOperationExecutor([1L, 2L, 3L])
         def db = new DB(mongo, 'test', executor)
@@ -135,7 +136,9 @@ class DBSpecification extends Specification {
 
     def 'should execute CreateViewOperation'() {
         given:
-        def mongo = Stub(Mongo)
+        def mongo = Stub(MongoClient) {
+            getCodecRegistry() >> MongoClient.defaultCodecRegistry
+        }
         mongo.mongoClientOptions >> MongoClientOptions.builder().build()
         def executor = new TestOperationExecutor([1L, 2L, 3L])
 


### PR DESCRIPTION
While finishing the UUID spec work in the 4.x branch, I realized I missed a few spots where it needed to be applied in 3.x:

* Implement required behavior in MapCodec and IterableCodec
* Implement required behavior in DBCollection

JAVA-3516