### PR TITLE
Improve reliability of mongocryptd connections

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/async/client/CommandMarker.java
+++ b/driver-core/src/main/com/mongodb/internal/async/client/CommandMarker.java
@@ -16,22 +16,18 @@
 
 package com.mongodb.internal.async.client;
 
-import com.mongodb.Block;
-import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientException;
-import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoTimeoutException;
 import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
-import com.mongodb.connection.ClusterSettings;
 import com.mongodb.internal.async.SingleResultCallback;
 import org.bson.RawBsonDocument;
 
 import java.io.Closeable;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
-import static com.mongodb.internal.capi.MongoCryptOptionsHelper.createMongocryptdSpawnArgs;
+import static com.mongodb.internal.capi.MongoCryptHelper.createMongocryptdSpawnArgs;
+import static com.mongodb.internal.capi.MongoCryptHelper.createMongocryptdClientSettings;
 
 @SuppressWarnings("UseOfProcessBuilder")
 class CommandMarker implements Closeable {
@@ -50,24 +46,7 @@ class CommandMarker implements Closeable {
             } else {
                 processBuilder = null;
             }
-
-            String connectionString;
-            if (options.containsKey("mongocryptdURI")) {
-                connectionString = (String) options.get("mongocryptdURI");
-            } else {
-                connectionString = "mongodb://localhost:27020";
-            }
-
-            client = AsyncMongoClients.create(MongoClientSettings.builder()
-                .applyConnectionString(new ConnectionString(connectionString))
-                .applyToClusterSettings(new Block<ClusterSettings.Builder>() {
-                    @Override
-                    public void apply(final ClusterSettings.Builder builder) {
-                        builder.serverSelectionTimeout(1, TimeUnit.SECONDS);
-                    }
-                })
-                .build());
-
+            client = AsyncMongoClients.create(createMongocryptdClientSettings((String) options.get("mongocryptdURI")));
         }
     }
 

--- a/driver-core/src/main/com/mongodb/internal/async/client/Crypts.java
+++ b/driver-core/src/main/com/mongodb/internal/async/client/Crypts.java
@@ -26,7 +26,7 @@ import com.mongodb.crypt.capi.MongoCrypts;
 import javax.net.ssl.SSLContext;
 import java.security.NoSuchAlgorithmException;
 
-import static com.mongodb.internal.capi.MongoCryptOptionsHelper.createMongoCryptOptions;
+import static com.mongodb.internal.capi.MongoCryptHelper.createMongoCryptOptions;
 
 public final class Crypts {
 

--- a/driver-core/src/main/com/mongodb/internal/capi/MongoCryptHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/capi/MongoCryptHelper.java
@@ -105,4 +105,7 @@ public final class MongoCryptHelper {
                         ? connectionString : "mongodb://localhost:27020"))
                 .build();
     }
+
+    private MongoCryptHelper() {
+    }
 }

--- a/driver-core/src/main/com/mongodb/internal/capi/MongoCryptHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/capi/MongoCryptHelper.java
@@ -21,6 +21,7 @@ import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientException;
 import com.mongodb.MongoClientSettings;
 import com.mongodb.connection.ClusterSettings;
+import com.mongodb.connection.SocketSettings;
 import com.mongodb.crypt.capi.MongoAwsKmsProviderOptions;
 import com.mongodb.crypt.capi.MongoCryptOptions;
 import com.mongodb.crypt.capi.MongoLocalKmsProviderOptions;
@@ -77,23 +78,31 @@ public final class MongoCryptHelper {
             spawnArgs.add("--idleShutdownTimeoutSecs");
             spawnArgs.add("60");
         }
