### PR TITLE
Apply client-side encryption in transactions on sharded clusters

### DIFF
--- a/driver-core/src/main/com/mongodb/internal/async/client/AsyncCryptBinding.java
+++ b/driver-core/src/main/com/mongodb/internal/async/client/AsyncCryptBinding.java
@@ -17,8 +17,9 @@
 package com.mongodb.internal.async.client;
 
 import com.mongodb.ReadPreference;
-import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.ServerAddress;
 import com.mongodb.connection.ServerDescription;
+import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.binding.AsyncClusterAwareReadWriteBinding;
 import com.mongodb.internal.binding.AsyncConnectionSource;
 import com.mongodb.internal.binding.AsyncReadWriteBinding;
@@ -63,6 +64,20 @@ public class AsyncCryptBinding implements AsyncClusterAwareReadWriteBinding {
     @Override
     public void getReadConnectionSource(final SingleResultCallback<AsyncConnectionSource> callback) {
         wrapped.getReadConnectionSource(new SingleResultCallback<AsyncConnectionSource>() {
+            @Override
+            public void onResult(final AsyncConnectionSource result, final Throwable t) {
+                if (t != null) {
+                    callback.onResult(null, t);
+                } else {
+                    callback.onResult(new AsyncCryptConnectionSource(result), null);
+                }
+            }
+        });
+    }
+
+    @Override
+    public void getConnectionSource(final ServerAddress serverAddress, final SingleResultCallback<AsyncConnectionSource> callback) {
+        wrapped.getConnectionSource(serverAddress, new SingleResultCallback<AsyncConnectionSource>() {
             @Override
             public void onResult(final AsyncConnectionSource result, final Throwable t) {
                 if (t != null) {

--- a/driver-core/src/main/com/mongodb/internal/binding/AsyncClusterAwareReadWriteBinding.java
+++ b/driver-core/src/main/com/mongodb/internal/binding/AsyncClusterAwareReadWriteBinding.java
@@ -16,6 +16,8 @@
 
 package com.mongodb.internal.binding;
 
+import com.mongodb.ServerAddress;
+import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.connection.Cluster;
 
 /**
@@ -23,4 +25,12 @@ import com.mongodb.internal.connection.Cluster;
  */
 public interface AsyncClusterAwareReadWriteBinding extends AsyncReadWriteBinding {
     Cluster getCluster();
+
+    /**
+     * Returns a connection source to the specified server
+     *
+     * @param serverAddress the server address
+     * @param callback the to be passed the connection source
+     */
+    void getConnectionSource(ServerAddress serverAddress, SingleResultCallback<AsyncConnectionSource> callback);
 }

--- a/driver-core/src/main/com/mongodb/internal/binding/AsyncClusterBinding.java
+++ b/driver-core/src/main/com/mongodb/internal/binding/AsyncClusterBinding.java
@@ -18,16 +18,18 @@ package com.mongodb.internal.binding;
 
 import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
-import com.mongodb.internal.async.SingleResultCallback;
+import com.mongodb.ServerAddress;
 import com.mongodb.connection.ServerDescription;
+import com.mongodb.internal.async.SingleResultCallback;
 import com.mongodb.internal.connection.AsyncConnection;
 import com.mongodb.internal.connection.Cluster;
 import com.mongodb.internal.connection.ReadConcernAwareNoOpSessionContext;
 import com.mongodb.internal.connection.Server;
 import com.mongodb.internal.selector.ReadPreferenceServerSelector;
+import com.mongodb.internal.selector.ServerAddressSelector;
 import com.mongodb.internal.selector.WritableServerSelector;
-import com.mongodb.selector.ServerSelector;
 import com.mongodb.internal.session.SessionContext;
+import com.mongodb.selector.ServerSelector;
 
 import static com.mongodb.assertions.Assertions.notNull;
 
@@ -85,6 +87,11 @@ public class AsyncClusterBinding extends AbstractReferenceCounted implements Asy
     @Override
     public void getWriteConnectionSource(final SingleResultCallback<AsyncConnectionSource> callback) {
         getAsyncClusterBindingConnectionSource(new WritableServerSelector(), callback);
+    }
+
+    @Override
+    public void getConnectionSource(final ServerAddress serverAddress, final SingleResultCallback<AsyncConnectionSource> callback) {
+        getAsyncClusterBindingConnectionSource(new ServerAddressSelector(serverAddress), callback);
     }
 
     private void getAsyncClusterBindingConnectionSource(final ServerSelector serverSelector,

--- a/driver-core/src/main/com/mongodb/internal/binding/ClusterAwareReadWriteBinding.java
+++ b/driver-core/src/main/com/mongodb/internal/binding/ClusterAwareReadWriteBinding.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.internal.binding;
 
+import com.mongodb.ServerAddress;
 import com.mongodb.internal.connection.Cluster;
 
 /**
@@ -23,4 +24,10 @@ import com.mongodb.internal.connection.Cluster;
  */
 public interface ClusterAwareReadWriteBinding extends ReadWriteBinding {
     Cluster getCluster();
+
+    /**
+     * Returns a connection source to the specified server address.
+     * @return the connection source
+     */
+    ConnectionSource getConnectionSource(ServerAddress serverAddress);
 }

--- a/driver-core/src/main/com/mongodb/internal/binding/ClusterBinding.java
+++ b/driver-core/src/main/com/mongodb/internal/binding/ClusterBinding.java
@@ -18,15 +18,17 @@ package com.mongodb.internal.binding;
 
 import com.mongodb.ReadConcern;
 import com.mongodb.ReadPreference;
+import com.mongodb.ServerAddress;
 import com.mongodb.connection.ServerDescription;
 import com.mongodb.internal.connection.Cluster;
 import com.mongodb.internal.connection.Connection;
 import com.mongodb.internal.connection.ReadConcernAwareNoOpSessionContext;
 import com.mongodb.internal.connection.Server;
 import com.mongodb.internal.selector.ReadPreferenceServerSelector;
+import com.mongodb.internal.selector.ServerAddressSelector;
 import com.mongodb.internal.selector.WritableServerSelector;
-import com.mongodb.selector.ServerSelector;
 import com.mongodb.internal.session.SessionContext;
+import com.mongodb.selector.ServerSelector;
 
 import static com.mongodb.assertions.Assertions.notNull;
 
@@ -75,18 +77,23 @@ public class ClusterBinding extends AbstractReferenceCounted implements ClusterA
     }
 
     @Override
-    public ConnectionSource getReadConnectionSource() {
-        return new ClusterBindingConnectionSource(new ReadPreferenceServerSelector(readPreference));
-    }
-
-    @Override
     public SessionContext getSessionContext() {
         return new ReadConcernAwareNoOpSessionContext(readConcern);
     }
 
     @Override
+    public ConnectionSource getReadConnectionSource() {
+        return new ClusterBindingConnectionSource(new ReadPreferenceServerSelector(readPreference));
+    }
+
+    @Override
     public ConnectionSource getWriteConnectionSource() {
         return new ClusterBindingConnectionSource(new WritableServerSelector());
+    }
+
+    @Override
+    public ConnectionSource getConnectionSource(final ServerAddress serverAddress) {
+        return new ClusterBindingConnectionSource(new ServerAddressSelector(serverAddress));
     }
 
     private final class ClusterBindingConnectionSource extends AbstractReferenceCounted implements ConnectionSource {

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideEncryptionSessionTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideEncryptionSessionTest.java
@@ -106,7 +106,11 @@ public class ClientSideEncryptionSessionTest {
                         .schemaMap(schemaMap).build())
                 .build();
         clientEncrypted = MongoClients.create(clientSettings);
-        new CollectionHelper<>(new BsonDocumentCodec(), new MongoNamespace(getDefaultDatabaseName(), COLLECTION_NAME)).drop();
+
+        CollectionHelper<BsonDocument> collectionHelper =
+        new CollectionHelper<>(new BsonDocumentCodec(), new MongoNamespace(getDefaultDatabaseName(), COLLECTION_NAME));
+        collectionHelper.drop();
+        collectionHelper.create();
     }
 
     @After

--- a/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideEncryptionSessionTest.java
+++ b/driver-reactive-streams/src/test/functional/com/mongodb/reactivestreams/client/ClientSideEncryptionSessionTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.reactivestreams.client;
+
+import com.mongodb.AutoEncryptionSettings;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoNamespace;
+import com.mongodb.WriteConcern;
+import com.mongodb.client.result.InsertOneResult;
+import com.mongodb.client.test.CollectionHelper;
+import com.mongodb.reactivestreams.client.Fixture.ObservableSubscriber;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.codecs.BsonDocumentCodec;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.mongodb.ClusterFixture.isStandalone;
+import static com.mongodb.ClusterFixture.serverVersionAtLeast;
+import static com.mongodb.internal.async.client.Fixture.getMongoClientBuilderFromConnectionString;
+import static com.mongodb.reactivestreams.client.Fixture.getDefaultDatabaseName;
+import static com.mongodb.reactivestreams.client.Fixture.getMongoClient;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
+import static util.JsonPoweredTestHelper.getTestDocument;
+
+@RunWith(Parameterized.class)
+public class ClientSideEncryptionSessionTest {
+    private static final String COLLECTION_NAME = "clientSideEncryptionSessionsTest";
+
+    private MongoClient client = getMongoClient();
+    private MongoClient clientEncrypted;
+    private final boolean useTransaction;
+
+    @Parameterized.Parameters(name = "useTransaction: {0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[]{true}, new Object[]{false});
+    }
+
+    public ClientSideEncryptionSessionTest(final boolean useTransaction) {
+        this.useTransaction = useTransaction;
+    }
+
+    @Before
+    public void setUp() throws Throwable {
+        assumeTrue(serverVersionAtLeast(4, 2));
+        assumeFalse(isStandalone());
+
+        /* Step 1: get unencrypted client and recreate keys collection */
+        client = getMongoClient();
+        MongoDatabase keyVaultDatabase = client.getDatabase("keyvault");
+        MongoCollection<BsonDocument> dataKeys = keyVaultDatabase.getCollection("datakeys", BsonDocument.class)
+                .withWriteConcern(WriteConcern.MAJORITY);
+        ObservableSubscriber<Void> subscriber = new ObservableSubscriber<>();
+        dataKeys.drop().subscribe(subscriber);
+        subscriber.await(5, SECONDS);
+
+        ObservableSubscriber<InsertOneResult> insertOneSubscriber = new ObservableSubscriber<>();
+        dataKeys.insertOne(bsonDocumentFromPath("external-key.json")).subscribe(insertOneSubscriber);
+        insertOneSubscriber.await(5, SECONDS);
+
+        /* Step 2: create encryption objects. */
+        Map<String, Map<String, Object>> kmsProviders = new HashMap<>();
+        Map<String, Object> localMasterkey = new HashMap<>();
+        Map<String, BsonDocument> schemaMap = new HashMap<>();
+
+        byte[] localMasterKeyBytes = Base64.getDecoder().decode("Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBM"
+                + "UN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk");
+        localMasterkey.put("key", localMasterKeyBytes);
+        kmsProviders.put("local", localMasterkey);
+        schemaMap.put(getDefaultDatabaseName() + "." + COLLECTION_NAME, bsonDocumentFromPath("external-schema.json"));
+
+        MongoClientSettings clientSettings = getMongoClientBuilderFromConnectionString()
+                .autoEncryptionSettings(AutoEncryptionSettings.builder()
+                        .keyVaultNamespace("keyvault.datakeys")
+                        .kmsProviders(kmsProviders)
+                        .schemaMap(schemaMap).build())
+                .build();
+        clientEncrypted = MongoClients.create(clientSettings);
+        new CollectionHelper<>(new BsonDocumentCodec(), new MongoNamespace(getDefaultDatabaseName(), COLLECTION_NAME)).drop();
+    }
+
+    @After
+    public void after() {
+        if (clientEncrypted != null) {
+            try {
+                clientEncrypted.close();
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+    }
+
+    @Test
+    public void testWithExplicitSession() throws Throwable {
+        BsonString unencryptedValue = new BsonString("test");
+
+        ObservableSubscriber<ClientSession> sessionSubscriber = new ObservableSubscriber<>();
+        clientEncrypted.startSession().subscribe(sessionSubscriber);
+        sessionSubscriber.await(5, SECONDS);
+        try (ClientSession clientSession = sessionSubscriber.getReceived().get(0)) {
+            if (useTransaction) {
+                clientSession.startTransaction();
+            }
+            MongoCollection<BsonDocument> autoEncryptedCollection = clientEncrypted.getDatabase(getDefaultDatabaseName())
+                    .getCollection(COLLECTION_NAME, BsonDocument.class);
+            ObservableSubscriber<InsertOneResult> insertOneResultSubscriber = new ObservableSubscriber<>();
+            autoEncryptedCollection.insertOne(clientSession, new BsonDocument().append("encrypted", new BsonString("test")))
+                    .subscribe(insertOneResultSubscriber);
+            insertOneResultSubscriber.await(5, SECONDS);
+
+            ObservableSubscriber<BsonDocument> documentSubscriber = new ObservableSubscriber<>();
+            autoEncryptedCollection.find(clientSession).first().subscribe(documentSubscriber);
+            documentSubscriber.await(5, SECONDS);
+            BsonDocument unencryptedDocument = documentSubscriber.getReceived().get(0);
+            assertEquals(unencryptedValue, unencryptedDocument.getString("encrypted"));
+
+            if (useTransaction) {
+                ObservableSubscriber<Void> commitSubscriber = new ObservableSubscriber<>();
+                clientSession.commitTransaction().subscribe(commitSubscriber);
+                commitSubscriber.await(5, SECONDS);
+            }
+        }
+
+        MongoCollection<BsonDocument> encryptedCollection = client.getDatabase(getDefaultDatabaseName())
+                .getCollection(COLLECTION_NAME, BsonDocument.class);
+        ObservableSubscriber<BsonDocument> documentSubscriber = new ObservableSubscriber<>();
+        encryptedCollection.find().first().subscribe(documentSubscriber);
+        documentSubscriber.await(5, SECONDS);
+        BsonDocument encryptedDocument = documentSubscriber.getReceived().get(0);
+        assertTrue(encryptedDocument.isBinary("encrypted"));
+        assertEquals(6, encryptedDocument.getBinary("encrypted").getType());
+    }
+
+    private static BsonDocument bsonDocumentFromPath(final String path) throws IOException, URISyntaxException {
+        return getTestDocument(new File(ClientSideEncryptionSessionTest.class
+                .getResource("/client-side-encryption-external/" + path).toURI()));
+    }
+}

--- a/driver-sync/src/main/com/mongodb/client/internal/CryptBinding.java
+++ b/driver-sync/src/main/com/mongodb/client/internal/CryptBinding.java
@@ -17,6 +17,7 @@
 package com.mongodb.client.internal;
 
 import com.mongodb.ReadPreference;
+import com.mongodb.ServerAddress;
 import com.mongodb.connection.ServerDescription;
 import com.mongodb.internal.binding.ClusterAwareReadWriteBinding;
 import com.mongodb.internal.binding.ConnectionSource;
@@ -47,6 +48,11 @@ class CryptBinding implements ClusterAwareReadWriteBinding {
     @Override
     public ConnectionSource getWriteConnectionSource() {
         return new CryptConnectionSource(wrapped.getWriteConnectionSource());
+    }
+
+    @Override
+    public ConnectionSource getConnectionSource(final ServerAddress serverAddress) {
+        return new CryptConnectionSource(wrapped.getConnectionSource(serverAddress));
     }
 
     @Override

--- a/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryptionSessionTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryptionSessionTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.client;
+
+import com.mongodb.AutoEncryptionSettings;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoNamespace;
+import com.mongodb.WriteConcern;
+import com.mongodb.client.test.CollectionHelper;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.codecs.BsonDocumentCodec;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.mongodb.ClusterFixture.isStandalone;
+import static com.mongodb.ClusterFixture.serverVersionAtLeast;
+import static com.mongodb.client.Fixture.getDefaultDatabaseName;
+import static com.mongodb.client.Fixture.getMongoClient;
+import static com.mongodb.client.Fixture.getMongoClientSettingsBuilder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
+import static util.JsonPoweredTestHelper.getTestDocument;
+
+@RunWith(Parameterized.class)
+public class ClientSideEncryptionSessionTest {
+    private static final String COLLECTION_NAME = "clientSideEncryptionSessionsTest";
+    private MongoClient client, clientEncrypted;
+    private final boolean useTransaction;
+
+    @Parameterized.Parameters(name = "useTransaction: {0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[]{true}, new Object[]{false});
+    }
+
+    public ClientSideEncryptionSessionTest(final boolean useTransaction) {
+        this.useTransaction = useTransaction;
+    }
+
+    @Before
+    public void setUp() throws IOException, URISyntaxException {
+        assumeTrue(serverVersionAtLeast(4, 2));
+        assumeFalse(isStandalone());
+
+        /* Step 1: get unencrypted client and recreate keys collection */
+        client = getMongoClient();
+        MongoDatabase keyvaultDatabase = client.getDatabase("keyvault");
+        MongoCollection<BsonDocument> datakeys = keyvaultDatabase.getCollection("datakeys", BsonDocument.class)
+                .withWriteConcern(WriteConcern.MAJORITY);
+        datakeys.drop();
+        datakeys.insertOne(bsonDocumentFromPath("external-key.json"));
+
+        /* Step 2: create encryption objects. */
+        Map<String, Map<String, Object>> kmsProviders = new HashMap<>();
+        Map<String, Object> localMasterkey = new HashMap<>();
+        Map<String, BsonDocument> schemaMap = new HashMap<>();
+
+        byte[] localMasterkeyBytes = Base64.getDecoder().decode("Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBM"
+                + "UN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk");
+        localMasterkey.put("key", localMasterkeyBytes);
+        kmsProviders.put("local", localMasterkey);
+        schemaMap.put(getDefaultDatabaseName() + "." + COLLECTION_NAME, bsonDocumentFromPath("external-schema.json"));
+
+        AutoEncryptionSettings autoEncryptionSettings = AutoEncryptionSettings.builder()
+                .keyVaultNamespace("keyvault.datakeys")
+                .kmsProviders(kmsProviders)
+                .schemaMap(schemaMap).build();
+
+        MongoClientSettings clientSettings = getMongoClientSettingsBuilder()
+                .autoEncryptionSettings(autoEncryptionSettings)
+                .build();
+        clientEncrypted = MongoClients.create(clientSettings);
+        new CollectionHelper<>(new BsonDocumentCodec(), new MongoNamespace(getDefaultDatabaseName(), COLLECTION_NAME)).drop();
+    }
+
+    @After
+    public void after() {
+        if (clientEncrypted != null) {
+            try {
+                clientEncrypted.close();
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+    }
+
+    @Test
+    public void testWithExplicitSession() {
+        BsonString unencryptedValue = new BsonString("test");
+
+        try (ClientSession clientSession = clientEncrypted.startSession()) {
+            if (useTransaction) {
+                clientSession.startTransaction();
+            }
+            MongoCollection<BsonDocument> encryptedCollection = clientEncrypted.getDatabase(getDefaultDatabaseName())
+                    .getCollection(COLLECTION_NAME, BsonDocument.class);
+            encryptedCollection.insertOne(clientSession, new BsonDocument().append("encrypted", unencryptedValue));
+            BsonDocument unencryptedDocument = encryptedCollection.find(clientSession).first();
+            assertEquals(unencryptedValue, unencryptedDocument.getString("encrypted"));
+            if (useTransaction) {
+                clientSession.commitTransaction();
+            }
+        }
+
+        MongoCollection<BsonDocument> unencryptedCollection = client.getDatabase(getDefaultDatabaseName())
+                .getCollection(COLLECTION_NAME, BsonDocument.class);
+        BsonDocument encryptedDocument = unencryptedCollection.find().first();
+        assertTrue(encryptedDocument.isBinary("encrypted"));
+        assertEquals(6, encryptedDocument.getBinary("encrypted").getType());
+    }
+
+
+    private static BsonDocument bsonDocumentFromPath(final String path) throws IOException, URISyntaxException {
+        return getTestDocument(new File(ClientSideEncryptionSessionTest.class
+                .getResource("/client-side-encryption-external/" + path).toURI()));
+    }
+}

--- a/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryptionSessionTest.java
+++ b/driver-sync/src/test/functional/com/mongodb/client/ClientSideEncryptionSessionTest.java
@@ -98,7 +98,11 @@ public class ClientSideEncryptionSessionTest {
                 .autoEncryptionSettings(autoEncryptionSettings)
                 .build();
         clientEncrypted = MongoClients.create(clientSettings);
-        new CollectionHelper<>(new BsonDocumentCodec(), new MongoNamespace(getDefaultDatabaseName(), COLLECTION_NAME)).drop();
+
+        CollectionHelper<BsonDocument> collectionHelper =
+        new CollectionHelper<>(new BsonDocumentCodec(), new MongoNamespace(getDefaultDatabaseName(), COLLECTION_NAME));
+        collectionHelper.drop();
+        collectionHelper.create();
     }
 
     @After


### PR DESCRIPTION
This fixes a bug in both sync and async drivers where client-side
encryption is not applied when in a transaction.

The root of the bug is in ClientSessionBinding.wrapConnectionSource (both sync and async). By creating a new concrete binding (`SingleServerBinding`) there, reaching in to `wrapped` to grab the `Cluste`r directly to do so, it subverts any logic contained in `wrapped`. In the case of client-side encryption, the logic that's skipped is the wrapping of `Connection` in a `CryptConnection` by `CryptBinding`, which is why encryption/decryption isn't happening in a sharded transaction.

One way of looking at this bug is that it was caused by a violation of the Liskov substitution principle. Even though this code initially depends on the `ClusterAwareReadWriteBinding` abstraction, it breaks that dependency by depending on the concrete `SingleServerBinding` class. In that way `CryptBinding` is not substitutable for `ClusterBinding`.

The bug is fixed by adding a method to the `ClusterAwareReadWriteBinding` interface that lets this code bind to a specific server. This allows `ClusterAwareReadWriteBinding` implementations to wrap `Connection` in the way that was intended.

Though this fixes the bug, in doesn't entirely fix the substitutability issue.  To do that, we would have to remove the `getCluster` method from `ClusterAwareReadWriteBinding` entirely.  The fact that `ClientSessionBinding` uses the `Cluster` to call its `selectServer` method could subvert any custom server selection logic in implementations of `getRead/WriteConnectionSource`.  Currently there is no such custom logic, so I didn't want to complicate this PR any further by fixing the design issue completely.

https://jira.mongodb.org/browse/JAVA-3752

https://evergreen.mongodb.com/version/5ed7873be3c331478a8933c2