### PR TITLE
Disable RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE Spotbugs check

### DIFF
--- a/config/findbugs-exclude.xml
+++ b/config/findbugs-exclude.xml
@@ -163,4 +163,10 @@
         <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
     </Match>
 
+    <!-- Caused by Java 11 generating a null check on try with resources.
+         See https://github.com/spotbugs/spotbugs/issues/756 for details. -->
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+    </Match>
+
 </FindBugsFilter>


### PR DESCRIPTION
Spotbugs plugin complains about an extraneous null check for any use
of try-with-resources compiled with Java 11.  Until the issue is
addressed by Spotbugs, disabling the check.

JAVA-3632