+        if (!spawnArgs.contains("--logpath")) {
+            spawnArgs.add("--logpath");
+            spawnArgs.add(System.getProperty("os.name").startsWith("Windows") ? "NUL" : "/dev/null");
+        }
         return spawnArgs;
     }
 
     public static MongoClientSettings createMongocryptdClientSettings(final String connectionString) {
 
         return MongoClientSettings.builder()
-                .applyConnectionString(new ConnectionString((connectionString != null)
-                        ? connectionString : "mongodb://localhost:27020"))
                 .applyToClusterSettings(new Block<ClusterSettings.Builder>() {
                     @Override
                     public void apply(final ClusterSettings.Builder builder) {
                         builder.serverSelectionTimeout(1, TimeUnit.SECONDS);
                     }
                 })
+                .applyToSocketSettings(new Block<SocketSettings.Builder>() {
+                    @Override
+                    public void apply(final SocketSettings.Builder builder) {
+                        builder.readTimeout(1, TimeUnit.SECONDS);
+                        builder.connectTimeout(1, TimeUnit.SECONDS);
+                    }
+                })
+                .applyConnectionString(new ConnectionString((connectionString != null)
+                        ? connectionString : "mongodb://localhost:27020"))
                 .build();
-    }
-
-    private MongoCryptHelper(){
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/capi/MongoCryptHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/capi/MongoCryptHelper.java
@@ -16,7 +16,11 @@
 
 package com.mongodb.internal.capi;
 
+import com.mongodb.Block;
+import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientException;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.connection.ClusterSettings;
 import com.mongodb.crypt.capi.MongoAwsKmsProviderOptions;
 import com.mongodb.crypt.capi.MongoCryptOptions;
 import com.mongodb.crypt.capi.MongoLocalKmsProviderOptions;
@@ -26,8 +30,9 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
-public final class MongoCryptOptionsHelper {
+public final class MongoCryptHelper {
 
     public static MongoCryptOptions createMongoCryptOptions(final Map<String, Map<String, Object>> kmsProviders,
                                                             final Map<String, BsonDocument> namespaceToLocalSchemaDocumentMap) {
@@ -75,6 +80,20 @@ public final class MongoCryptOptionsHelper {
         return spawnArgs;
     }
 
-    private MongoCryptOptionsHelper(){
+    public static MongoClientSettings createMongocryptdClientSettings(final String connectionString) {
+
+        return MongoClientSettings.builder()
+                .applyConnectionString(new ConnectionString((connectionString != null)
+                        ? connectionString : "mongodb://localhost:27020"))
+                .applyToClusterSettings(new Block<ClusterSettings.Builder>() {
+                    @Override
+                    public void apply(final ClusterSettings.Builder builder) {
+                        builder.serverSelectionTimeout(1, TimeUnit.SECONDS);
+                    }
+                })
+                .build();
+    }
+
+    private MongoCryptHelper(){
     }
 }

--- a/driver-core/src/main/com/mongodb/internal/capi/MongoCryptHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/capi/MongoCryptHelper.java
@@ -79,6 +79,7 @@ public final class MongoCryptHelper {
             spawnArgs.add("60");
         }
         if (!spawnArgs.contains("--logpath")) {
+            spawnArgs.add("--logappend");
             spawnArgs.add("--logpath");
             spawnArgs.add(System.getProperty("os.name").startsWith("Windows") ? "NUL" : "/dev/null");
         }

--- a/driver-sync/src/main/com/mongodb/client/internal/CommandMarker.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/CommandMarker.java
@@ -16,25 +16,21 @@
 
 package com.mongodb.client.internal;
 
-import com.mongodb.Block;
-import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientException;
-import com.mongodb.MongoClientSettings;
 import com.mongodb.MongoException;
 import com.mongodb.MongoTimeoutException;
 import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
-import com.mongodb.connection.ClusterSettings;
 import org.bson.RawBsonDocument;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
-import static com.mongodb.internal.capi.MongoCryptOptionsHelper.createMongocryptdSpawnArgs;
+import static com.mongodb.internal.capi.MongoCryptHelper.createMongocryptdSpawnArgs;
+import static com.mongodb.internal.capi.MongoCryptHelper.createMongocryptdClientSettings;
 
 @SuppressWarnings("UseOfProcessBuilder")
 class CommandMarker implements Closeable {
@@ -52,24 +48,7 @@ class CommandMarker implements Closeable {
             } else {
                 processBuilder = null;
             }
-
-            String connectionString;
-
-            if (options.containsKey("mongocryptdURI")) {
-                connectionString = (String) options.get("mongocryptdURI");
-            } else {
-                connectionString = "mongodb://localhost:27020";
-            }
-
-            client = MongoClients.create(MongoClientSettings.builder()
-                    .applyConnectionString(new ConnectionString(connectionString))
-                    .applyToClusterSettings(new Block<ClusterSettings.Builder>() {
-                        @Override
-                        public void apply(final ClusterSettings.Builder builder) {
-                            builder.serverSelectionTimeout(1, TimeUnit.SECONDS);
-                        }
-                    })
-                    .build());
+            client = MongoClients.create(createMongocryptdClientSettings((String) options.get("mongocryptdURI")));
         }
     }
 

--- a/driver-sync/src/main/com/mongodb/client/internal/Crypts.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/Crypts.java
@@ -27,7 +27,7 @@ import com.mongodb.crypt.capi.MongoCrypts;
 import javax.net.ssl.SSLContext;
 import java.security.NoSuchAlgorithmException;
 
-import static com.mongodb.internal.capi.MongoCryptOptionsHelper.createMongoCryptOptions;
+import static com.mongodb.internal.capi.MongoCryptHelper.createMongoCryptOptions;
 
 public final class Crypts {
 


### PR DESCRIPTION
The master builds against "latest" replica sets and sharded clusters are timing out.  I traced it down with logging to socket timeouts on the connections to the local mongocryptd process.  So first thing I did was to set a socket timeout on the MongoClient that connections to mongocryptd.  That seems like a good idea regardless. The next thing I tried was to set mongocryptd's logpath.  But when I did that the build succeeded.  So then I tried setting the logpath to /dev/null, and with that change the build also succeeded. 

This patch implements both of these changes.

The first commit is just a refactoring to share some code between the sync and async CommandMarker classes (whose responsibility it is to communicate with mongocryptd).

The second adds the behavioral changes.

I have no clear idea yet why these changes stop the test failures.  My best guess is that it has something to do with running out of file handles.  I will keep searching for the root cause, but in the meantime these changes green the build and seem beneficial regardless.

Jira: https://jira.mongodb.org/browse/JAVA-3636

Evergreen: https://evergreen.mongodb.com/version/5e5c3908e3c33174f87bb548