### PR TITLE
CodecRegistry extends CodecProvider

### DIFF
--- a/bson/src/main/org/bson/codecs/configuration/CodecRegistries.java
+++ b/bson/src/main/org/bson/codecs/configuration/CodecRegistries.java
@@ -19,7 +19,6 @@ package org.bson.codecs.configuration;
 import org.bson.codecs.Codec;
 import org.bson.internal.ProvidersCodecRegistry;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -124,28 +123,7 @@ public final class CodecRegistries {
      * @return a {@code CodecRegistry} that combines the list of {@code CodecRegistry} instances into a single one
      */
     public static CodecRegistry fromRegistries(final List<? extends CodecRegistry> registries) {
-        List<CodecProvider> providers = new ArrayList<CodecProvider>();
-        for (CodecRegistry registry : registries) {
-            providers.add(providerFromRegistry(registry));
-        }
-        return new ProvidersCodecRegistry(providers);
-    }
-
-    private static CodecProvider providerFromRegistry(final CodecRegistry innerRegistry) {
-        if (innerRegistry instanceof CodecProvider) {
-            return (CodecProvider) innerRegistry;
-        } else {
-            return new CodecProvider() {
-                @Override
-                public <T> Codec<T> get(final Class<T> clazz, final CodecRegistry outerRregistry) {
-                    try {
-                        return innerRegistry.get(clazz);
-                    } catch (CodecConfigurationException e) {
-                        return null;
-                    }
-                }
-            };
-        }
+        return new ProvidersCodecRegistry(registries);
     }
 
     private CodecRegistries() {

--- a/bson/src/main/org/bson/codecs/configuration/CodecRegistry.java
+++ b/bson/src/main/org/bson/codecs/configuration/CodecRegistry.java
@@ -26,9 +26,11 @@ import org.bson.codecs.Codec;
  * {@code Object.equals}. It is not necessary to do so, and the simplest course of action is to rely on Object's implementation, but the
  * implementer may wish to implement a "value comparison" in place of the default "reference comparison."</p>
  *
+ * <p>As of the 4.0 release, this class extends the {@code CodecProvider} interface.  This capability was introduced to enable nesting
+ * registries inside another registry.</p>
  * @since 3.0
  */
-public interface CodecRegistry {
+public interface CodecRegistry extends CodecProvider {
     /**
      * Gets a {@code Codec} for the given Class.
      *

--- a/bson/src/main/org/bson/internal/ChildCodecRegistry.java
+++ b/bson/src/main/org/bson/internal/ChildCodecRegistry.java
@@ -53,6 +53,11 @@ class ChildCodecRegistry<T> implements CodecRegistry {
         }
     }
 
+    @Override
+    public <U> Codec<U> get(final Class<U> clazz, final CodecRegistry registry) {
+        return this.registry.get(clazz, registry);
+    }
+
     @SuppressWarnings("rawtypes")
     private <U> Boolean hasCycles(final Class<U> theClass) {
         ChildCodecRegistry current = this;

--- a/bson/src/main/org/bson/internal/CodecRegistryHelper.java
+++ b/bson/src/main/org/bson/internal/CodecRegistryHelper.java
@@ -17,23 +17,17 @@
 package org.bson.internal;
 
 import org.bson.UuidRepresentation;
-import org.bson.codecs.configuration.CodecConfigurationException;
 import org.bson.codecs.configuration.CodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
 
 public final class CodecRegistryHelper {
 
     public static CodecRegistry createRegistry(final CodecRegistry codecRegistry, final UuidRepresentation uuidRepresentation) {
-        CodecRegistry retVal = codecRegistry;
-        if (uuidRepresentation != UuidRepresentation.UNSPECIFIED) {
-            if (codecRegistry instanceof CodecProvider) {
-                retVal = new OverridableUuidRepresentationCodecRegistry((CodecProvider) codecRegistry, uuidRepresentation);
-            } else {
-                throw new CodecConfigurationException("Changing the default UuidRepresentation requires a CodecRegistry that also "
-                        +    "implements the CodecProvider interface");
-            }
+        if (uuidRepresentation == UuidRepresentation.UNSPECIFIED) {
+            return codecRegistry;
+        } else {
+            return new OverridableUuidRepresentationCodecRegistry((CodecProvider) codecRegistry, uuidRepresentation);
         }
-        return retVal;
     }
 
     private CodecRegistryHelper() {

--- a/bson/src/main/org/bson/internal/CodecRegistryHelper.java
+++ b/bson/src/main/org/bson/internal/CodecRegistryHelper.java
@@ -17,7 +17,6 @@
 package org.bson.internal;
 
 import org.bson.UuidRepresentation;
-import org.bson.codecs.configuration.CodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
 
 public final class CodecRegistryHelper {
@@ -26,7 +25,7 @@ public final class CodecRegistryHelper {
         if (uuidRepresentation == UuidRepresentation.UNSPECIFIED) {
             return codecRegistry;
         } else {
-            return new OverridableUuidRepresentationCodecRegistry((CodecProvider) codecRegistry, uuidRepresentation);
+            return new OverridableUuidRepresentationCodecRegistry(codecRegistry, uuidRepresentation);
         }
     }
 

--- a/bson/src/main/org/bson/internal/OverridableUuidRepresentationCodecRegistry.java
+++ b/bson/src/main/org/bson/internal/OverridableUuidRepresentationCodecRegistry.java
@@ -20,6 +20,7 @@ import org.bson.UuidRepresentation;
 import org.bson.codecs.Codec;
 import org.bson.codecs.OverridableUuidRepresentationCodec;
 import org.bson.codecs.configuration.CodecProvider;
+import org.bson.codecs.configuration.CodecRegistry;
 
 import static org.bson.assertions.Assertions.notNull;
 
@@ -47,8 +48,19 @@ public class OverridableUuidRepresentationCodecRegistry implements CycleDetectin
         return get(new ChildCodecRegistry<T>(this, clazz));
     }
 
+
     @Override
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({"unchecked"})
+    public <T> Codec<T> get(final Class<T> clazz, final CodecRegistry registry) {
+        Codec<T> codec = wrapped.get(clazz, registry);
+        if (codec instanceof OverridableUuidRepresentationCodec) {
+            return ((OverridableUuidRepresentationCodec<T>) codec).withUuidRepresentation(uuidRepresentation);
+        }
+        return codec;
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked"})
     public <T> Codec<T> get(final ChildCodecRegistry<T> context) {
         if (!codecCache.containsKey(context.getCodecClass())) {
             Codec<T> codec = wrapped.get(context.getCodecClass(), context);

--- a/bson/src/main/org/bson/internal/ProvidersCodecRegistry.java
+++ b/bson/src/main/org/bson/internal/ProvidersCodecRegistry.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 import static org.bson.assertions.Assertions.isTrueArgument;
 
-public final class ProvidersCodecRegistry implements CodecRegistry, CodecProvider, CycleDetectingCodecRegistry {
+public final class ProvidersCodecRegistry implements CodecRegistry, CycleDetectingCodecRegistry {
     private final List<CodecProvider> codecProviders;
     private final CodecCache codecCache = new CodecCache();
 
@@ -50,7 +50,7 @@ public final class ProvidersCodecRegistry implements CodecRegistry, CodecProvide
         return null;
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @SuppressWarnings({"rawtypes" })
     public <T> Codec<T> get(final ChildCodecRegistry<T> context) {
         if (!codecCache.containsKey(context.getCodecClass())) {
             for (CodecProvider provider : codecProviders) {


### PR DESCRIPTION
This enables an existing CodecRegistry to be wrapped by another CodecRegistry and used
as a CodecProvider.  We take advantage of this for the
OverridableUuidRepresentationCodecRegistry, allowing us to remove an ugly cast.

https://jira.mongodb.org/browse/JAVA-3506