### PR TITLE
Close connection pool in test teardown

### DIFF
--- a/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
+++ b/driver-core/src/test/unit/com/mongodb/internal/connection/AbstractConnectionPoolTest.java
@@ -123,6 +123,9 @@ public abstract class AbstractConnectionPoolTest {
         for (ExecutorService cur : executorServiceMap.values()) {
             cur.shutdownNow();
         }
+        if (pool != null) {
+            pool.close();
+        }
     }
 
     @Test


### PR DESCRIPTION
The pool in this test starts a background thread running,
so by closing it we also shutdown that thread.

https://jira.mongodb.org/browse/JAVA-3643

https://evergreen.mongodb.com/version/5e5f1fc2e3c33148df5ff466

Only 8 occurrences of the offending log line in the patch build.