### PR TITLE
Redirect mongocryptd error stream to the output stream

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/capi/MongoCryptHelper.java
+++ b/driver-core/src/main/com/mongodb/internal/capi/MongoCryptHelper.java
@@ -109,6 +109,7 @@ public final class MongoCryptHelper {
 
     public static void startProcess(final ProcessBuilder processBuilder) {
         try {
+            processBuilder.redirectErrorStream(true);
             processBuilder.redirectOutput(new File(System.getProperty("os.name").startsWith("Windows") ? "NUL" : "/dev/null"));
             processBuilder.start();
         } catch (Throwable t) {


### PR DESCRIPTION
One small addendum to the previous fix: although currently mongocryptd doesn't write often to stderr, we shouldn't rely on it.  This change ensures that stderr is also redirected to /dev/null

https://jira.mongodb.org/browse/JAVA-3636

Tested locally