### PR TITLE
Fix JSON parsing of shell-mode UUID constructor

### DIFF
--- a/bson/src/main/org/bson/json/JsonReader.java
+++ b/bson/src/main/org/bson/json/JsonReader.java
@@ -244,16 +244,9 @@ public class JsonReader extends AbstractBsonReader {
                 } else if ("DBPointer".equals(value)) {
                     setCurrentBsonType(BsonType.DB_POINTER);
                     currentValue = visitDBPointerConstructor();
-                } else if ("UUID".equals(value)
-                           || "GUID".equals(value)
-                           || "CSUUID".equals(value)
-                           || "CSGUID".equals(value)
-                           || "JUUID".equals(value)
-                           || "JGUID".equals(value)
-                           || "PYUUID".equals(value)
-                           || "PYGUID".equals(value)) {
+                } else if ("UUID".equals(value)) {
                     setCurrentBsonType(BsonType.BINARY);
-                    currentValue = visitUUIDConstructor(value);
+                    currentValue = visitUUIDConstructor();
                 } else if ("new".equals(value)) {
                     visitNew();
                 } else {
@@ -594,15 +587,8 @@ public class JsonReader extends AbstractBsonReader {
         } else if ("DBPointer".equals(value)) {
             currentValue = visitDBPointerConstructor();
             setCurrentBsonType(BsonType.DB_POINTER);
-        } else if ("UUID".equals(value)
-                   || "GUID".equals(value)
-                   || "CSUUID".equals(value)
-                   || "CSGUID".equals(value)
-                   || "JUUID".equals(value)
-                   || "JGUID".equals(value)
-                   || "PYUUID".equals(value)
-                   || "PYGUID".equals(value)) {
-            currentValue = visitUUIDConstructor(value);
+        } else if ("UUID".equals(value)) {
+            currentValue = visitUUIDConstructor();
             setCurrentBsonType(BsonType.BINARY);
         } else {
             throw new JsonParseException("JSON reader expected a type name but found '%s'.", value);
@@ -716,16 +702,11 @@ public class JsonReader extends AbstractBsonReader {
         return new BsonBinary(subTypeToken.getValue(Integer.class).byteValue(), bytes);
     }
 
-    private BsonBinary visitUUIDConstructor(final String uuidConstructorName) {
+    private BsonBinary visitUUIDConstructor() {
         verifyToken(JsonTokenType.LEFT_PAREN);
-        String hexString = readStringFromExtendedJson().replaceAll("\\{", "").replaceAll("}", "").replaceAll("-", "");
+        String hexString = readStringFromExtendedJson().replace("-", "");
         verifyToken(JsonTokenType.RIGHT_PAREN);
-        byte[] bytes = decodeHex(hexString);
-        BsonBinarySubType subType = BsonBinarySubType.UUID_STANDARD;
-        if (!"UUID".equals(uuidConstructorName) || !"GUID".equals(uuidConstructorName)) {
-            subType = BsonBinarySubType.UUID_LEGACY;
-        }
-        return new BsonBinary(subType, bytes);
+        return new BsonBinary(BsonBinarySubType.UUID_STANDARD, decodeHex(hexString));
     }
 
     private BsonRegularExpression visitRegularExpressionConstructor() {

--- a/bson/src/test/unit/org/bson/json/JsonReaderTest.java
+++ b/bson/src/test/unit/org/bson/json/JsonReaderTest.java
@@ -946,6 +946,19 @@ public class JsonReaderTest {
     }
 
     @Test
+    public void testUuidConstructor() {
+        String json = "UUID(\"b5f21e0c-2a0d-42d6-ad03-d827008d8ab6\")";
+        testStringAndStream(json, bsonReader -> {
+            assertEquals(BsonType.BINARY, bsonReader.readBsonType());
+            BsonBinary binary = bsonReader.readBinaryData();
+            assertEquals(BsonBinarySubType.UUID_STANDARD.getValue(), binary.getType());
+            assertArrayEquals(new byte[]{-75, -14, 30, 12, 42, 13, 66, -42, -83, 3, -40, 39, 0, -115, -118, -74}, binary.getData());
+            assertEquals(AbstractBsonReader.State.DONE, bsonReader.getState());
+            return null;
+        });
+    }
+
+    @Test
     public void testInfinity() {
         String json = "{ \"value\" : Infinity }";
         testStringAndStream(json, bsonReader -> {


### PR DESCRIPTION
It's quite broken in a number of ways, actually:

* It produced the wrong binary subtype for UUID/GUID (legacy instead of standard)
* It partially supported alternate constructors for UUIDs that were proposed
  long ago for the shell but never implemented, but does not actually produced
  the correct byte ordering for CSUUID/CSGUID or JUUID/JGUID

This fix does two things:

* It produces the correct subtype for the UUID constructor: standard, subtype 4
* It removes the broken support for all the other constructors that were never
  actually implemented correctly.

JAVA-3749